### PR TITLE
refactor: Introduce allow-tags and deprecate tag-match annotation

### DIFF
--- a/docs/configuration/images.md
+++ b/docs/configuration/images.md
@@ -127,7 +127,7 @@ only consider tags that you are generally interested in.
 You can define a tag filter by using the following annotation:
 
 ```yaml
-argocd-image-updater.argoproj.io/<image_name>.tag-match: <match_func>
+argocd-image-updater.argoproj.io/<image_name>.allow-tags: <match_func>
 ```
 
 The following match functions are currently available:
@@ -292,14 +292,14 @@ some identifier (i.e. the hash of the Git commit) in the tag.
 2. Use `latest` as update strategy
 
 3. If you just want to consider a given set of tags, i.e. `v1.0.0-<hash>`, use a
-  `tag-match` annotation.
+  `allow-tags` annotation.
 
 Annotations might look like follows:
 
 ```yaml
 argocd-image-updater.argoproj.io/image-list: yourtool=yourorg/yourimage
 argocd-image-updater.argoproj.io/yourtool.update-strategy: latest
-argocd-image-updater.argoproj.io/yourtool.tag-match: regexp:^v1.0.0-[0-9a-zA-Z]+$
+argocd-image-updater.argoproj.io/yourtool.allow-tags: regexp:^v1.0.0-[0-9a-zA-Z]+$
 ```
 
 ### Multiple images in the same Helm chart
@@ -341,7 +341,7 @@ must be prefixed with `argocd-image-updater.argoproj.io`.
 |---------------|-------|-----------|
 |`image-list`|*none*|Comma separated list of images to consider for update|
 |`<image_alias>.update-strategy`|`semver`|The update strategy to be used for the image|
-|`<image_alias>.tag-match`|*any*|A function to match tag names from registry against to be considered for update|
+|`<image_alias>.allow-tags`|*any*|A function to match tag names from registry against to be considered for update|
 |`<image_alias>.ignore-tags`|*none*|A comma-separated list of glob patterns that when match ignore a certain tag from the registry|
 |`<image_alias>.pull-secret`|*none*|A reference to a secret to be used as registry credentials for this image|
 |`<image_alias>.helm.image-spec`|*none*|Name of the Helm parameter to specify the canonical name of the image, i.e. holds `image/name:1.0`. If this is set, other Helm parameter related options will be ignored.|

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -258,8 +258,8 @@ func Test_UpdateApplication(t *testing.T) {
 					Name:      "guestbook",
 					Namespace: "guestbook",
 					Annotations: map[string]string{
-						fmt.Sprintf(common.MatchOptionAnnotation, "dummy"):    "regexp:^foobar$",
-						fmt.Sprintf(common.UpdateStrategyAnnotation, "dummy"): "name",
+						fmt.Sprintf(common.AllowTagsOptionAnnotation, "dummy"): "regexp:^foobar$",
+						fmt.Sprintf(common.UpdateStrategyAnnotation, "dummy"):  "name",
 					},
 				},
 				Spec: v1alpha1.ApplicationSpec{

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -28,7 +28,8 @@ const (
 
 // Upgrade strategy related annotations
 const (
-	MatchOptionAnnotation      = ImageUpdaterAnnotationPrefix + "/%s.tag-match"
+	OldMatchOptionAnnotation   = ImageUpdaterAnnotationPrefix + "/%s.tag-match" // Deprecated and will be removed
+	AllowTagsOptionAnnotation  = ImageUpdaterAnnotationPrefix + "/%s.allow-tags"
 	IgnoreTagsOptionAnnotation = ImageUpdaterAnnotationPrefix + "/%s.ignore-tags"
 	UpdateStrategyAnnotation   = ImageUpdaterAnnotationPrefix + "/%s.update-strategy"
 )

--- a/pkg/image/options.go
+++ b/pkg/image/options.go
@@ -83,11 +83,20 @@ func (img *ContainerImage) GetParameterUpdateStrategy(annotations map[string]str
 // tag names. If an invalid option is found, it returns MatchFuncNone as the
 // default, to prevent accidental matches.
 func (img *ContainerImage) GetParameterMatch(annotations map[string]string) (MatchFuncFn, interface{}) {
-	key := fmt.Sprintf(common.MatchOptionAnnotation, img.normalizedSymbolicName())
+
+	key := fmt.Sprintf(common.AllowTagsOptionAnnotation, img.normalizedSymbolicName())
 	val, ok := annotations[key]
 	if !ok {
-		log.Tracef("No match annotation %s found", key)
-		return MatchFuncAny, ""
+		// The old match-tag annotation is deprecated and will be subject to removal
+		// in a future version.
+		key = fmt.Sprintf(common.OldMatchOptionAnnotation, img.normalizedSymbolicName())
+		val, ok = annotations[key]
+		if !ok {
+			log.Tracef("No match annotation %s found", key)
+			return MatchFuncAny, ""
+		} else {
+			log.Warnf("The 'tag-match' annotation is deprecated and subject to removal. Please use 'allow-tags' annotation instead.")
+		}
 	}
 
 	// The special value "any" doesn't take any parameter

--- a/pkg/image/options_test.go
+++ b/pkg/image/options_test.go
@@ -123,7 +123,7 @@ func Test_GetMatchOption(t *testing.T) {
 
 	t.Run("Get regexp match option for configured application", func(t *testing.T) {
 		annotations := map[string]string{
-			fmt.Sprintf(common.MatchOptionAnnotation, "dummy"): "regexp:a-z",
+			fmt.Sprintf(common.AllowTagsOptionAnnotation, "dummy"): "regexp:a-z",
 		}
 		img := NewFromIdentifier("dummy=foo/bar:1.12")
 		matchFunc, matchArgs := img.GetParameterMatch(annotations)
@@ -134,7 +134,7 @@ func Test_GetMatchOption(t *testing.T) {
 
 	t.Run("Get regexp match option for configured application with invalid expression", func(t *testing.T) {
 		annotations := map[string]string{
-			fmt.Sprintf(common.MatchOptionAnnotation, "dummy"): `regexp:/foo\`,
+			fmt.Sprintf(common.AllowTagsOptionAnnotation, "dummy"): `regexp:/foo\`,
 		}
 		img := NewFromIdentifier("dummy=foo/bar:1.12")
 		matchFunc, matchArgs := img.GetParameterMatch(annotations)
@@ -144,7 +144,7 @@ func Test_GetMatchOption(t *testing.T) {
 
 	t.Run("Get invalid match option for configured application", func(t *testing.T) {
 		annotations := map[string]string{
-			fmt.Sprintf(common.MatchOptionAnnotation, "dummy"): "invalid",
+			fmt.Sprintf(common.AllowTagsOptionAnnotation, "dummy"): "invalid",
 		}
 		img := NewFromIdentifier("dummy=foo/bar:1.12")
 		matchFunc, matchArgs := img.GetParameterMatch(annotations)


### PR DESCRIPTION
The `tag-match` annotation has been deprecated and renamed in favour of `allow-tags` to be more consistent with the new `ignore-tags` annotation.

The `tag-match` annotation will still work for a couple of versions before being removed, but a warning is printed in the logs.
