### PR TITLE
feat: add argocd-image-updater test command

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -201,6 +201,7 @@ func newTestCommand() *cobra.Command {
 		registriesConf   string
 		logLevel         string
 		allowTags        string
+		ignoreTags       []string
 	)
 	var runCmd = &cobra.Command{
 		Use:   "test IMAGE",
@@ -225,6 +226,8 @@ func newTestCommand() *cobra.Command {
 			if allowTags != "" {
 				vc.MatchFunc, vc.MatchArgs = image.ParseMatchfunc(allowTags)
 			}
+
+			vc.IgnoreList = ignoreTags
 
 			img := image.NewFromIdentifier(args[0])
 			log.WithContext().
@@ -279,8 +282,9 @@ func newTestCommand() *cobra.Command {
 	}
 
 	runCmd.Flags().StringVar(&semverConstraint, "semver-constraint", "", "only consider tags matching semantic version constraint")
-	runCmd.Flags().StringVar(&allowTags, "allow-tags", "", "function to match tag names from registry")
-	runCmd.Flags().StringVar(&strategy, "strategy", "semver", "update strategy to use, one of: semver, latest)")
+	runCmd.Flags().StringVar(&allowTags, "allow-tags", "", "only consider tags in registry that satisfy the match function")
+	runCmd.Flags().StringArrayVar(&ignoreTags, "ignore-tags", nil, "ignore tags in registry that match given glob pattern")
+	runCmd.Flags().StringVar(&strategy, "update-strategy", "semver", "update strategy to use, one of: semver, latest)")
 	runCmd.Flags().StringVar(&registriesConf, "registries-conf", "", "path to registries configuration")
 	runCmd.Flags().StringVar(&logLevel, "loglevel", "debug", "log level to use (one of trace, debug, info, warn, error)")
 	return runCmd

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -206,6 +206,26 @@ func newTestCommand() *cobra.Command {
 	var runCmd = &cobra.Command{
 		Use:   "test IMAGE",
 		Short: "Test the behaviour of argocd-image-updater",
+		Long: `
+The test command lets you test the behaviour of argocd-image-updater before
+configuring annotations on your Argo CD Applications.
+
+Its main use case is to tell you to which tag a given image would be updated
+to using the given parametrization. Command line switches can be used as a
+way to supply the required parameters.
+`,
+		Example: `
+# In the most simple form, check for the latest available (semver) version of 
+# an image in the registry
+argocd-image-updater test nginx
+
+# Check to which version the nginx image within the 1.17 branch would be
+# updated to, using the default semver strategy
+argocd-image-updater test nginx --semver-constraint v1.17.x
+
+# Check for the latest built image for a tag that matches a pattern
+argocd-image-updater test nginx --allow-tags '^1.19.\d+(\-.*)*$' --update-strategy latest
+`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 1 {
 				cmd.HelpFunc()(cmd, args)


### PR DESCRIPTION
This adds the new `test` command to `argocd-image-updater` CLI.

Its main purpose is to test & validate behaviour of argocd-image-updater, without requiring changes to your live resources.