### PR TITLE
feat: support managing Application CRD using K8S client (#140)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -79,7 +79,7 @@ func runImageUpdater(cfg *ImageUpdaterConfig, warmUp bool) (argocd.ImageUpdaterR
 	var argoClient argocd.ArgoCD
 	switch cfg.ApplicationsAPIKind {
 	case applicationsAPIKindK8S:
-		argoClient = argocd.NewK8SClient(cfg.KubeClient)
+		argoClient, err = argocd.NewK8SClient(cfg.KubeClient)
 	case applicationsAPIKindArgoCD:
 		argoClient, err = argocd.NewAPIClient(&cfg.ClientOpts)
 	default:

--- a/manifests/base/deployment/argocd-image-updater-deployment.yaml
+++ b/manifests/base/deployment/argocd-image-updater-deployment.yaml
@@ -22,6 +22,12 @@ spec:
         image: argoprojlabs/argocd-image-updater:latest
         imagePullPolicy: Always
         env:
+        - name: APPLICATIONS_API
+          valueFrom:
+            configMapKeyRef:
+              name: argocd-image-updater-config
+              key: applications_api
+              optional: true
         - name: ARGOCD_GRPC_WEB
           valueFrom:
             configMapKeyRef:

--- a/manifests/base/rbac/argocd-image-updater-role.yaml
+++ b/manifests/base/rbac/argocd-image-updater-role.yaml
@@ -16,3 +16,12 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - applications
+    verbs:
+      - get
+      - list
+      - update
+      - patch

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -25,6 +25,15 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - applications
+  verbs:
+  - get
+  - list
+  - update
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -80,6 +89,12 @@ spec:
         - /usr/local/bin/argocd-image-updater
         - run
         env:
+        - name: APPLICATIONS_API
+          valueFrom:
+            configMapKeyRef:
+              key: applications_api
+              name: argocd-image-updater-config
+              optional: true
         - name: ARGOCD_GRPC_WEB
           valueFrom:
             configMapKeyRef:

--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -59,8 +59,8 @@ func (client *k8sClient) UpdateSpec(ctx context.Context, spec *application.Appli
 
 // NewAPIClient creates a new API client for ArgoCD and connects to the ArgoCD
 // API server.
-func NewK8SClient(kubeClient *kube.KubernetesClient) ArgoCD {
-	return &k8sClient{kubeClient: kubeClient}
+func NewK8SClient(kubeClient *kube.KubernetesClient) (ArgoCD, error) {
+	return &k8sClient{kubeClient: kubeClient}, nil
 }
 
 // Native

--- a/pkg/argocd/argocd_test.go
+++ b/pkg/argocd/argocd_test.go
@@ -638,10 +638,12 @@ func TestKubernetesClient(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{Name: "test-app2", Namespace: "testns2"},
 	}
 
-	client := NewK8SClient(&kube.KubernetesClient{
+	client, err := NewK8SClient(&kube.KubernetesClient{
 		Namespace:             "testns1",
 		ApplicationsClientset: fake.NewSimpleClientset(app1, app2),
 	})
+
+	require.NoError(t, err)
 
 	t.Run("List applications", func(t *testing.T) {
 		apps, err := client.ListApplications()
@@ -681,10 +683,11 @@ func TestKubernetesClient_UpdateSpec_Conflict(t *testing.T) {
 		}
 	})
 
-	client := NewK8SClient(&kube.KubernetesClient{
+	client, err := NewK8SClient(&kube.KubernetesClient{
 		Namespace:             "testns",
 		ApplicationsClientset: clientset,
 	})
+	require.NoError(t, err)
 
 	appName := "test-app"
 

--- a/pkg/kube/kubernetes.go
+++ b/pkg/kube/kubernetes.go
@@ -9,21 +9,24 @@ import (
 
 	"github.com/argoproj-labs/argocd-image-updater/pkg/metrics"
 
+	"github.com/argoproj/argo-cd/pkg/client/clientset/versioned"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
 type KubernetesClient struct {
-	Clientset kubernetes.Interface
-	Context   context.Context
-	Namespace string
+	Clientset             kubernetes.Interface
+	ApplicationsClientset versioned.Interface
+	Context               context.Context
+	Namespace             string
 }
 
-func NewKubernetesClient(ctx context.Context, client kubernetes.Interface, namespace string) *KubernetesClient {
+func NewKubernetesClient(ctx context.Context, client kubernetes.Interface, applicationsClientset versioned.Interface, namespace string) *KubernetesClient {
 	kc := &KubernetesClient{}
 	kc.Context = ctx
 	kc.Clientset = client
+	kc.ApplicationsClientset = applicationsClientset
 	kc.Namespace = namespace
 	return kc
 }
@@ -55,7 +58,12 @@ func NewKubernetesClientFromConfig(ctx context.Context, namespace string, kubeco
 		return nil, err
 	}
 
-	return NewKubernetesClient(ctx, clientset, namespace), nil
+	applicationsClientset, err := versioned.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewKubernetesClient(ctx, clientset, applicationsClientset, namespace), nil
 }
 
 // GetSecretData returns the raw data from named K8s secret in given namespace


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

Closes https://github.com/argoproj-labs/argocd-image-updater/issues/140 


PR implements proposal from  https://github.com/argoproj-labs/argocd-image-updater/issues/140:

* By default image updater tries to manage Argo CD applications in the same namespace where it is running using K8S API 
* Namespace can be changed using `--argocd-namespace` flag
* Updater can be switch back to Argo CD API using `--applications-api argocd` flag (or `APPLICATIONS_API` env variable). 

