### PR TITLE
refactor: make argocd-image-updater-config volume mapping optional

### DIFF
--- a/docs/install/start.md
+++ b/docs/install/start.md
@@ -93,25 +93,6 @@ kubectl apply -n argocd -f manifests/install.yaml
     instance. Just leave the number of replicas at 1, otherwise weird side
     effects could occur.
 
-### Minimum mandatory configuration
-
-Even if you don't plan to use private registries, you will need to configure at
-least an empty `registries.conf`, because the `argocd-image-updater` pod will
-volume mount this entry from the config map.
-
-Edit the `argocd-image-updater-config` ConfigMap and add the following entry:
-
-```yaml
-data:
-  registries.conf: ""
-```
-
-Without this entry, the `argocd-image-updater` pod will not be able to start.
-
-If you are going to use private container registries, this is also a good time
-to
-[configure them](../../configuration/registries/#configuring-a-custom-container-registry)
-
 ### Configure the desired log level
 
 While this step is optional, we recommend to set the log level explicitly.

--- a/manifests/base/deployment/argocd-image-updater-deployment.yaml
+++ b/manifests/base/deployment/argocd-image-updater-deployment.yaml
@@ -87,6 +87,7 @@ spec:
       - name: registries-conf
         configMap:
           name: argocd-image-updater-config
+          optional: true
           items:
           - key: registries.conf
             path: registries.conf

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -158,4 +158,5 @@ spec:
           - key: registries.conf
             path: registries.conf
           name: argocd-image-updater-config
+          optional: true
         name: registries-conf


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

https://github.com/argoproj-labs/argocd-image-updater/issues/109

PR make `argocd-image-updater-config` ConfigMap volume optional to simplify bootstapping process. The image updater fallback to "default" registries configuration and still support public image registries. 