### PR TITLE
feat: Allow setting tag sorting per image via annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ handling on your side.
 
 ### New features
 
+* feat: Allow setting the sort mode for tags per image via annotation
+
 ### Other changes
 
 * refactor: Change run behaviour by providing `run` and `version` commands

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -108,6 +108,8 @@ func updateApplication(argoClient *argocd.ArgoCD, kubeClient *client.KubernetesC
 			imgCtx.Debugf("Using no version constraint when looking for a new tag")
 		}
 
+		vc.SortMode = updateableImage.GetParameterSort(curApplication.Application.Annotations)
+
 		// Get the latest available tag matching any constraint that might be set
 		// for allowed updates.
 		latest, err := applicationImage.GetNewestVersionFromTags(&vc, tags)

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -10,5 +10,8 @@ const HelmParamImageNameAnnotation = "argocd-image-updater.argoproj.io/%s.image-
 const HelmParamImageTagAnnotation = "argocd-image-updater.argoproj.io/%s.image-tag"
 const HelmParamImageSpecAnnotation = "argocd-image-updater.argoproj.io/%s.image-spec"
 
+const MatchOptionAnnotation = "argocd-image-updater.argoproj.io/%s.match"
+const SortOptionAnnotation = "argocd-image-updater.argoproj.io/%s.sort"
+
 // gcr.io=secret:argocd/mysecret,docker.io=env:FOOBAR
 const SecretListAnnotation = "argocd-image-updater.argoproj.io/pullsecrets"

--- a/pkg/image/options.go
+++ b/pkg/image/options.go
@@ -1,0 +1,72 @@
+package image
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/argoproj-labs/argocd-image-updater/pkg/common"
+	"github.com/argoproj-labs/argocd-image-updater/pkg/log"
+)
+
+// GetParameterHelmImageName gets the value for image-name option for the image
+// from a set of annotations
+func (img *ContainerImage) GetParameterHelmImageName(annotations map[string]string) string {
+	key := fmt.Sprintf(common.HelmParamImageNameAnnotation, img.normalizedSymbolicName())
+	val, ok := annotations[key]
+	if !ok {
+		return ""
+	}
+	return val
+}
+
+// GetParameterHelmImageTag gets the value for image-tag option for the image
+// from a set of annotations
+func (img *ContainerImage) GetParameterHelmImageTag(annotations map[string]string) string {
+	key := fmt.Sprintf(common.HelmParamImageTagAnnotation, img.normalizedSymbolicName())
+	val, ok := annotations[key]
+	if !ok {
+		return ""
+	}
+	return val
+}
+
+// GetParameterHelmImageSpec gets the value for image-spec option for the image
+// from a set of annotations
+func (img *ContainerImage) GetParameterHelmImageSpec(annotations map[string]string) string {
+	key := fmt.Sprintf(common.HelmParamImageSpecAnnotation, img.normalizedSymbolicName())
+	val, ok := annotations[key]
+	if !ok {
+		return ""
+	}
+	return val
+}
+
+// GetParameterSort gets and validates the value for the sort option for the
+// image from a set of annotations
+func (img *ContainerImage) GetParameterSort(annotations map[string]string) VersionSortMode {
+	key := fmt.Sprintf(common.SortOptionAnnotation, img.normalizedSymbolicName())
+	val, ok := annotations[key]
+	if !ok {
+		// Default is sort by version
+		log.Tracef("No sort option %s found", key)
+		return VersionSortSemVer
+	}
+	switch strings.ToLower(val) {
+	case "semver":
+		log.Tracef("Sort option semver in %s", key)
+		return VersionSortSemVer
+	case "date":
+		log.Tracef("Sort option date in %s", key)
+		return VersionSortLatest
+	case "name":
+		log.Tracef("Sort option name in %s", key)
+		return VersionSortName
+	default:
+		log.Warnf("Unknown sort option in %s: %s -- using semver", key, val)
+		return VersionSortSemVer
+	}
+}
+
+func (img *ContainerImage) normalizedSymbolicName() string {
+	return strings.ReplaceAll(img.SymbolicName, "/", "_")
+}

