### PR TITLE
fix: add missing git-ask-pass.sh to support password auth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN mkdir -p /usr/local/bin
 RUN mkdir -p /app/config
 
 COPY --from=builder /src/argocd-image-updater/dist/argocd-image-updater /usr/local/bin/
+COPY hack/git-ask-pass.sh /usr/local/bin/git-ask-pass.sh
 
 USER 1000
 

--- a/hack/git-ask-pass.sh
+++ b/hack/git-ask-pass.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# This script is used as the command supplied to GIT_ASKPASS as a way to supply username/password
+# credentials to git, without having to use git credentials helpers, or having on-disk config.
+case "$1" in
+Username*) echo "${GIT_USERNAME}" ;;
+Password*) echo "${GIT_PASSWORD}" ;;
+esac


### PR DESCRIPTION
Signed-off-by: Alexander Matyushentsev <AMatyushentsev@gmail.com>

PR adds missing `git-ask-pass.sh` that is required for password based authentication