### PR TITLE
feat: Implement rate limiter and metadata parallelism

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -148,6 +148,7 @@ Printf
 pullsecret
 pwd
 pygments
+ratelimit
 rbac
 readthedocs
 refactor
@@ -193,6 +194,7 @@ TODO
 toolchain
 Torvalds
 Tracef
+uber
 unmarshal
 unmarshals
 unparam
@@ -204,6 +206,7 @@ usr
 varcheck
 versioned
 versioning
+waitgroup
 Warnf
 webkit
 webroot

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cobra v1.0.0
 	github.com/stretchr/testify v1.6.1
+	go.uber.org/ratelimit v0.1.1-0.20201110185707-e86515f0dda9
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v1.18.8

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/alicebob/gopher-json v0.0.0-20180125190556-5a6b3ba71ee6 h1:45bxf7AZMw
 github.com/alicebob/gopher-json v0.0.0-20180125190556-5a6b3ba71ee6/go.mod h1:SGnFV6hVsYE877CKEZ6tDNTjaSXYUk6QqoIK6PrAtcc=
 github.com/alicebob/miniredis v2.5.0+incompatible h1:yBHoLpsyjupjz3NL3MhKMVkR41j82Yjf3KFv7ApYzUI=
 github.com/alicebob/miniredis v2.5.0+incompatible/go.mod h1:8HZjEj4yU0dwhYHky+DxYx+6BMjkBbe5ONFIF1MXffk=
