### PR TITLE
feat: Allow reuse of Argo CD repo credentials

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -4,3 +4,5 @@ mypass
 otherapp
 wildcard
 wildcards
+credref
+repocreds

--- a/docs/configuration/applications.md
+++ b/docs/configuration/applications.md
@@ -160,21 +160,21 @@ Configuration for the Git write-back method comes from two sources:
 
 #### Specifying Git credentials
 
-In order for Argo CD Image Updater to be able to push any changes back to your
-Git repository (e.g. hosted on GitHub, GitLab or elsewhere), you will need to
-configure credentials that have write access to your remote upstream repository.
-Argo CD Image Updater will **not** re-use the credentials you have configured
+By default Argo CD Image Updater re-uses the credentials you have configured
 in Argo CD for accessing the repository.
 
-Credentials must be stored in a Kubernetes secret, which needs to be accessible
-by the Argo CD Image Updater's Service Account. The secret can be configured
-using the `argocd-image-updater.argoproj.io/git-credentials` annotation, whose
-value must be in format `namespace/secret-name`, for example to use a secret
-named `git-creds` in the namespace `argocd-image-updater`, use following
-annotation:
+If you don't want to use credentials configured for Argo CD you can use other credentials stored in a Kubernetes secret,
+which needs to be accessible by the Argo CD Image Updater's Service Account. The secret should be specified in 
+`argocd-image-updater.argoproj.io/write-back-method` annotation using `git:<credref>` format. Where `<credref>` might
+take one of following values:
+
+* `repocreds` (default) - Git repository credentials configured in Argo CD settings
+* `secret:<namespace>/<secret>` - namespace and secret name.
+
+Example:
 
 ```yaml
-argocd-image-updater.argoproj.io/git-credentials: argocd-image-updater/git-creds
+argocd-image-updater.argoproj.io/write-back-method: git:secret:argocd-image-updater/git-creds
 ```
 
 If the repository is accessed using HTTPS, the secret must contain two fields:

--- a/manifests/base/rbac/argocd-image-updater-role.yaml
+++ b/manifests/base/rbac/argocd-image-updater-role.yaml
@@ -11,6 +11,7 @@ rules:
       - ''
     resources:
       - secrets
+      - configmaps
     verbs:
       - get
       - list

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -20,6 +20,7 @@ rules:
   - ""
   resources:
   - secrets
+  - configmaps
   verbs:
   - get
   - list

