### PR TITLE
feat: Allow configuration of default namespace for registries

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -38,6 +38,7 @@ ctx
 Ctx
 deadcode
 Debugf
+defaultns
 dest
 dexidp
 dirname

--- a/docs/configuration/registries.md
+++ b/docs/configuration/registries.md
@@ -24,6 +24,7 @@ registries:
   api_url: https://registry-1.docker.io
   ping: yes
   credentials: secret:foo/bar#creds
+  defaultns: library
 - name: Google Container Registry
   api_url: https://gcr.io
   prefix: gcr.io
@@ -63,6 +64,11 @@ following semantics:
 * `insecure` (optional) if set to true, does not validate the TLS certificate
   for the connection to the registry. Use with care.
 
+* `defaultns` (optional) defines a default namespace for images that do not
+  specify one. For example, Docker Hub uses the default namespace `library`
+  which turns an image specification of `nginx:latest` into the canonical name
+  `library/nginx:latest`.
+
 * `tagsortmode` (optional) defines whether and how the list of tags is sorted
   chronologically by the registry. Valid values are `latest_first` (the last
   pushed image will appear first in list), `latest_last` (the last pushed image
@@ -84,6 +90,7 @@ data:
       api_url: https://registry-1.docker.io
       ping: yes
       credentials: secret:foo/bar#creds
+      defaultns: library
     - name: Google Container Registry
       api_url: https://gcr.io
       prefix: gcr.io

--- a/pkg/registry/config.go
+++ b/pkg/registry/config.go
@@ -19,6 +19,7 @@ type RegistryConfiguration struct {
 	TagSortMode string `yaml:"tagsortmode,omitempty"`
 	Prefix      string `yaml:"prefix,omitempty"`
 	Insecure    bool   `yaml:"insecure,omitempty"`
+	DefaultNS   string `yaml:"defaultns,omitempty"`
 }
 
 // RegistryList contains multiple RegistryConfiguration items
@@ -45,7 +46,7 @@ func LoadRegistryConfiguration(path string, clear bool) error {
 	}
 
 	for _, reg := range registryList.Items {
-		err = AddRegistryEndpoint(reg.Prefix, reg.Name, reg.ApiURL, reg.Credentials, reg.Insecure)
+		err = AddRegistryEndpoint(reg.Prefix, reg.Name, reg.ApiURL, reg.Credentials, reg.DefaultNS, reg.Insecure)
 		if err != nil {
 			return err
 		}

--- a/pkg/registry/endpoints.go
+++ b/pkg/registry/endpoints.go
@@ -49,6 +49,7 @@ type RegistryEndpoint struct {
 	Ping           bool
 	Credentials    string
 	Insecure       bool
+	DefaultNS      string
 	TagListSort    TagListSort
 	Cache          cache.ImageTagCache
 
@@ -63,6 +64,7 @@ var defaultRegistries map[string]*RegistryEndpoint = map[string]*RegistryEndpoin
 		RegistryAPI:    "https://registry-1.docker.io",
 		Ping:           true,
 		Insecure:       false,
+		DefaultNS:      "library",
 		Cache:          cache.NewMemCache(),
 	},
 	"gcr.io": {
@@ -98,7 +100,7 @@ var registries map[string]*RegistryEndpoint = make(map[string]*RegistryEndpoint)
 var registryLock sync.RWMutex
 
 // AddRegistryEndpoint adds registry endpoint information with the given details
-func AddRegistryEndpoint(prefix, name, apiUrl, credentials string, insecure bool) error {
+func AddRegistryEndpoint(prefix, name, apiUrl, credentials, defaultNS string, insecure bool) error {
 	registryLock.Lock()
 	defer registryLock.Unlock()
 	registries[prefix] = &RegistryEndpoint{
@@ -108,6 +110,7 @@ func AddRegistryEndpoint(prefix, name, apiUrl, credentials string, insecure bool
 		Credentials:    credentials,
 		Cache:          cache.NewMemCache(),
 		Insecure:       insecure,
+		DefaultNS:      defaultNS,
 	}
 	return nil
 }
@@ -158,6 +161,7 @@ func (ep *RegistryEndpoint) DeepCopy() *RegistryEndpoint {
 	newEp.TagListSort = ep.TagListSort
 	newEp.Cache = cache.NewMemCache()
 	newEp.Insecure = ep.Insecure
+	newEp.DefaultNS = ep.DefaultNS
 	return newEp
 }
 

--- a/pkg/registry/endpoints_test.go
+++ b/pkg/registry/endpoints_test.go
@@ -31,7 +31,7 @@ func Test_GetEndpoints(t *testing.T) {
 
 func Test_AddEndpoint(t *testing.T) {
 	t.Run("Add new endpoint", func(t *testing.T) {
-		err := AddRegistryEndpoint("example.com", "Example", "https://example.com", "", false)
+		err := AddRegistryEndpoint("example.com", "Example", "https://example.com", "", "", false)
 		require.NoError(t, err)
 	})
 	t.Run("Get example.com endpoint", func(t *testing.T) {
@@ -42,14 +42,16 @@ func Test_AddEndpoint(t *testing.T) {
 		assert.Equal(t, ep.RegistryName, "Example")
 		assert.Equal(t, ep.RegistryAPI, "https://example.com")
 		assert.Equal(t, ep.Insecure, false)
+		assert.Equal(t, ep.DefaultNS, "")
 	})
 	t.Run("Change existing endpoint", func(t *testing.T) {
-		err := AddRegistryEndpoint("example.com", "Example", "https://example.com", "", true)
+		err := AddRegistryEndpoint("example.com", "Example", "https://example.com", "", "library", true)
 		require.NoError(t, err)
 		ep, err := GetRegistryEndpoint("example.com")
 		require.NoError(t, err)
 		require.NotNil(t, ep)
 		assert.Equal(t, ep.Insecure, true)
+		assert.Equal(t, ep.DefaultNS, "library")
 	})
 }
 

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -23,11 +23,12 @@ func (endpoint *RegistryEndpoint) GetTags(img *image.ContainerImage, regClient R
 	var imgTag *tag.ImageTag
 	var err error
 
-	// DockerHub has a special namespace 'library', that is hidden from the user
-	// FIXME: How do other registries handle this?
+	// Some registries have a default namespace that is used when the image name
+	// doesn't specify one. For example at Docker Hub, this is 'library'.
 	var nameInRegistry string
-	if len := len(strings.Split(img.ImageName, "/")); len == 1 {
-		nameInRegistry = "library/" + img.ImageName
+	if len := len(strings.Split(img.ImageName, "/")); len == 1 && endpoint.DefaultNS != "" {
+		nameInRegistry = endpoint.DefaultNS + "/" + img.ImageName
+		log.Debugf("Using canonical image name '%s' for image '%s'", nameInRegistry, img.ImageName)
 	} else {
 		nameInRegistry = img.ImageName
 	}


### PR DESCRIPTION
Allows configuration of a default image namespace to use when the image name doesn't specify one (i.e. DockerHub has a default namespace of `library`).

Might help resolution of #90 