### PR TITLE
enhancement: Store tag metadata and introduce metadata cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@ handling on your side.
 
 * refactor: Change run behaviour by providing `run` and `version` commands
 * enhancement: Provide a `version` command to print out version information
-* enhancment: Allow storing metadata for image tags
+* enhancement: Allow storing metadata for image tags
+* enhancement: Fetch tag metadata along with tags and store creation timestamp
+* enhancement: Introduce simple cache for immutable metadata
 
 ## 2020-08-06 - Release v0.2.0
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -97,12 +97,12 @@ func updateApplication(argoClient *argocd.ArgoCD, kubeClient *client.KubernetesC
 			continue
 		}
 
-		imgCtx.Tracef("List of available tags found: %v", tags)
+		imgCtx.Tracef("List of available tags found: %v", tags.Tags())
 
 		var versConstraint string
 		if updateableImage.ImageTag != nil {
-			imgCtx.Debugf("Using constraint %s when looking for a new tag", versConstraint)
 			versConstraint = updateableImage.ImageTag.TagName
+			imgCtx.Debugf("Using version constraint '%s' when looking for a new tag", versConstraint)
 		} else {
 			imgCtx.Debugf("Using no version constraint when looking for a new tag")
 		}
@@ -127,7 +127,7 @@ func updateApplication(argoClient *argocd.ArgoCD, kubeClient *client.KubernetesC
 
 		// If the latest tag does not match image's current tag, it means we have
 		// an update candidate.
-		if applicationImage.ImageTag != latest {
+		if applicationImage.ImageTag.TagName != latest.TagName {
 			if dryRun {
 				imgCtx.Infof("Would upgrade image to %s, but this is a dry run. Skipping.", applicationImage.WithTag(latest).String())
 				continue

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
 	github.com/gorilla/mux v1.7.4 // indirect
 	github.com/nokia/docker-registry-client v0.0.0-20190305095957-e91f10057c5b
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cobra v1.0.0
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -863,6 +863,7 @@ gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.1.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/gotestsum v0.3.5/go.mod h1:Mnf3e5FUzXbkCfynWBGOwLssY7gTQgCHObK9tMpAriY=
 grpc.go4.org v0.0.0-20170609214715-11d0a25b4919/go.mod h1:77eQGdRu53HpSqPFJFmuJdjuHRquDANNeA4x7B8WQ9o=

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1,0 +1,11 @@
+package cache
+
+import (
+	"github.com/argoproj-labs/argocd-image-updater/pkg/tag"
+)
+
+type ImageTagCache interface {
+	HasTag(imageName string, imageTag string) bool
+	GetTag(imageName string, imageTag string) (*tag.ImageTag, error)
+	SetTag(imageName string, imgTag *tag.ImageTag)
+}

--- a/pkg/cache/memcache.go
+++ b/pkg/cache/memcache.go
@@ -1,0 +1,52 @@
+package cache
+
+import (
+	"fmt"
+
+	"github.com/argoproj-labs/argocd-image-updater/pkg/tag"
+
+	memcache "github.com/patrickmn/go-cache"
+)
+
+type MemCache struct {
+	cache *memcache.Cache
+}
+
+// NewMemCache returns a new instance of MemCache
+func NewMemCache() ImageTagCache {
+	mc := MemCache{}
+	c := memcache.New(0, 0)
+	mc.cache = c
+	return &mc
+}
+
+// HasTag returns true if cache has entry for given tag, false if not
+func (mc *MemCache) HasTag(imageName string, tagName string) bool {
+	tag, err := mc.GetTag(imageName, tagName)
+	if err != nil || tag == nil {
+		return false
+	} else {
+		return true
+	}
+}
+
+func (mc *MemCache) SetTag(imageName string, imgTag *tag.ImageTag) {
+	mc.cache.Set(cacheKey(imageName, imgTag.TagName), *imgTag, -1)
+}
+
+func (mc *MemCache) GetTag(imageName string, tagName string) (*tag.ImageTag, error) {
+	var imgTag tag.ImageTag
+	e, ok := mc.cache.Get(cacheKey(imageName, tagName))
+	if !ok {
+		return nil, nil
+	}
+	imgTag, ok = e.(tag.ImageTag)
+	if !ok {
+		return nil, fmt.Errorf("")
+	}
+	return &imgTag, nil
+}
+
+func cacheKey(imageName, imageTag string) string {
+	return fmt.Sprintf("%s:%s", imageName, imageTag)
+}

--- a/pkg/cache/memcache_test.go
+++ b/pkg/cache/memcache_test.go
@@ -1,0 +1,36 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/argoproj-labs/argocd-image-updater/pkg/tag"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_MemCache(t *testing.T) {
+	imageName := "foo/bar"
+	imageTag := "v1.0.0"
+	t.Run("Cache hit", func(t *testing.T) {
+		mc := NewMemCache()
+		newTag := tag.NewImageTag(imageTag, time.Unix(0, 0))
+		mc.SetTag(imageName, newTag)
+		cachedTag, err := mc.GetTag(imageName, imageTag)
+		require.NoError(t, err)
+		require.NotNil(t, cachedTag)
+		assert.Equal(t, imageTag, cachedTag.TagName)
+		assert.True(t, mc.HasTag(imageName, imageTag))
+	})
+
+	t.Run("Cache miss", func(t *testing.T) {
+		mc := NewMemCache()
+		newTag := tag.NewImageTag(imageTag, time.Unix(0, 0))
+		mc.SetTag(imageName, newTag)
+		cachedTag, err := mc.GetTag(imageName, "v1.0.1")
+		require.NoError(t, err)
+		require.Nil(t, cachedTag)
+		assert.False(t, mc.HasTag(imageName, "v1.0.1"))
+	})
+}

--- a/pkg/image/version.go
+++ b/pkg/image/version.go
@@ -13,9 +13,11 @@ import (
 // GetNewestVersionFromTags returns the latest available version from a list of
 // tags while optionally taking a semver constraint into account. Returns the
 // original version if no new version could be found from the list of tags.
-func (img *ContainerImage) GetNewestVersionFromTags(constraint string, availableTags []string) (*tag.ImageTag, error) {
+func (img *ContainerImage) GetNewestVersionFromTags(constraint string, tagList *tag.ImageTagList) (*tag.ImageTag, error) {
 	logCtx := log.NewContext()
 	logCtx.AddField("image", img.String())
+
+	availableTags := tagList.Tags()
 
 	// It makes no sense to proceed if we have no available tags
 	if len(availableTags) == 0 {

--- a/pkg/image/version_test.go
+++ b/pkg/image/version_test.go
@@ -2,14 +2,25 @@ package image
 
 import (
 	"testing"
+	"time"
+
+	"github.com/argoproj-labs/argocd-image-updater/pkg/tag"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+func newImageTagList(tagNames []string) *tag.ImageTagList {
+	tagList := tag.NewImageTagList()
+	for _, tagName := range tagNames {
+		tagList.Add(tag.NewImageTag(tagName, time.Unix(0, 0)))
+	}
+	return tagList
+}
+
 func Test_LatestVersion(t *testing.T) {
 	t.Run("Find the latest version without any constraint", func(t *testing.T) {
-		tagList := []string{"0.1", "0.5.1", "0.9", "1.0", "1.0.1", "1.1.2", "2.0.3"}
+		tagList := newImageTagList([]string{"0.1", "0.5.1", "0.9", "1.0", "1.0.1", "1.1.2", "2.0.3"})
 		img := NewFromIdentifier("jannfis/test:1.0")
 		newTag, err := img.GetNewestVersionFromTags("", tagList)
 		require.NoError(t, err)
@@ -18,7 +29,7 @@ func Test_LatestVersion(t *testing.T) {
 	})
 
 	t.Run("Find the latest version with a semver constraint on major", func(t *testing.T) {
-		tagList := []string{"0.1", "0.5.1", "0.9", "1.0", "1.0.1", "1.1.2", "2.0.3"}
+		tagList := newImageTagList([]string{"0.1", "0.5.1", "0.9", "1.0", "1.0.1", "1.1.2", "2.0.3"})
 		img := NewFromIdentifier("jannfis/test:1.0")
 		newTag, err := img.GetNewestVersionFromTags("^1.0", tagList)
 		require.NoError(t, err)
@@ -27,7 +38,7 @@ func Test_LatestVersion(t *testing.T) {
 	})
 
 	t.Run("Find the latest version with a semver constraint on patch", func(t *testing.T) {
-		tagList := []string{"0.1", "0.5.1", "0.9", "1.0", "1.0.1", "1.1.2", "2.0.3"}
+		tagList := newImageTagList([]string{"0.1", "0.5.1", "0.9", "1.0", "1.0.1", "1.1.2", "2.0.3"})
 		img := NewFromIdentifier("jannfis/test:1.0")
 		newTag, err := img.GetNewestVersionFromTags("~1.0", tagList)
 		require.NoError(t, err)
@@ -36,7 +47,7 @@ func Test_LatestVersion(t *testing.T) {
 	})
 
 	t.Run("Find the latest version with a semver constraint that has no match", func(t *testing.T) {
-		tagList := []string{"0.1", "0.5.1", "0.9", "2.0.3"}
+		tagList := newImageTagList([]string{"0.1", "0.5.1", "0.9", "2.0.3"})
 		img := NewFromIdentifier("jannfis/test:1.0")
 		newTag, err := img.GetNewestVersionFromTags("~1.0", tagList)
 		require.NoError(t, err)
@@ -45,7 +56,7 @@ func Test_LatestVersion(t *testing.T) {
 	})
 
 	t.Run("Find the latest version with a semver constraint that is invalid", func(t *testing.T) {
-		tagList := []string{"0.1", "0.5.1", "0.9", "2.0.3"}
+		tagList := newImageTagList([]string{"0.1", "0.5.1", "0.9", "2.0.3"})
 		img := NewFromIdentifier("jannfis/test:1.0")
 		newTag, err := img.GetNewestVersionFromTags("latest", tagList)
 		assert.Error(t, err)
@@ -53,7 +64,7 @@ func Test_LatestVersion(t *testing.T) {
 	})
 
 	t.Run("Find the latest version with no tags", func(t *testing.T) {
-		tagList := []string{}
+		tagList := newImageTagList([]string{})
 		img := NewFromIdentifier("jannfis/test:1.0")
 		newTag, err := img.GetNewestVersionFromTags("~1.0", tagList)
 		require.NoError(t, err)

--- a/pkg/registry/endpoints.go
+++ b/pkg/registry/endpoints.go
@@ -3,6 +3,8 @@ package registry
 import (
 	"fmt"
 	"sync"
+
+	"github.com/argoproj-labs/argocd-image-updater/pkg/cache"
 )
 
 // RegistryEndpoint holds information on how to access any specific registry API
@@ -15,6 +17,7 @@ type RegistryEndpoint struct {
 	Password       string
 	Ping           bool
 	Credentials    string
+	Cache          cache.ImageTagCache
 
 	lock sync.RWMutex
 }
@@ -26,18 +29,21 @@ var registries map[string]*RegistryEndpoint = map[string]*RegistryEndpoint{
 		RegistryPrefix: "",
 		RegistryAPI:    "https://registry-1.docker.io",
 		Ping:           true,
+		Cache:          cache.NewMemCache(),
 	},
 	"gcr.io": {
 		RegistryName:   "Google Container Registry",
 		RegistryPrefix: "gcr.io",
 		RegistryAPI:    "https://gcr.io",
 		Ping:           false,
+		Cache:          cache.NewMemCache(),
 	},
 	"quay.io": {
 		RegistryName:   "RedHat Quay",
 		RegistryPrefix: "quay.io",
 		RegistryAPI:    "https://quay.io",
 		Ping:           false,
+		Cache:          cache.NewMemCache(),
 	},
 }
 
@@ -55,6 +61,7 @@ func AddRegistryEndpoint(prefix, name, apiUrl, username, password, credentials s
 		Username:       username,
 		Password:       password,
 		Credentials:    credentials,
+		Cache:          cache.NewMemCache(),
 	}
 	return nil
 }

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -1,19 +1,31 @@
 package registry
 
+// Package registry implements functions for retrieving data from container
+// registries.
+//
+// TODO: Refactor this package and provide mocks for better testing.
+
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/argoproj-labs/argocd-image-updater/pkg/client"
 	"github.com/argoproj-labs/argocd-image-updater/pkg/image"
 	"github.com/argoproj-labs/argocd-image-updater/pkg/log"
+	"github.com/argoproj-labs/argocd-image-updater/pkg/tag"
 
 	"github.com/nokia/docker-registry-client/registry"
 )
 
 // GetTags returns a list of available tags for the given image
-func (clientInfo *RegistryEndpoint) GetTags(img *image.ContainerImage, kubeClient *client.KubernetesClient) ([]string, error) {
-	err := clientInfo.setEndpointCredentials(kubeClient)
+func (clientInfo *RegistryEndpoint) GetTags(img *image.ContainerImage, kubeClient *client.KubernetesClient) (*tag.ImageTagList, error) {
+	var tagList *tag.ImageTagList = tag.NewImageTagList()
+	var imgTag *tag.ImageTag
+	var err error
+
+	err = clientInfo.setEndpointCredentials(kubeClient)
 	if err != nil {
 		return nil, err
 	}
@@ -38,9 +50,69 @@ func (clientInfo *RegistryEndpoint) GetTags(img *image.ContainerImage, kubeClien
 	if err != nil {
 		return nil, err
 	}
-	return tags, err
+
+	// Fetch the manifest for the tag -- we need v1, because it contains history
+	// information that we require.
+	for _, tagStr := range tags {
+
+		// Look into the cache first and re-use any found item. If GetTag() returns
+		// an error, we treat it as a cache miss and just go ahead to invalidate
+		// the entry.
+		imgTag, err = clientInfo.Cache.GetTag(nameInRegistry, tagStr)
+		if err != nil {
+			log.Warnf("invalid entry for %s:%s in cache, invalidating.", nameInRegistry, imgTag.TagName)
+		} else if imgTag != nil {
+			log.Debugf("Cache hit for %s:%s", nameInRegistry, imgTag.TagName)
+			tagList.Add(imgTag)
+			continue
+		}
+
+		ml, err := client.ManifestV1(nameInRegistry, tagStr)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(ml.History) < 1 {
+			log.Warnf("Could not get creation date for %s: History information missing", img.GetFullNameWithTag())
+			continue
+		}
+
+		var histInfo map[string]interface{}
+		err = json.Unmarshal([]byte(ml.History[0].V1Compatibility), &histInfo)
+		if err != nil {
+			log.Warnf("Could not unmarshal history info for %s: %v", img.GetFullNameWithTag(), err)
+			continue
+		}
+
+		crIf, ok := histInfo["created"]
+		if !ok {
+			log.Warnf("Incomplete history information for %s: no creation timestamp found", img.GetFullNameWithTag())
+			continue
+		}
+
+		crStr, ok := crIf.(string)
+		if !ok {
+			log.Warnf("Creation timestamp for %s has wrong type - need string, is %T", img.GetFullNameWithTag(), crIf)
+			continue
+		}
+
+		// Creation date is stored as RFC3339 timestamp with nanoseconds, i.e. like
+		// this: 2017-12-01T23:06:12.607835588Z
+		log.Tracef("Found origin creation date for %s: %s", img.GetFullNameWithTag(), crStr)
+		crDate, err := time.Parse(time.RFC3339Nano, crStr)
+		if err != nil {
+			log.Warnf("Could not parse creation timestamp for %s (%s): %v", img.GetFullNameWithTag(), crStr, err)
+			continue
+		}
+		imgTag = tag.NewImageTag(tagStr, crDate)
+		tagList.Add(imgTag)
+		clientInfo.Cache.SetTag(nameInRegistry, imgTag)
+	}
+
+	return tagList, err
 }
 
+// Sets endpoint credentials for this registry from a reference to a K8s secret
 func (clientInfo *RegistryEndpoint) setEndpointCredentials(kubeClient *client.KubernetesClient) error {
 	if clientInfo.Username == "" && clientInfo.Password == "" && clientInfo.Credentials != "" {
 		credSrc, err := image.ParseCredentialSource(clientInfo.Credentials, false)

--- a/pkg/tag/tag.go
+++ b/pkg/tag/tag.go
@@ -49,6 +49,17 @@ func NewImageTagList() *ImageTagList {
 	return &itl
 }
 
+// Tags returns a list of verbatim tag names as string slice
+func (il *ImageTagList) Tags() []string {
+	il.lock.RLock()
+	defer il.lock.RUnlock()
+	tagList := []string{}
+	for k := range il.items {
+		tagList = append(tagList, k)
+	}
+	return tagList
+}
+
 // String returns the tag name of the ImageTag
 func (tag *ImageTag) String() string {
 	return tag.TagName


### PR DESCRIPTION
This PR introduces fetching some metadata along with the tag from the registry, and also a simple in-memory cache for storing this (immutable) metadata