--- a/pkg/argocd/gitcreds.go
+++ b/pkg/argocd/gitcreds.go
@@ -1,0 +1,79 @@
+package argocd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/util/db"
+	"github.com/argoproj/argo-cd/util/settings"
+
+	"github.com/argoproj-labs/argocd-image-updater/ext/git"
+	"github.com/argoproj-labs/argocd-image-updater/pkg/kube"
+)
+
+// getGitCredsSource returns git credentials source that loads credentials from the secret or from Argo CD settings
+func getGitCredsSource(creds string, kubeClient *kube.KubernetesClient) (GitCredsSource, error) {
+	switch {
+	case creds == "repocreds":
+		return func(app *v1alpha1.Application) (git.Creds, error) {
+			return getCredsFromArgoCD(app, kubeClient)
+		}, nil
+	case strings.HasPrefix(creds, "secret:"):
+		return func(app *v1alpha1.Application) (git.Creds, error) {
+			return getCredsFromSecret(app, creds[len("secret:"):], kubeClient)
+		}, nil
+	}
+	return nil, fmt.Errorf("unexpected credentials format. Expected 'repocreds' or 'secret:<namespace>/<secret>' but got '%s'", creds)
+}
+
+// getCredsFromArgoCD loads repository credentials from Argo CD settings
+func getCredsFromArgoCD(app *v1alpha1.Application, kubeClient *kube.KubernetesClient) (git.Creds, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	settingsMgr := settings.NewSettingsManager(ctx, kubeClient.Clientset, kubeClient.Namespace)
+	argocdDB := db.NewDB(kubeClient.Namespace, settingsMgr, kubeClient.Clientset)
+	repo, err := argocdDB.GetRepository(ctx, app.Spec.Source.RepoURL)
+	if err != nil {
+		return nil, err
+	}
+	if !repo.HasCredentials() {
+		return nil, fmt.Errorf("credentials for '%s' are not configured in Argo CD settings", app.Spec.Source.RepoURL)
+	}
+	return repo.GetGitCreds(), nil
+}
+
+// getCredsFromSecret loads repository credentials from secret
+func getCredsFromSecret(app *v1alpha1.Application, credentialsSecret string, kubeClient *kube.KubernetesClient) (git.Creds, error) {
+	var credentials map[string][]byte
+	var err error
+	s := strings.SplitN(credentialsSecret, "/", 2)
+	if len(s) == 2 {
+		credentials, err = kubeClient.GetSecretData(s[0], s[1])
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		return nil, fmt.Errorf("secret ref must be in format 'namespace/name', but is '%s'", credentialsSecret)
+	}
+
+	if ok, _ := git.IsSSHURL(app.Spec.Source.RepoURL); ok {
+		var sshPrivateKey []byte
+		if sshPrivateKey, ok = credentials["sshPrivateKey"]; !ok {
+			return nil, fmt.Errorf("invalid secret %s: does not contain field sshPrivateKey", credentialsSecret)
+		}
+		return git.NewSSHCreds(string(sshPrivateKey), "", true), nil
+	} else if git.IsHTTPSURL(app.Spec.Source.RepoURL) {
+		var username, password []byte
+		if username, ok = credentials["username"]; !ok {
+			return nil, fmt.Errorf("invalid secret %s: does not contain field username", credentialsSecret)
+		}
+		if password, ok = credentials["password"]; !ok {
+			return nil, fmt.Errorf("invalid secret %s: does not contain field password", credentialsSecret)
+		}
+		return git.NewHTTPSCreds(string(username), string(password), "", "", true), nil
+	}
+	return nil, fmt.Errorf("unknown repository type")
+}

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -42,6 +42,5 @@ const (
 // Application update configuration related annotations
 const (
 	WriteBackMethodAnnotation = ImageUpdaterAnnotationPrefix + "/write-back-method"
-	GitCredentialsAnnotation  = ImageUpdaterAnnotationPrefix + "/git-credentials"
 	GitBranchAnnotation       = ImageUpdaterAnnotationPrefix + "/git-branch"
 )

--- a/pkg/kube/kubernetes_test.go
+++ b/pkg/kube/kubernetes_test.go
@@ -2,7 +2,6 @@ package kube
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/argoproj-labs/argocd-image-updater/test/fake"
@@ -14,21 +13,17 @@ import (
 
 func Test_NewKubernetesClient(t *testing.T) {
 	t.Run("Get new K8s client for remote cluster instance", func(t *testing.T) {
-		client, err := NewKubernetesClientFromConfig(context.TODO(), "../../test/testdata/kubernetes/config")
+		client, err := NewKubernetesClientFromConfig(context.TODO(), "", "../../test/testdata/kubernetes/config")
 		require.NoError(t, err)
 		assert.NotNil(t, client)
+		assert.Equal(t, "default", client.Namespace)
 	})
 
-	t.Run("Get new K8s client for in-cluster instance", func(t *testing.T) {
-		os.Setenv("KUBERNETES_SERVICE_HOST", "127.0.0.1")
-		os.Setenv("KUBERNETES_SERVICE_PORT", "6443")
-		defer os.Setenv("KUBERNETES_SERVICE_HOST", "")
-		defer os.Setenv("KUBERNETES_SERVICE_PORT", "")
-		client, err := NewKubernetesClientFromConfig(context.TODO(), "")
-		// We cannot create /var/run/secrets/kubernetes.io/serviceaccount/token so
-		// we just assume error and look for that path in error message.
-		assert.Errorf(t, err, "open /var/run/secrets/kubernetes.io/serviceaccount/token: no such file or directory")
-		assert.Nil(t, client)
+	t.Run("Get new K8s client for remote cluster instance specified namespace", func(t *testing.T) {
+		client, err := NewKubernetesClientFromConfig(context.TODO(), "argocd", "../../test/testdata/kubernetes/config")
+		require.NoError(t, err)
+		assert.NotNil(t, client)
+		assert.Equal(t, "argocd", client.Namespace)
 	})
 }
 

--- a/test/fixture/kubernetes.go
+++ b/test/fixture/kubernetes.go
@@ -7,6 +7,17 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func AddPartOfArgoCDLabel(objs ...metav1.Object) {
+	for _, obj := range objs {
+		labels := obj.GetLabels()
+		if labels == nil {
+			labels = map[string]string{}
+		}
+		labels["app.kubernetes.io/part-of"] = "argocd"
+		obj.SetLabels(labels)
+	}
+}
+
 // NewSecret creates a new Kubernetes secret object in given namespace, with
 // given name and with given data.
 func NewSecret(namespace, name string, entries map[string][]byte) *v1.Secret {
@@ -18,6 +29,19 @@ func NewSecret(namespace, name string, entries map[string][]byte) *v1.Secret {
 		Data: entries,
 	}
 	return &secret
+}
+
+// NewSecret creates a new Kubernetes secret object in given namespace, with
+// given name and with given data.
+func NewConfigMap(namespace, name string, entries map[string]string) *v1.ConfigMap {
+	configMap := v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Data: entries,
+	}
+	return &configMap
 }
 
 // MustCreateSecretFromFile reads a Kubernetes secret definition from filepath


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Closes https://github.com/argoproj-labs/argocd-image-updater/issues/138

PR implements proposal described in https://github.com/argoproj-labs/argocd-image-updater/issues/138 . The default credentials source is "repocreds" since it requires no configuration.