### PR TITLE
chore: Add openssh-client to container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,11 @@ RUN mkdir -p dist && \
 
 FROM alpine:latest
 
-RUN apk update && apk upgrade && apk add git
+RUN apk update && apk upgrade && apk add git openssh-client
 
 RUN mkdir -p /usr/local/bin
 RUN mkdir -p /app/config
+RUN adduser --home "/app" --disabled-password --uid 1000 argocd
 
 COPY --from=builder /src/argocd-image-updater/dist/argocd-image-updater /usr/local/bin/
 COPY hack/git-ask-pass.sh /usr/local/bin/git-ask-pass.sh


### PR DESCRIPTION
This adds the openssh-client to the container image, which will be used for connecting to Git repositories via SSH.

Closes #163 