### PR TITLE
fix: Use dedicated HTTP muxers for health and metrics endpoints

### DIFF
--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -12,8 +12,9 @@ import (
 func StartHealthServer(port int) chan error {
 	errCh := make(chan error)
 	go func() {
-		http.HandleFunc("/healthz", HealthProbe)
-		errCh <- http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
+		sm := http.NewServeMux()
+		sm.HandleFunc("/healthz", HealthProbe)
+		errCh <- http.ListenAndServe(fmt.Sprintf(":%d", port), sm)
 	}()
 	return errCh
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -40,8 +40,9 @@ type ClientMetrics struct {
 func StartMetricsServer(port int) chan error {
 	errCh := make(chan error)
 	go func() {
-		http.Handle("/metrics", promhttp.Handler())
-		errCh <- http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
+		sm := http.NewServeMux()
+		sm.Handle("/metrics", promhttp.Handler())
+		errCh <- http.ListenAndServe(fmt.Sprintf(":%d", port), sm)
 	}()
 	return errCh
 }


### PR DESCRIPTION
Fixes #160 

Signed-off-by: jannfis <jann@mistrust.net>