--- a/pkg/image/options_test.go
+++ b/pkg/image/options_test.go
@@ -1,0 +1,84 @@
+package image
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/argoproj-labs/argocd-image-updater/pkg/common"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GetHelmOptions(t *testing.T) {
+	annotations := map[string]string{
+		fmt.Sprintf(common.HelmParamImageNameAnnotation, "dummy"): "release.name",
+		fmt.Sprintf(common.HelmParamImageTagAnnotation, "dummy"):  "release.tag",
+		fmt.Sprintf(common.HelmParamImageSpecAnnotation, "dummy"): "release.image",
+	}
+
+	t.Run("Get Helm parameter for configured application", func(t *testing.T) {
+		img := NewFromIdentifier("dummy=foo/bar:1.12")
+		paramName := img.GetParameterHelmImageName(annotations)
+		paramTag := img.GetParameterHelmImageTag(annotations)
+		paramSpec := img.GetParameterHelmImageSpec(annotations)
+		assert.Equal(t, "release.name", paramName)
+		assert.Equal(t, "release.tag", paramTag)
+		assert.Equal(t, "release.image", paramSpec)
+	})
+
+	t.Run("Get Helm parameter for non-configured application", func(t *testing.T) {
+		img := NewFromIdentifier("foo=foo/bar:1.12")
+		paramName := img.GetParameterHelmImageName(annotations)
+		paramTag := img.GetParameterHelmImageTag(annotations)
+		paramSpec := img.GetParameterHelmImageSpec(annotations)
+		assert.Equal(t, "", paramName)
+		assert.Equal(t, "", paramTag)
+		assert.Equal(t, "", paramSpec)
+	})
+}
+
+func Test_GetSortOption(t *testing.T) {
+
+	t.Run("Get sort option semver for configured application", func(t *testing.T) {
+		annotations := map[string]string{
+			fmt.Sprintf(common.SortOptionAnnotation, "dummy"): "semver",
+		}
+		img := NewFromIdentifier("dummy=foo/bar:1.12")
+		sortMode := img.GetParameterSort(annotations)
+		assert.Equal(t, VersionSortSemVer, sortMode)
+	})
+
+	t.Run("Get sort option date for configured application", func(t *testing.T) {
+		annotations := map[string]string{
+			fmt.Sprintf(common.SortOptionAnnotation, "dummy"): "date",
+		}
+		img := NewFromIdentifier("dummy=foo/bar:1.12")
+		sortMode := img.GetParameterSort(annotations)
+		assert.Equal(t, VersionSortLatest, sortMode)
+	})
+
+	t.Run("Get sort option name for configured application", func(t *testing.T) {
+		annotations := map[string]string{
+			fmt.Sprintf(common.SortOptionAnnotation, "dummy"): "name",
+		}
+		img := NewFromIdentifier("dummy=foo/bar:1.12")
+		sortMode := img.GetParameterSort(annotations)
+		assert.Equal(t, VersionSortName, sortMode)
+	})
+
+	t.Run("Get default sort option configured application because of invalid option", func(t *testing.T) {
+		annotations := map[string]string{
+			fmt.Sprintf(common.SortOptionAnnotation, "dummy"): "invalid",
+		}
+		img := NewFromIdentifier("dummy=foo/bar:1.12")
+		sortMode := img.GetParameterSort(annotations)
+		assert.Equal(t, VersionSortSemVer, sortMode)
+	})
+
+	t.Run("Get default sort option configured application because of option not set", func(t *testing.T) {
+		annotations := map[string]string{}
+		img := NewFromIdentifier("dummy=foo/bar:1.12")
+		sortMode := img.GetParameterSort(annotations)
+		assert.Equal(t, VersionSortSemVer, sortMode)
+	})
+}


### PR DESCRIPTION
This will allow setting the tag sorting mechanism - and thereby ultimately which tag to update to - by setting an annotation:

`argocd-image-updater.argoproj.io/<image>.sort: <sortmode>`

where `<sortmode>` can be one of:

* `semver` (the default) - sort by latest version
* `date` - sort by creation date, i.e. take the latest built image
* `name` - sort by tag name

This will be useful if you want to upgrade to the latest image (i.e. those who have a Git hash in the tag) or if you have another version scheme than semver.