+github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 h1:MzBOUgng9orim59UnfUTLRjMpd09C5uEVQ6RPGeCaVI=
+github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129/go.mod h1:rFgpPQZYZ8vdbc+48xibu8ALc3yeyd64IhHS+PU6Yyg=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
@@ -638,7 +640,11 @@ go.mongodb.org/mongo-driver v1.1.2/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qL
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
+go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
+go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
+go.uber.org/ratelimit v0.1.1-0.20201110185707-e86515f0dda9 h1:kDMN0JgYHdW9UXbNzDISNbosytZK57hy/1T58y52Q3s=
+go.uber.org/ratelimit v0.1.1-0.20201110185707-e86515f0dda9/go.mod h1:YYBV4e4naJvhpitQrWJu1vCpgB7CboMe0qhltKt6mUg=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go4.org v0.0.0-20180809161055-417644f6feb5/go.mod h1:MkTOUMDaeVYJUOUsaDXIhWPZYa1yOyC1qaOBpL57BhE=
 golang.org/x/build v0.0.0-20190927031335-2835ba2e683f/go.mod h1:fYw7AShPAhGMdXqA9gRadk/CcMsvLlClpE5oBwnS3dM=

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -25,7 +25,7 @@ func Test_UpdateApplication(t *testing.T) {
 	t.Run("Test successful update", func(t *testing.T) {
 		mockClientFn := func(endpoint *registry.RegistryEndpoint, username, password string) (registry.RegistryClient, error) {
 			regMock := regmock.RegistryClient{}
-			regMock.On("Tags", mock.Anything).Return([]string{"1.0.1"}, nil)
+			regMock.On("Tags", mock.Anything, mock.Anything).Return([]string{"1.0.1"}, nil)
 			return &regMock, nil
 		}
 
@@ -76,7 +76,7 @@ func Test_UpdateApplication(t *testing.T) {
 			regMock := regmock.RegistryClient{}
 			assert.Equal(t, "myuser", username)
 			assert.Equal(t, "mypass", password)
-			regMock.On("Tags", mock.Anything).Return([]string{"1.0.1"}, nil)
+			regMock.On("Tags", mock.Anything, mock.Anything).Return([]string{"1.0.1"}, nil)
 			return &regMock, nil
 		}
 
@@ -128,7 +128,7 @@ func Test_UpdateApplication(t *testing.T) {
 	t.Run("Test skip because of image not in list", func(t *testing.T) {
 		mockClientFn := func(endpoint *registry.RegistryEndpoint, username, password string) (registry.RegistryClient, error) {
 			regMock := regmock.RegistryClient{}
-			regMock.On("Tags", mock.Anything).Return([]string{"1.0.1"}, nil)
+			regMock.On("Tags", mock.Anything, mock.Anything).Return([]string{"1.0.1"}, nil)
 			return &regMock, nil
 		}
 
@@ -177,7 +177,7 @@ func Test_UpdateApplication(t *testing.T) {
 	t.Run("Test skip because of image up-to-date", func(t *testing.T) {
 		mockClientFn := func(endpoint *registry.RegistryEndpoint, username, password string) (registry.RegistryClient, error) {
 			regMock := regmock.RegistryClient{}
-			regMock.On("Tags", mock.Anything).Return([]string{"1.0.1"}, nil)
+			regMock.On("Tags", mock.Anything, mock.Anything).Return([]string{"1.0.1"}, nil)
 			return &regMock, nil
 		}
 
@@ -240,7 +240,7 @@ func Test_UpdateApplication(t *testing.T) {
 		called := 0
 		mockClientFn := func(endpoint *registry.RegistryEndpoint, username, password string) (registry.RegistryClient, error) {
 			regMock := regmock.RegistryClient{}
-			regMock.On("Tags", mock.Anything).Return([]string{"one", "two", "three", "four"}, nil)
+			regMock.On("Tags", mock.Anything, mock.Anything).Return([]string{"one", "two", "three", "four"}, nil)
 			regMock.On("ManifestV1", mock.Anything, mock.Anything).Return(meta[called], nil)
 			called += 1
 			return &regMock, nil
@@ -309,7 +309,7 @@ func Test_UpdateApplication(t *testing.T) {
 		called := 0
 		mockClientFn := func(endpoint *registry.RegistryEndpoint, username, password string) (registry.RegistryClient, error) {
 			regMock := regmock.RegistryClient{}
-			regMock.On("Tags", mock.Anything).Return([]string{"one", "two", "three", "four"}, nil)
+			regMock.On("Tags", mock.Anything, mock.Anything).Return([]string{"one", "two", "three", "four"}, nil)
 			regMock.On("ManifestV1", mock.Anything, mock.Anything).Return(meta[called], nil)
 			called += 1
 			return &regMock, nil
@@ -364,7 +364,7 @@ func Test_UpdateApplication(t *testing.T) {
 	t.Run("Error - unknown registry", func(t *testing.T) {
 		mockClientFn := func(endpoint *registry.RegistryEndpoint, username, password string) (registry.RegistryClient, error) {
 			regMock := regmock.RegistryClient{}
-			regMock.On("Tags", mock.Anything).Return([]string{"1.0.1"}, nil)
+			regMock.On("Tags", mock.Anything, mock.Anything).Return([]string{"1.0.1"}, nil)
 			return &regMock, nil
 		}
 
@@ -460,7 +460,7 @@ func Test_UpdateApplication(t *testing.T) {
 	t.Run("Test error on failure to list tags", func(t *testing.T) {
 		mockClientFn := func(endpoint *registry.RegistryEndpoint, username, password string) (registry.RegistryClient, error) {
 			regMock := regmock.RegistryClient{}
-			regMock.On("Tags", mock.Anything).Return(nil, errors.New("some error"))
+			regMock.On("Tags", mock.Anything, mock.Anything).Return(nil, errors.New("some error"))
 			return &regMock, nil
 		}
 
@@ -509,7 +509,7 @@ func Test_UpdateApplication(t *testing.T) {
 	t.Run("Test error on improper semver in tag", func(t *testing.T) {
 		mockClientFn := func(endpoint *registry.RegistryEndpoint, username, password string) (registry.RegistryClient, error) {
 			regMock := regmock.RegistryClient{}
-			regMock.On("Tags", mock.Anything).Return([]string{"1.0.0", "1.0.1"}, nil)
+			regMock.On("Tags", mock.Anything, mock.Anything).Return([]string{"1.0.0", "1.0.1"}, nil)
 			return &regMock, nil
 		}
 

--- a/pkg/registry/config.go
+++ b/pkg/registry/config.go
@@ -20,6 +20,7 @@ type RegistryConfiguration struct {
 	Prefix      string `yaml:"prefix,omitempty"`
 	Insecure    bool   `yaml:"insecure,omitempty"`
 	DefaultNS   string `yaml:"defaultns,omitempty"`
+	Limit       int    `yaml:"limit,omitempty"`
 }
 
 // RegistryList contains multiple RegistryConfiguration items
@@ -47,7 +48,7 @@ func LoadRegistryConfiguration(path string, clear bool) error {
 
 	for _, reg := range registryList.Items {
 		tagSortMode := TagListSortFromString(reg.TagSortMode)
-		err = AddRegistryEndpoint(reg.Prefix, reg.Name, reg.ApiURL, reg.Credentials, reg.DefaultNS, reg.Insecure, tagSortMode)
+		err = AddRegistryEndpoint(reg.Prefix, reg.Name, reg.ApiURL, reg.Credentials, reg.DefaultNS, reg.Insecure, tagSortMode, reg.Limit)
 		if err != nil {
 			return err
 		}

--- a/pkg/registry/endpoints_test.go
+++ b/pkg/registry/endpoints_test.go
@@ -31,7 +31,7 @@ func Test_GetEndpoints(t *testing.T) {
 
 func Test_AddEndpoint(t *testing.T) {
 	t.Run("Add new endpoint", func(t *testing.T) {
-		err := AddRegistryEndpoint("example.com", "Example", "https://example.com", "", "", false, SortUnsorted)
+		err := AddRegistryEndpoint("example.com", "Example", "https://example.com", "", "", false, SortUnsorted, 5)
 		require.NoError(t, err)
 	})
 	t.Run("Get example.com endpoint", func(t *testing.T) {
@@ -46,7 +46,7 @@ func Test_AddEndpoint(t *testing.T) {
 		assert.Equal(t, ep.TagListSort, SortUnsorted)
 	})
 	t.Run("Change existing endpoint", func(t *testing.T) {
-		err := AddRegistryEndpoint("example.com", "Example", "https://example.com", "", "library", true, SortLatestFirst)
+		err := AddRegistryEndpoint("example.com", "Example", "https://example.com", "", "library", true, SortLatestFirst, 5)
 		require.NoError(t, err)
 		ep, err := GetRegistryEndpoint("example.com")
 		require.NoError(t, err)

--- a/pkg/registry/mocks/RegistryClient.go
+++ b/pkg/registry/mocks/RegistryClient.go
@@ -6,6 +6,8 @@ import (
 	distribution "github.com/docker/distribution"
 	mock "github.com/stretchr/testify/mock"
 
+	ratelimit "go.uber.org/ratelimit"
+
 	schema1 "github.com/docker/distribution/manifest/schema1"
 
 	schema2 "github.com/docker/distribution/manifest/schema2"
@@ -18,13 +20,13 @@ type RegistryClient struct {
 	mock.Mock
 }
 
-// ManifestV1 provides a mock function with given fields: repository, reference
-func (_m *RegistryClient) ManifestV1(repository string, reference string) (*schema1.SignedManifest, error) {
-	ret := _m.Called(repository, reference)
+// ManifestV1 provides a mock function with given fields: repository, reference, limiter
+func (_m *RegistryClient) ManifestV1(repository string, reference string, limiter ratelimit.Limiter) (*schema1.SignedManifest, error) {
+	ret := _m.Called(repository, reference, limiter)
 
 	var r0 *schema1.SignedManifest
-	if rf, ok := ret.Get(0).(func(string, string) *schema1.SignedManifest); ok {
-		r0 = rf(repository, reference)
+	if rf, ok := ret.Get(0).(func(string, string, ratelimit.Limiter) *schema1.SignedManifest); ok {
+		r0 = rf(repository, reference, limiter)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*schema1.SignedManifest)
@@ -32,8 +34,8 @@ func (_m *RegistryClient) ManifestV1(repository string, reference string) (*sche
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, string) error); ok {
-		r1 = rf(repository, reference)
+	if rf, ok := ret.Get(1).(func(string, string, ratelimit.Limiter) error); ok {
+		r1 = rf(repository, reference, limiter)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -41,13 +43,13 @@ func (_m *RegistryClient) ManifestV1(repository string, reference string) (*sche
 	return r0, r1
 }
 
-// ManifestV2 provides a mock function with given fields: repository, reference
-func (_m *RegistryClient) ManifestV2(repository string, reference string) (*schema2.DeserializedManifest, error) {
-	ret := _m.Called(repository, reference)
+// ManifestV2 provides a mock function with given fields: repository, reference, limiter
+func (_m *RegistryClient) ManifestV2(repository string, reference string, limiter ratelimit.Limiter) (*schema2.DeserializedManifest, error) {
+	ret := _m.Called(repository, reference, limiter)
 
 	var r0 *schema2.DeserializedManifest
-	if rf, ok := ret.Get(0).(func(string, string) *schema2.DeserializedManifest); ok {
-		r0 = rf(repository, reference)
+	if rf, ok := ret.Get(0).(func(string, string, ratelimit.Limiter) *schema2.DeserializedManifest); ok {
+		r0 = rf(repository, reference, limiter)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*schema2.DeserializedManifest)
@@ -55,8 +57,8 @@ func (_m *RegistryClient) ManifestV2(repository string, reference string) (*sche
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, string) error); ok {
-		r1 = rf(repository, reference)
+	if rf, ok := ret.Get(1).(func(string, string, ratelimit.Limiter) error); ok {
+		r1 = rf(repository, reference, limiter)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -64,13 +66,13 @@ func (_m *RegistryClient) ManifestV2(repository string, reference string) (*sche
 	return r0, r1
 }
 
-// TagMetadata provides a mock function with given fields: repository, manifest
-func (_m *RegistryClient) TagMetadata(repository string, manifest distribution.Manifest) (*tag.TagInfo, error) {
-	ret := _m.Called(repository, manifest)
+// TagMetadata provides a mock function with given fields: repository, manifest, limiter
+func (_m *RegistryClient) TagMetadata(repository string, manifest distribution.Manifest, limiter ratelimit.Limiter) (*tag.TagInfo, error) {
+	ret := _m.Called(repository, manifest, limiter)
 
 	var r0 *tag.TagInfo
-	if rf, ok := ret.Get(0).(func(string, distribution.Manifest) *tag.TagInfo); ok {
-		r0 = rf(repository, manifest)
+	if rf, ok := ret.Get(0).(func(string, distribution.Manifest, ratelimit.Limiter) *tag.TagInfo); ok {
+		r0 = rf(repository, manifest, limiter)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*tag.TagInfo)
@@ -78,8 +80,8 @@ func (_m *RegistryClient) TagMetadata(repository string, manifest distribution.M
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, distribution.Manifest) error); ok {
-		r1 = rf(repository, manifest)
+	if rf, ok := ret.Get(1).(func(string, distribution.Manifest, ratelimit.Limiter) error); ok {
+		r1 = rf(repository, manifest, limiter)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -87,13 +89,13 @@ func (_m *RegistryClient) TagMetadata(repository string, manifest distribution.M
 	return r0, r1
 }
 
-// Tags provides a mock function with given fields: nameInRepository
-func (_m *RegistryClient) Tags(nameInRepository string) ([]string, error) {
-	ret := _m.Called(nameInRepository)
+// Tags provides a mock function with given fields: nameInRepository, limiter
+func (_m *RegistryClient) Tags(nameInRepository string, limiter ratelimit.Limiter) ([]string, error) {
+	ret := _m.Called(nameInRepository, limiter)
 
 	var r0 []string
-	if rf, ok := ret.Get(0).(func(string) []string); ok {
-		r0 = rf(nameInRepository)
+	if rf, ok := ret.Get(0).(func(string, ratelimit.Limiter) []string); ok {
+		r0 = rf(nameInRepository, limiter)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
@@ -101,8 +103,8 @@ func (_m *RegistryClient) Tags(nameInRepository string) ([]string, error) {
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(nameInRepository)
+	if rf, ok := ret.Get(1).(func(string, ratelimit.Limiter) error); ok {
+		r1 = rf(nameInRepository, limiter)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -19,7 +19,7 @@ func Test_GetTags(t *testing.T) {
 
 	t.Run("Check for correctly returned tags with semver sort", func(t *testing.T) {
 		regClient := mocks.RegistryClient{}
-		regClient.On("Tags", mock.Anything).Return([]string{"1.2.0", "1.2.1", "1.2.2"}, nil)
+		regClient.On("Tags", mock.Anything, mock.Anything).Return([]string{"1.2.0", "1.2.1", "1.2.2"}, nil)
 
 		ep, err := GetRegistryEndpoint("")
 		require.NoError(t, err)
@@ -37,7 +37,7 @@ func Test_GetTags(t *testing.T) {
 
 	t.Run("Check for correctly returned tags with filter function applied", func(t *testing.T) {
 		regClient := mocks.RegistryClient{}
-		regClient.On("Tags", mock.Anything).Return([]string{"1.2.0", "1.2.1", "1.2.2"}, nil)
+		regClient.On("Tags", mock.Anything, mock.Anything).Return([]string{"1.2.0", "1.2.1", "1.2.2"}, nil)
 
 		ep, err := GetRegistryEndpoint("")
 		require.NoError(t, err)
@@ -56,7 +56,7 @@ func Test_GetTags(t *testing.T) {
 	t.Run("Check for correctly returned tags with name sort", func(t *testing.T) {
 
 		regClient := mocks.RegistryClient{}
-		regClient.On("Tags", mock.Anything).Return([]string{"1.2.0", "1.2.1", "1.2.2"}, nil)
+		regClient.On("Tags", mock.Anything, mock.Anything).Return([]string{"1.2.0", "1.2.1", "1.2.2"}, nil)
 
 		ep, err := GetRegistryEndpoint("")
 		require.NoError(t, err)
@@ -88,10 +88,10 @@ func Test_GetTags(t *testing.T) {
 		}
 
 		regClient := mocks.RegistryClient{}
-		regClient.On("Tags", mock.Anything).Return([]string{"1.2.0", "1.2.1", "1.2.2"}, nil)
-		regClient.On("ManifestV1", mock.Anything, mock.Anything).Return(meta1, nil)
-		regClient.On("ManifestV2", mock.Anything, mock.Anything).Return(meta2, nil)
-		regClient.On("TagMetadata", mock.Anything, mock.Anything).Return(&tag.TagInfo{}, nil)
+		regClient.On("Tags", mock.Anything, mock.Anything).Return([]string{"1.2.0", "1.2.1", "1.2.2"}, nil)
+		regClient.On("ManifestV1", mock.Anything, mock.Anything, mock.Anything).Return(meta1, nil)
+		regClient.On("ManifestV2", mock.Anything, mock.Anything, mock.Anything).Return(meta2, nil)
+		regClient.On("TagMetadata", mock.Anything, mock.Anything, mock.Anything).Return(&tag.TagInfo{}, nil)
 
 		ep, err := GetRegistryEndpoint("")
 		require.NoError(t, err)
@@ -119,10 +119,10 @@ func Test_GetTags(t *testing.T) {
 		}
 
 		regClient := mocks.RegistryClient{}
-		regClient.On("Tags", mock.Anything).Return([]string{"1.2.0", "1.2.1", "1.2.2"}, nil)
-		regClient.On("ManifestV1", mock.Anything, mock.Anything).Return(meta1, nil)
-		regClient.On("ManifestV2", mock.Anything, mock.Anything).Return(meta2, fmt.Errorf("not implemented"))
-		regClient.On("TagMetadata", mock.Anything, mock.Anything).Return(nil, nil)
+		regClient.On("Tags", mock.Anything, mock.Anything).Return([]string{"1.2.0", "1.2.1", "1.2.2"}, nil)
+		regClient.On("ManifestV1", mock.Anything, mock.Anything, mock.Anything).Return(meta1, nil)
+		regClient.On("ManifestV2", mock.Anything, mock.Anything, mock.Anything).Return(meta2, fmt.Errorf("not implemented"))
+		regClient.On("TagMetadata", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
 
 		ep, err := GetRegistryEndpoint("")
 		require.NoError(t, err)
@@ -153,10 +153,10 @@ func Test_GetTags(t *testing.T) {
 		}
 
 		regClient := mocks.RegistryClient{}
-		regClient.On("Tags", mock.Anything).Return([]string{"1.2.0", "1.2.1", "1.2.2"}, nil)
-		regClient.On("ManifestV1", mock.Anything, mock.Anything).Return(meta1, nil)
-		regClient.On("ManifestV2", mock.Anything, mock.Anything).Return(meta2, fmt.Errorf("not implemented"))
-		regClient.On("TagMetadata", mock.Anything, mock.Anything).Return(nil, nil)
+		regClient.On("Tags", mock.Anything, mock.Anything).Return([]string{"1.2.0", "1.2.1", "1.2.2"}, nil)
+		regClient.On("ManifestV1", mock.Anything, mock.Anything, mock.Anything).Return(meta1, nil)
+		regClient.On("ManifestV2", mock.Anything, mock.Anything, mock.Anything).Return(meta2, fmt.Errorf("not implemented"))
+		regClient.On("TagMetadata", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
 
 		ep, err := GetRegistryEndpoint("")
 		require.NoError(t, err)
@@ -187,10 +187,10 @@ func Test_GetTags(t *testing.T) {
 		}
 
 		regClient := mocks.RegistryClient{}
-		regClient.On("Tags", mock.Anything).Return([]string{"1.2.0", "1.2.1", "1.2.2"}, nil)
-		regClient.On("ManifestV1", mock.Anything, mock.Anything).Return(meta1, nil)
-		regClient.On("ManifestV2", mock.Anything, mock.Anything).Return(meta2, fmt.Errorf("not implemented"))
-		regClient.On("TagMetadata", mock.Anything, mock.Anything).Return(nil, nil)
+		regClient.On("Tags", mock.Anything, mock.Anything).Return([]string{"1.2.0", "1.2.1", "1.2.2"}, nil)
+		regClient.On("ManifestV1", mock.Anything, mock.Anything, mock.Anything).Return(meta1, nil)
+		regClient.On("ManifestV2", mock.Anything, mock.Anything, mock.Anything).Return(meta2, fmt.Errorf("not implemented"))
+		regClient.On("TagMetadata", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
 
 		ep, err := GetRegistryEndpoint("")
 		require.NoError(t, err)
@@ -222,10 +222,10 @@ func Test_GetTags(t *testing.T) {
 		}
 
 		regClient := mocks.RegistryClient{}
-		regClient.On("Tags", mock.Anything).Return([]string{"1.2.0", "1.2.1", "1.2.2"}, nil)
-		regClient.On("ManifestV1", mock.Anything, mock.Anything).Return(meta1, nil)
-		regClient.On("ManifestV2", mock.Anything, mock.Anything).Return(meta2, fmt.Errorf("not implemented"))
-		regClient.On("TagMetadata", mock.Anything, mock.Anything).Return(nil, nil)
+		regClient.On("Tags", mock.Anything, mock.Anything).Return([]string{"1.2.0", "1.2.1", "1.2.2"}, nil)
+		regClient.On("ManifestV1", mock.Anything, mock.Anything, mock.Anything).Return(meta1, nil)
+		regClient.On("ManifestV2", mock.Anything, mock.Anything, mock.Anything).Return(meta2, fmt.Errorf("not implemented"))
+		regClient.On("TagMetadata", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
 
 		ep, err := GetRegistryEndpoint("")
 		require.NoError(t, err)


### PR DESCRIPTION
This change implements two new features:

* pulling tag meta-data in parallel for better performance of `latest` mode and
* basic rate-limiting of requests to the registry (configurable per endpoint/registry)

Signed-off-by: jannfis <jann@mistrust.net>