### PR TITLE
feat: Support for getting pull creds from external scripts

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -6,6 +6,7 @@ apimachinery
 apps
 argocd
 argocdclient
+argoexec
 argomock
 argoproj
 argoprojlabs
@@ -62,6 +63,7 @@ Fprintf
 func
 gcr
 Getenv
+Getwd
 gh
 ghcr
 githash
@@ -132,6 +134,7 @@ nokia
 nolint
 noproto
 notastring
+notexist
 omitempty
 otherimg
 otherparam

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -267,7 +267,7 @@ argocd-image-updater test nginx --allow-tags '^1.19.\d+(\-.*)*$' --update-strate
 			}
 
 			if err := ep.SetEndpointCredentials(nil); err != nil {
-				log.Fatalf("could not set registry credentials")
+				log.Fatalf("could not set registry credentials: %v", err)
 			}
 
 			regClient, err := registry.NewClient(ep, "", "")

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/argoproj/argo-cd v1.7.4
+	github.com/argoproj/pkg v0.0.0-20200624215116-23e74cb168fe
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
 	github.com/gorilla/mux v1.7.4 // indirect

--- a/test/testdata/scripts/get-credentials-invalid.sh
+++ b/test/testdata/scripts/get-credentials-invalid.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "some gibberish foo"

--- a/test/testdata/scripts/get-credentials-valid.sh
+++ b/test/testdata/scripts/get-credentials-valid.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "username:password"


### PR DESCRIPTION
This PR adds support for a new type of credential source for image pull secrets: `ext`

This credential source can specify a script to execute, and will use the output of the script to define the credentials. Output of the script must be a single line in the format `username:password`.

This will allow users to authenticate with third parties that require volatile tokens for authentication.