### PR TITLE
refactor: Better integration of rate limiter

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -107,6 +107,7 @@ LDFLAGS
 len
 linted
 logctx
+logf
 Logf
 loglevel
 logrus
@@ -156,6 +157,7 @@ refactoring
 regexp
 regmock
 RLock
+rlt
 roadmap
 rolebinding
 rolebindings

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,8 @@ require (
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
 	github.com/gorilla/mux v1.7.4 // indirect
-	github.com/nokia/docker-registry-client v0.0.0-20190305095957-e91f10057c5b
+	github.com/nokia/docker-registry-client v0.0.0-20201015093031-af1a6d3b4fb1
+	github.com/opencontainers/go-digest v1.0.0-rc1
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cobra v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
 	github.com/gorilla/mux v1.7.4 // indirect
 	github.com/nokia/docker-registry-client v0.0.0-20201015093031-af1a6d3b4fb1
-	github.com/opencontainers/go-digest v1.0.0-rc1
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cobra v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -474,8 +474,8 @@ github.com/naoina/go-stringutil v0.1.0/go.mod h1:XJ2SJL9jCtBh+P9q5btrd/Ylo8XwT/h
 github.com/naoina/toml v0.1.1/go.mod h1:NBIhNtsFMo3G2szEBne+bO4gS192HuIYRqfvOWb4i1E=
 github.com/nbutton23/zxcvbn-go v0.0.0-20160627004424-a22cb81b2ecd/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
 github.com/nbutton23/zxcvbn-go v0.0.0-20171102151520-eafdab6b0663/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
-github.com/nokia/docker-registry-client v0.0.0-20190305095957-e91f10057c5b h1:6d02Onq/KxC2qZlMzSwLx12KZU80xIS7hRQw05/nDJs=
-github.com/nokia/docker-registry-client v0.0.0-20190305095957-e91f10057c5b/go.mod h1:0DpUaZpSvIXrsvYc6Wb+fKwjhKz0Lu1NHwMziqTqqvA=
+github.com/nokia/docker-registry-client v0.0.0-20201015093031-af1a6d3b4fb1 h1:QNZos2cYVSeT7m1IEQupD3dWJG3ELuThKQMP3WRDZVE=
+github.com/nokia/docker-registry-client v0.0.0-20201015093031-af1a6d3b4fb1/go.mod h1:0DpUaZpSvIXrsvYc6Wb+fKwjhKz0Lu1NHwMziqTqqvA=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -25,7 +25,7 @@ func Test_UpdateApplication(t *testing.T) {
 	t.Run("Test successful update", func(t *testing.T) {
 		mockClientFn := func(endpoint *registry.RegistryEndpoint, username, password string) (registry.RegistryClient, error) {
 			regMock := regmock.RegistryClient{}
-			regMock.On("Tags", mock.Anything, mock.Anything).Return([]string{"1.0.1"}, nil)
+			regMock.On("Tags", mock.Anything).Return([]string{"1.0.1"}, nil)
 			return &regMock, nil
 		}
 
@@ -76,7 +76,7 @@ func Test_UpdateApplication(t *testing.T) {
 			regMock := regmock.RegistryClient{}
 			assert.Equal(t, "myuser", username)
 			assert.Equal(t, "mypass", password)
-			regMock.On("Tags", mock.Anything, mock.Anything).Return([]string{"1.0.1"}, nil)
+			regMock.On("Tags", mock.Anything).Return([]string{"1.0.1"}, nil)
 			return &regMock, nil
 		}
 
@@ -128,7 +128,7 @@ func Test_UpdateApplication(t *testing.T) {
 	t.Run("Test skip because of image not in list", func(t *testing.T) {
 		mockClientFn := func(endpoint *registry.RegistryEndpoint, username, password string) (registry.RegistryClient, error) {
 			regMock := regmock.RegistryClient{}
-			regMock.On("Tags", mock.Anything, mock.Anything).Return([]string{"1.0.1"}, nil)
+			regMock.On("Tags", mock.Anything).Return([]string{"1.0.1"}, nil)
 			return &regMock, nil
 		}
 
@@ -177,7 +177,7 @@ func Test_UpdateApplication(t *testing.T) {
 	t.Run("Test skip because of image up-to-date", func(t *testing.T) {
 		mockClientFn := func(endpoint *registry.RegistryEndpoint, username, password string) (registry.RegistryClient, error) {
 			regMock := regmock.RegistryClient{}
-			regMock.On("Tags", mock.Anything, mock.Anything).Return([]string{"1.0.1"}, nil)
+			regMock.On("Tags", mock.Anything).Return([]string{"1.0.1"}, nil)
 			return &regMock, nil
 		}
 
@@ -240,8 +240,8 @@ func Test_UpdateApplication(t *testing.T) {
 		called := 0
 		mockClientFn := func(endpoint *registry.RegistryEndpoint, username, password string) (registry.RegistryClient, error) {
 			regMock := regmock.RegistryClient{}
-			regMock.On("Tags", mock.Anything, mock.Anything).Return([]string{"one", "two", "three", "four"}, nil)
-			regMock.On("ManifestV1", mock.Anything, mock.Anything).Return(meta[called], nil)
+			regMock.On("Tags", mock.Anything).Return([]string{"one", "two", "three", "four"}, nil)
+			regMock.On("ManifestV1", mock.Anything).Return(meta[called], nil)
 			called += 1
 			return &regMock, nil
 		}
@@ -309,8 +309,8 @@ func Test_UpdateApplication(t *testing.T) {
 		called := 0
 		mockClientFn := func(endpoint *registry.RegistryEndpoint, username, password string) (registry.RegistryClient, error) {
 			regMock := regmock.RegistryClient{}
-			regMock.On("Tags", mock.Anything, mock.Anything).Return([]string{"one", "two", "three", "four"}, nil)
-			regMock.On("ManifestV1", mock.Anything, mock.Anything).Return(meta[called], nil)
+			regMock.On("Tags", mock.Anything).Return([]string{"one", "two", "three", "four"}, nil)
+			regMock.On("ManifestV1", mock.Anything).Return(meta[called], nil)
 			called += 1
 			return &regMock, nil
 		}
@@ -364,7 +364,7 @@ func Test_UpdateApplication(t *testing.T) {
 	t.Run("Error - unknown registry", func(t *testing.T) {
 		mockClientFn := func(endpoint *registry.RegistryEndpoint, username, password string) (registry.RegistryClient, error) {
 			regMock := regmock.RegistryClient{}
-			regMock.On("Tags", mock.Anything, mock.Anything).Return([]string{"1.0.1"}, nil)
+			regMock.On("Tags", mock.Anything).Return([]string{"1.0.1"}, nil)
 			return &regMock, nil
 		}
 
@@ -460,7 +460,7 @@ func Test_UpdateApplication(t *testing.T) {
 	t.Run("Test error on failure to list tags", func(t *testing.T) {
 		mockClientFn := func(endpoint *registry.RegistryEndpoint, username, password string) (registry.RegistryClient, error) {
 			regMock := regmock.RegistryClient{}
-			regMock.On("Tags", mock.Anything, mock.Anything).Return(nil, errors.New("some error"))
+			regMock.On("Tags", mock.Anything).Return(nil, errors.New("some error"))
 			return &regMock, nil
 		}
 
@@ -509,7 +509,7 @@ func Test_UpdateApplication(t *testing.T) {
 	t.Run("Test error on improper semver in tag", func(t *testing.T) {
 		mockClientFn := func(endpoint *registry.RegistryEndpoint, username, password string) (registry.RegistryClient, error) {
 			regMock := regmock.RegistryClient{}
-			regMock.On("Tags", mock.Anything, mock.Anything).Return([]string{"1.0.0", "1.0.1"}, nil)
+			regMock.On("Tags", mock.Anything).Return([]string{"1.0.0", "1.0.1"}, nil)
 			return &regMock, nil
 		}
 

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -46,6 +46,7 @@ type rateLimitTransport struct {
 // RoundTrip is a custom RoundTrip method with rate-limiter
 func (rlt *rateLimitTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	rlt.limiter.Take()
+	log.Tracef("%s", r.URL)
 	return rlt.transport.RoundTrip(r)
 }
 

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -2,8 +2,11 @@ package registry
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"strings"
 	"time"
 
 	"github.com/argoproj-labs/argocd-image-updater/pkg/log"
@@ -20,10 +23,10 @@ import (
 
 // RegistryClient defines the methods we need for querying container registries
 type RegistryClient interface {
-	Tags(nameInRepository string, limiter ratelimit.Limiter) ([]string, error)
-	ManifestV1(repository string, reference string, limiter ratelimit.Limiter) (*schema1.SignedManifest, error)
-	ManifestV2(repository string, reference string, limiter ratelimit.Limiter) (*schema2.DeserializedManifest, error)
-	TagMetadata(repository string, manifest distribution.Manifest, limiter ratelimit.Limiter) (*tag.TagInfo, error)
+	Tags(nameInRepository string) ([]string, error)
+	ManifestV1(repository string, reference string) (*schema1.SignedManifest, error)
+	ManifestV2(repository string, reference string) (*schema2.DeserializedManifest, error)
+	TagMetadata(repository string, manifest distribution.Manifest) (*tag.TagInfo, error)
 }
 
 type NewRegistryClient func(*RegistryEndpoint, string, string) (RegistryClient, error)
@@ -31,6 +34,60 @@ type NewRegistryClient func(*RegistryEndpoint, string, string) (RegistryClient, 
 // Helper type for registry clients
 type registryClient struct {
 	regClient *registry.Registry
+}
+
+// rateLimitTransport encapsulates our custom HTTP round tripper with rate
+// limiter from the endpoint.
+type rateLimitTransport struct {
+	limiter   ratelimit.Limiter
+	transport http.RoundTripper
+}
+
+// RoundTrip is a custom RoundTrip method with rate-limiter
+func (rlt *rateLimitTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	rlt.limiter.Take()
+	return rlt.transport.RoundTrip(r)
+}
+
+// newRegistry is a wrapper for creating a registry client that is possibly
+// rate-limited by using a custom HTTP round tripper method.
+func newRegistry(ep *RegistryEndpoint, opts registry.Options) (*registry.Registry, error) {
+	url := strings.TrimSuffix(ep.RegistryAPI, "/")
+	var transport http.RoundTripper
+	if opts.Insecure {
+		transport = &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		}
+	} else {
+		transport = http.DefaultTransport
+	}
+	transport = registry.WrapTransport(transport, url, opts)
+
+	rlt := &rateLimitTransport{
+		limiter:   ep.Limiter,
+		transport: transport,
+	}
+
+	logf := opts.Logf
+	if logf == nil {
+		logf = registry.Log
+	}
+	registry := &registry.Registry{
+		URL: url,
+		Client: &http.Client{
+			Transport: rlt,
+		},
+		Logf: logf,
+	}
+	if opts.DoInitialPing {
+		if err := registry.Ping(); err != nil {
+			return nil, err
+		}
+	}
+	return registry, nil
+
 }
 
 // NewClient returns a new RegistryClient for the given endpoint information
@@ -43,7 +100,7 @@ func NewClient(endpoint *RegistryEndpoint, username, password string) (RegistryC
 		password = endpoint.Password
 	}
 
-	client, err := registry.NewCustom(endpoint.RegistryAPI, registry.Options{
+	client, err := newRegistry(endpoint, registry.Options{
 		DoInitialPing: endpoint.Ping,
 		Logf:          registry.Quiet,
 		Username:      username,
@@ -59,25 +116,22 @@ func NewClient(endpoint *RegistryEndpoint, username, password string) (RegistryC
 }
 
 // Tags returns a list of tags for given name in repository
-func (client *registryClient) Tags(nameInRepository string, limiter ratelimit.Limiter) ([]string, error) {
-	limiter.Take()
+func (client *registryClient) Tags(nameInRepository string) ([]string, error) {
 	return client.regClient.Tags(nameInRepository)
 }
 
 // ManifestV1 returns a signed V1 manifest for a given tag in given repository
-func (client *registryClient) ManifestV1(repository string, reference string, limiter ratelimit.Limiter) (*schema1.SignedManifest, error) {
-	limiter.Take()
+func (client *registryClient) ManifestV1(repository string, reference string) (*schema1.SignedManifest, error) {
 	return client.regClient.ManifestV1(repository, reference)
 }
 
 // ManifestV2 returns a deserialized V2 manifest for a given tag in given repository
-func (client *registryClient) ManifestV2(repository string, reference string, limiter ratelimit.Limiter) (*schema2.DeserializedManifest, error) {
-	limiter.Take()
+func (client *registryClient) ManifestV2(repository string, reference string) (*schema2.DeserializedManifest, error) {
 	return client.regClient.ManifestV2(repository, reference)
 }
 
 // GetTagInfo retrieves metadata for a given manifest of given repository
-func (client *registryClient) TagMetadata(repository string, manifest distribution.Manifest, limiter ratelimit.Limiter) (*tag.TagInfo, error) {
+func (client *registryClient) TagMetadata(repository string, manifest distribution.Manifest) (*tag.TagInfo, error) {
 	ti := &tag.TagInfo{}
 
 	var info struct {
@@ -110,13 +164,11 @@ func (client *registryClient) TagMetadata(repository string, manifest distributi
 
 		// The data we require from a V2 manifest is in a blob that we need to
 		// fetch from the registry.
-		limiter.Take()
 		_, err := client.regClient.BlobMetadata(repository, man.Config.Digest)
 		if err != nil {
 			return nil, fmt.Errorf("could not get metadata: %v", err)
 		}
 
-		limiter.Take()
 		blobReader, err := client.regClient.DownloadBlob(repository, man.Config.Digest)
 		if err != nil {
 			return nil, err

--- a/pkg/registry/mocks/RegistryClient.go
+++ b/pkg/registry/mocks/RegistryClient.go
@@ -6,8 +6,6 @@ import (
 	distribution "github.com/docker/distribution"
 	mock "github.com/stretchr/testify/mock"
 
-	ratelimit "go.uber.org/ratelimit"
-
 	schema1 "github.com/docker/distribution/manifest/schema1"
 
 	schema2 "github.com/docker/distribution/manifest/schema2"
@@ -20,13 +18,13 @@ type RegistryClient struct {
 	mock.Mock
 }
 
-// ManifestV1 provides a mock function with given fields: repository, reference, limiter
-func (_m *RegistryClient) ManifestV1(repository string, reference string, limiter ratelimit.Limiter) (*schema1.SignedManifest, error) {
-	ret := _m.Called(repository, reference, limiter)
+// ManifestV1 provides a mock function with given fields: repository, reference
+func (_m *RegistryClient) ManifestV1(repository string, reference string) (*schema1.SignedManifest, error) {
+	ret := _m.Called(repository, reference)
 
 	var r0 *schema1.SignedManifest
-	if rf, ok := ret.Get(0).(func(string, string, ratelimit.Limiter) *schema1.SignedManifest); ok {
-		r0 = rf(repository, reference, limiter)
+	if rf, ok := ret.Get(0).(func(string, string) *schema1.SignedManifest); ok {
+		r0 = rf(repository, reference)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*schema1.SignedManifest)
@@ -34,8 +32,8 @@ func (_m *RegistryClient) ManifestV1(repository string, reference string, limite
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, string, ratelimit.Limiter) error); ok {
-		r1 = rf(repository, reference, limiter)
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(repository, reference)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -43,13 +41,13 @@ func (_m *RegistryClient) ManifestV1(repository string, reference string, limite
 	return r0, r1
 }
 
-// ManifestV2 provides a mock function with given fields: repository, reference, limiter
-func (_m *RegistryClient) ManifestV2(repository string, reference string, limiter ratelimit.Limiter) (*schema2.DeserializedManifest, error) {
-	ret := _m.Called(repository, reference, limiter)
+// ManifestV2 provides a mock function with given fields: repository, reference
+func (_m *RegistryClient) ManifestV2(repository string, reference string) (*schema2.DeserializedManifest, error) {
+	ret := _m.Called(repository, reference)
 
 	var r0 *schema2.DeserializedManifest
-	if rf, ok := ret.Get(0).(func(string, string, ratelimit.Limiter) *schema2.DeserializedManifest); ok {
-		r0 = rf(repository, reference, limiter)
+	if rf, ok := ret.Get(0).(func(string, string) *schema2.DeserializedManifest); ok {
+		r0 = rf(repository, reference)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*schema2.DeserializedManifest)
@@ -57,8 +55,8 @@ func (_m *RegistryClient) ManifestV2(repository string, reference string, limite
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, string, ratelimit.Limiter) error); ok {
-		r1 = rf(repository, reference, limiter)
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(repository, reference)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -66,13 +64,13 @@ func (_m *RegistryClient) ManifestV2(repository string, reference string, limite
 	return r0, r1
 }
 
-// TagMetadata provides a mock function with given fields: repository, manifest, limiter
-func (_m *RegistryClient) TagMetadata(repository string, manifest distribution.Manifest, limiter ratelimit.Limiter) (*tag.TagInfo, error) {
-	ret := _m.Called(repository, manifest, limiter)
+// TagMetadata provides a mock function with given fields: repository, manifest
+func (_m *RegistryClient) TagMetadata(repository string, manifest distribution.Manifest) (*tag.TagInfo, error) {
+	ret := _m.Called(repository, manifest)
 
 	var r0 *tag.TagInfo
-	if rf, ok := ret.Get(0).(func(string, distribution.Manifest, ratelimit.Limiter) *tag.TagInfo); ok {
-		r0 = rf(repository, manifest, limiter)
+	if rf, ok := ret.Get(0).(func(string, distribution.Manifest) *tag.TagInfo); ok {
+		r0 = rf(repository, manifest)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*tag.TagInfo)
@@ -80,8 +78,8 @@ func (_m *RegistryClient) TagMetadata(repository string, manifest distribution.M
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, distribution.Manifest, ratelimit.Limiter) error); ok {
-		r1 = rf(repository, manifest, limiter)
+	if rf, ok := ret.Get(1).(func(string, distribution.Manifest) error); ok {
+		r1 = rf(repository, manifest)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -89,13 +87,13 @@ func (_m *RegistryClient) TagMetadata(repository string, manifest distribution.M
 	return r0, r1
 }
 
-// Tags provides a mock function with given fields: nameInRepository, limiter
-func (_m *RegistryClient) Tags(nameInRepository string, limiter ratelimit.Limiter) ([]string, error) {
-	ret := _m.Called(nameInRepository, limiter)
+// Tags provides a mock function with given fields: nameInRepository
+func (_m *RegistryClient) Tags(nameInRepository string) ([]string, error) {
+	ret := _m.Called(nameInRepository)
 
 	var r0 []string
-	if rf, ok := ret.Get(0).(func(string, ratelimit.Limiter) []string); ok {
-		r0 = rf(nameInRepository, limiter)
+	if rf, ok := ret.Get(0).(func(string) []string); ok {
+		r0 = rf(nameInRepository)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
@@ -103,8 +101,8 @@ func (_m *RegistryClient) Tags(nameInRepository string, limiter ratelimit.Limite
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, ratelimit.Limiter) error); ok {
-		r1 = rf(nameInRepository, limiter)
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(nameInRepository)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -40,7 +40,7 @@ func (endpoint *RegistryEndpoint) GetTags(img *image.ContainerImage, regClient R
 	} else {
 		nameInRegistry = img.ImageName
 	}
-	tTags, err := regClient.Tags(nameInRegistry, endpoint.Limiter)
+	tTags, err := regClient.Tags(nameInRegistry)
 	if err != nil {
 		return nil, err
 	}
@@ -130,9 +130,9 @@ func (endpoint *RegistryEndpoint) GetTags(img *image.ContainerImage, regClient R
 
 			// We first try to fetch a V2 manifest, and if that's not available we fall
 			// back to fetching V1 manifest. If that fails also, we just skip this tag.
-			if ml, err = regClient.ManifestV2(nameInRegistry, tagStr, endpoint.Limiter); err != nil {
+			if ml, err = regClient.ManifestV2(nameInRegistry, tagStr); err != nil {
 				log.Debugf("No V2 manifest for %s:%s, fetching V1 (%v)", nameInRegistry, tagStr, err)
-				if ml, err = regClient.ManifestV1(nameInRegistry, tagStr, endpoint.Limiter); err != nil {
+				if ml, err = regClient.ManifestV1(nameInRegistry, tagStr); err != nil {
 					log.Errorf("Error fetching metadata for %s:%s - neither V1 or V2 manifest returned by registry: %v", nameInRegistry, tagStr, err)
 					return
 				}
@@ -140,7 +140,7 @@ func (endpoint *RegistryEndpoint) GetTags(img *image.ContainerImage, regClient R
 
 			// Parse required meta data from the manifest. The metadata contains all
 			// information needed to decide whether to consider this tag or not.
-			ti, err := regClient.TagMetadata(nameInRegistry, ml, endpoint.Limiter)
+			ti, err := regClient.TagMetadata(nameInRegistry, ml)
 			if err != nil {
 				log.Errorf("error fetching metadata for %s:%s: %v", nameInRegistry, tagStr, err)
 				return

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -19,7 +19,7 @@ func Test_GetTags(t *testing.T) {
 
 	t.Run("Check for correctly returned tags with semver sort", func(t *testing.T) {
 		regClient := mocks.RegistryClient{}
-		regClient.On("Tags", mock.Anything, mock.Anything).Return([]string{"1.2.0", "1.2.1", "1.2.2"}, nil)
+		regClient.On("Tags", mock.Anything).Return([]string{"1.2.0", "1.2.1", "1.2.2"}, nil)
 
 		ep, err := GetRegistryEndpoint("")
 		require.NoError(t, err)
@@ -37,7 +37,7 @@ func Test_GetTags(t *testing.T) {
 
 	t.Run("Check for correctly returned tags with filter function applied", func(t *testing.T) {
 		regClient := mocks.RegistryClient{}
-		regClient.On("Tags", mock.Anything, mock.Anything).Return([]string{"1.2.0", "1.2.1", "1.2.2"}, nil)
+		regClient.On("Tags", mock.Anything).Return([]string{"1.2.0", "1.2.1", "1.2.2"}, nil)
 
 		ep, err := GetRegistryEndpoint("")
 		require.NoError(t, err)
@@ -56,7 +56,7 @@ func Test_GetTags(t *testing.T) {
 	t.Run("Check for correctly returned tags with name sort", func(t *testing.T) {
 
 		regClient := mocks.RegistryClient{}
-		regClient.On("Tags", mock.Anything, mock.Anything).Return([]string{"1.2.0", "1.2.1", "1.2.2"}, nil)
+		regClient.On("Tags", mock.Anything).Return([]string{"1.2.0", "1.2.1", "1.2.2"}, nil)
 
 		ep, err := GetRegistryEndpoint("")
 		require.NoError(t, err)
@@ -88,10 +88,10 @@ func Test_GetTags(t *testing.T) {
 		}
 
 		regClient := mocks.RegistryClient{}
-		regClient.On("Tags", mock.Anything, mock.Anything).Return([]string{"1.2.0", "1.2.1", "1.2.2"}, nil)
-		regClient.On("ManifestV1", mock.Anything, mock.Anything, mock.Anything).Return(meta1, nil)
-		regClient.On("ManifestV2", mock.Anything, mock.Anything, mock.Anything).Return(meta2, nil)
-		regClient.On("TagMetadata", mock.Anything, mock.Anything, mock.Anything).Return(&tag.TagInfo{}, nil)
+		regClient.On("Tags", mock.Anything).Return([]string{"1.2.0", "1.2.1", "1.2.2"}, nil)
+		regClient.On("ManifestV1", mock.Anything, mock.Anything).Return(meta1, nil)
+		regClient.On("ManifestV2", mock.Anything, mock.Anything).Return(meta2, nil)
+		regClient.On("TagMetadata", mock.Anything, mock.Anything).Return(&tag.TagInfo{}, nil)
 
 		ep, err := GetRegistryEndpoint("")
 		require.NoError(t, err)
@@ -119,10 +119,10 @@ func Test_GetTags(t *testing.T) {
 		}
 
 		regClient := mocks.RegistryClient{}
-		regClient.On("Tags", mock.Anything, mock.Anything).Return([]string{"1.2.0", "1.2.1", "1.2.2"}, nil)
-		regClient.On("ManifestV1", mock.Anything, mock.Anything, mock.Anything).Return(meta1, nil)
-		regClient.On("ManifestV2", mock.Anything, mock.Anything, mock.Anything).Return(meta2, fmt.Errorf("not implemented"))
-		regClient.On("TagMetadata", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+		regClient.On("Tags", mock.Anything).Return([]string{"1.2.0", "1.2.1", "1.2.2"}, nil)
+		regClient.On("ManifestV1", mock.Anything, mock.Anything).Return(meta1, nil)
+		regClient.On("ManifestV2", mock.Anything, mock.Anything).Return(meta2, fmt.Errorf("not implemented"))
+		regClient.On("TagMetadata", mock.Anything, mock.Anything).Return(nil, nil)
 
 		ep, err := GetRegistryEndpoint("")
 		require.NoError(t, err)
@@ -153,10 +153,10 @@ func Test_GetTags(t *testing.T) {
 		}
 
 		regClient := mocks.RegistryClient{}
-		regClient.On("Tags", mock.Anything, mock.Anything).Return([]string{"1.2.0", "1.2.1", "1.2.2"}, nil)
-		regClient.On("ManifestV1", mock.Anything, mock.Anything, mock.Anything).Return(meta1, nil)
-		regClient.On("ManifestV2", mock.Anything, mock.Anything, mock.Anything).Return(meta2, fmt.Errorf("not implemented"))
-		regClient.On("TagMetadata", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+		regClient.On("Tags", mock.Anything).Return([]string{"1.2.0", "1.2.1", "1.2.2"}, nil)
+		regClient.On("ManifestV1", mock.Anything, mock.Anything).Return(meta1, nil)
+		regClient.On("ManifestV2", mock.Anything, mock.Anything).Return(meta2, fmt.Errorf("not implemented"))
+		regClient.On("TagMetadata", mock.Anything, mock.Anything).Return(nil, nil)
 
 		ep, err := GetRegistryEndpoint("")
 		require.NoError(t, err)
@@ -187,10 +187,10 @@ func Test_GetTags(t *testing.T) {
 		}
 
 		regClient := mocks.RegistryClient{}
-		regClient.On("Tags", mock.Anything, mock.Anything).Return([]string{"1.2.0", "1.2.1", "1.2.2"}, nil)
-		regClient.On("ManifestV1", mock.Anything, mock.Anything, mock.Anything).Return(meta1, nil)
-		regClient.On("ManifestV2", mock.Anything, mock.Anything, mock.Anything).Return(meta2, fmt.Errorf("not implemented"))
-		regClient.On("TagMetadata", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+		regClient.On("Tags", mock.Anything).Return([]string{"1.2.0", "1.2.1", "1.2.2"}, nil)
+		regClient.On("ManifestV1", mock.Anything, mock.Anything).Return(meta1, nil)
+		regClient.On("ManifestV2", mock.Anything, mock.Anything).Return(meta2, fmt.Errorf("not implemented"))
+		regClient.On("TagMetadata", mock.Anything, mock.Anything).Return(nil, nil)
 
 		ep, err := GetRegistryEndpoint("")
 		require.NoError(t, err)
@@ -222,10 +222,10 @@ func Test_GetTags(t *testing.T) {
 		}
 
 		regClient := mocks.RegistryClient{}
-		regClient.On("Tags", mock.Anything, mock.Anything).Return([]string{"1.2.0", "1.2.1", "1.2.2"}, nil)
-		regClient.On("ManifestV1", mock.Anything, mock.Anything, mock.Anything).Return(meta1, nil)
-		regClient.On("ManifestV2", mock.Anything, mock.Anything, mock.Anything).Return(meta2, fmt.Errorf("not implemented"))
-		regClient.On("TagMetadata", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+		regClient.On("Tags", mock.Anything).Return([]string{"1.2.0", "1.2.1", "1.2.2"}, nil)
+		regClient.On("ManifestV1", mock.Anything, mock.Anything).Return(meta1, nil)
+		regClient.On("ManifestV2", mock.Anything, mock.Anything).Return(meta2, fmt.Errorf("not implemented"))
+		regClient.On("TagMetadata", mock.Anything, mock.Anything).Return(nil, nil)
 
 		ep, err := GetRegistryEndpoint("")
 		require.NoError(t, err)


### PR DESCRIPTION
This change moves the rate limiter downstream into a custom `http.RoundTrip` object, so it will handle all outgoing HTTP requests.