### PR TITLE
#164 Send events on image change

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -51,7 +51,7 @@ type ImageUpdaterConfig struct {
 	AppNamePatterns     []string
 	GitCommitUser       string
 	GitCommitMail       string
-	disableKubeEvents   bool
+	DisableKubeEvents   bool
 }
 
 // warmupImageCache performs a cache warm-up, which is basically one cycle of
@@ -153,7 +153,7 @@ func runImageUpdater(cfg *ImageUpdaterConfig, warmUp bool) (argocd.ImageUpdaterR
 				DryRun:            dryRun,
 				GitCommitUser:     cfg.GitCommitUser,
 				GitCommitEmail:    cfg.GitCommitMail,
-				DisableKubeEvents: cfg.disableKubeEvents,
+				DisableKubeEvents: cfg.DisableKubeEvents,
 			}
 			res := argocd.UpdateApplication(upconf)
 			result.NumApplicationsProcessed += 1
@@ -546,7 +546,7 @@ func newRunCommand() *cobra.Command {
 	runCmd.Flags().BoolVar(&warmUpCache, "warmup-cache", true, "whether to perform a cache warm-up on startup")
 	runCmd.Flags().StringVar(&cfg.GitCommitUser, "git-commit-user", env.GetStringVal("GIT_COMMIT_USER", "argocd-image-updater"), "Username to use for Git commits")
 	runCmd.Flags().StringVar(&cfg.GitCommitMail, "git-commit-email", env.GetStringVal("GIT_COMMIT_EMAIL", "noreply@argoproj.io"), "E-Mail address to use for Git commits")
-	runCmd.Flags().BoolVar(&cfg.disableKubeEvents, "disable-kube-events", env.GetBoolVal("IMAGE_UPDATER_KUBE_EVENTS", false), "Disable kubernetes events")
+	runCmd.Flags().BoolVar(&cfg.DisableKubeEvents, "disable-kube-events", env.GetBoolVal("IMAGE_UPDATER_KUBE_EVENTS", false), "Disable kubernetes events")
 
 	return runCmd
 }

--- a/manifests/base/deployment/argocd-image-updater-deployment.yaml
+++ b/manifests/base/deployment/argocd-image-updater-deployment.yaml
@@ -76,6 +76,12 @@ spec:
               name: argocd-image-updater-config
               key: git.email
               optional: true
+        - name: IMAGE_UPDATER_KUBE_EVENTS
+          valueFrom:
+            configMapKeyRef:
+              name: argocd-image-updater-config
+              key: kube.events
+              optional: true
         livenessProbe:
           httpGet:
             path: /healthz

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -5,7 +5,7 @@ images:
 - name: argoprojlabs/argocd-image-updater
   newTag: latest
 
-bases:
+resources:
 - ./config
 - ./deployment
 - ./rbac

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -5,7 +5,7 @@ images:
 - name: argoprojlabs/argocd-image-updater
   newTag: latest
 
-resources:
+bases:
 - ./config
 - ./deployment
 - ./rbac

--- a/manifests/base/rbac/argocd-image-updater-role.yaml
+++ b/manifests/base/rbac/argocd-image-updater-role.yaml
@@ -25,3 +25,19 @@ rules:
       - list
       - update
       - patch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - applications
+    verbs:
+      - get
+      - list
+      - update
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+

--- a/manifests/base/rbac/argocd-image-updater-role.yaml
+++ b/manifests/base/rbac/argocd-image-updater-role.yaml
@@ -26,15 +26,6 @@ rules:
       - update
       - patch
   - apiGroups:
-      - argoproj.io
-    resources:
-      - applications
-    verbs:
-      - get
-      - list
-      - update
-      - patch
-  - apiGroups:
       - ""
     resources:
       - events

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -34,6 +34,12 @@ rules:
   - list
   - update
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -141,6 +147,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: git.email
+              name: argocd-image-updater-config
+              optional: true
+        - name: IMAGE_UPDATER_KUBE_EVENTS
+          valueFrom:
+            configMapKeyRef:
+              key: kube.events
               name: argocd-image-updater-config
               optional: true
         image: argoprojlabs/argocd-image-updater:latest

--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -32,13 +32,14 @@ type ImageUpdaterResult struct {
 }
 
 type UpdateConfiguration struct {
-	NewRegFN       registry.NewRegistryClient
-	ArgoClient     ArgoCD
-	KubeClient     *kube.KubernetesClient
-	UpdateApp      *ApplicationImages
-	DryRun         bool
-	GitCommitUser  string
-	GitCommitEmail string
+	NewRegFN          registry.NewRegistryClient
+	ArgoClient        ArgoCD
+	KubeClient        *kube.KubernetesClient
+	UpdateApp         *ApplicationImages
+	DryRun            bool
+	GitCommitUser     string
+	GitCommitEmail    string
+	DisableKubeEvents bool
 }
 
 type GitCredsSource func(app *v1alpha1.Application) (git.Creds, error)
@@ -206,7 +207,7 @@ func UpdateApplication(updateConf *UpdateConfiguration) ImageUpdaterResult {
 				message := fmt.Sprintf("Successfully updated image '%s' to '%s', but pending spec update (dry run=%v)", updateableImage.GetFullNameWithTag(), updateableImage.WithTag(latest).GetFullNameWithTag(), updateConf.DryRun)
 				imgCtx.Infof(message)
 				result.NumImagesUpdated += 1
-				if !updateConf.DryRun {
+				if !updateConf.DryRun && updateConf.KubeClient != nil && !updateConf.DisableKubeEvents {
 					annotations := map[string]string{
 						"image-old": updateableImage.GetFullNameWithTag(),
 						"image-new": updateableImage.WithTag(latest).GetFullNameWithTag(),

--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -82,9 +82,9 @@ type helmOverride struct {
 }
 
 type change struct {
-    image     *image.ContainerImage
-	oldTag    *tag.ImageTag
-	newTag    *tag.ImageTag
+	image  *image.ContainerImage
+	oldTag *tag.ImageTag
+	newTag *tag.ImageTag
 }
 
 // UpdateApplication update all images of a single application. Will run in a goroutine.

--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -203,8 +203,16 @@ func UpdateApplication(updateConf *UpdateConfiguration) ImageUpdaterResult {
 				result.NumErrors += 1
 				continue
 			} else {
-				imgCtx.Infof("Successfully updated image '%s' to '%s', but pending spec update (dry run=%v)", updateableImage.GetFullNameWithTag(), updateableImage.WithTag(latest).GetFullNameWithTag(), updateConf.DryRun)
+                message := fmt.Sprintf("Successfully updated image '%s' to '%s', but pending spec update (dry run=%v)", updateableImage.GetFullNameWithTag(), updateableImage.WithTag(latest).GetFullNameWithTag(), updateConf.DryRun)
+				imgCtx.Infof(message)
 				result.NumImagesUpdated += 1
+                if ! updateConf.DryRun {
+                    annotations := map[string]string{
+                            "image-old": updateableImage.GetFullNameWithTag(),
+                            "image-new": updateableImage.WithTag(latest).GetFullNameWithTag(),
+                        }
+                    updateConf.KubeClient.CreateApplicationEvent(&updateConf.UpdateApp.Application, "ImageUpdated", message, annotations)
+                }
 			}
 		} else {
 			// We need to explicitly set the up-to-date images in the spec too, so

--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -203,16 +203,19 @@ func UpdateApplication(updateConf *UpdateConfiguration) ImageUpdaterResult {
 				result.NumErrors += 1
 				continue
 			} else {
-                message := fmt.Sprintf("Successfully updated image '%s' to '%s', but pending spec update (dry run=%v)", updateableImage.GetFullNameWithTag(), updateableImage.WithTag(latest).GetFullNameWithTag(), updateConf.DryRun)
+				message := fmt.Sprintf("Successfully updated image '%s' to '%s', but pending spec update (dry run=%v)", updateableImage.GetFullNameWithTag(), updateableImage.WithTag(latest).GetFullNameWithTag(), updateConf.DryRun)
 				imgCtx.Infof(message)
 				result.NumImagesUpdated += 1
-                if ! updateConf.DryRun {
-                    annotations := map[string]string{
-                            "image-old": updateableImage.GetFullNameWithTag(),
-                            "image-new": updateableImage.WithTag(latest).GetFullNameWithTag(),
-                        }
-                    updateConf.KubeClient.CreateApplicationEvent(&updateConf.UpdateApp.Application, "ImageUpdated", message, annotations)
-                }
+				if !updateConf.DryRun {
+					annotations := map[string]string{
+						"image-old": updateableImage.GetFullNameWithTag(),
+						"image-new": updateableImage.WithTag(latest).GetFullNameWithTag(),
+					}
+					_, err = updateConf.KubeClient.CreateApplicationEvent(&updateConf.UpdateApp.Application, "ImageUpdated", message, annotations)
+					if err != nil {
+						imgCtx.Warnf("Event could not be sent: %v", err)
+					}
+				}
 			}
 		} else {
 			// We need to explicitly set the up-to-date images in the spec too, so

--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -82,7 +82,7 @@ type helmOverride struct {
 }
 
 type change struct {
-	imageName string
+    image     *image.ContainerImage
 	oldTag    *tag.ImageTag
 	newTag    *tag.ImageTag
 }
@@ -214,7 +214,7 @@ func UpdateApplication(updateConf *UpdateConfiguration) ImageUpdaterResult {
 			} else {
 				containerImageNew := updateableImage.WithTag(latest)
 				imgCtx.Infof("Successfully updated image '%s' to '%s', but pending spec update (dry run=%v)", updateableImage.GetFullNameWithTag(), containerImageNew.GetFullNameWithTag(), updateConf.DryRun)
-				changeList = append(changeList, change{updateableImage.ImageName, updateableImage.ImageTag, containerImageNew.ImageTag})
+				changeList = append(changeList, change{containerImageNew, updateableImage.ImageTag, containerImageNew.ImageTag})
 			}
 		} else {
 			// We need to explicitly set the up-to-date images in the spec too, so
@@ -258,7 +258,8 @@ func UpdateApplication(updateConf *UpdateConfiguration) ImageUpdaterResult {
 				if !updateConf.DisableKubeEvents && updateConf.KubeClient != nil {
 					annotations := map[string]string{}
 					for i, c := range changeList {
-						annotations[fmt.Sprintf("argocd-image-updater.image-%d/image-name", i)] = c.imageName
+						annotations[fmt.Sprintf("argocd-image-updater.image-%d/full-image-name", i)] = c.image.GetFullNameWithoutTag()
+						annotations[fmt.Sprintf("argocd-image-updater.image-%d/image-name", i)] = c.image.ImageName
 						annotations[fmt.Sprintf("argocd-image-updater.image-%d/old-tag", i)] = c.oldTag.TagName
 						annotations[fmt.Sprintf("argocd-image-updater.image-%d/new-tag", i)] = c.newTag.TagName
 					}

--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -257,9 +257,10 @@ func UpdateApplication(updateConf *UpdateConfiguration) ImageUpdaterResult {
 				result.NumImagesUpdated += 1
 				if !updateConf.DisableKubeEvents && updateConf.KubeClient != nil {
 					annotations := map[string]string{}
-					for _, c := range changeList {
-						annotations[fmt.Sprintf("%s/oldtag", c.imageName)] = c.oldTag.TagName
-						annotations[fmt.Sprintf("%s/newtag", c.imageName)] = c.newTag.TagName
+					for i, c := range changeList {
+						annotations[fmt.Sprintf("argocd-image-updater.image-%d/image-name", i)] = c.imageName
+						annotations[fmt.Sprintf("argocd-image-updater.image-%d/old-tag", i)] = c.oldTag.TagName
+						annotations[fmt.Sprintf("argocd-image-updater.image-%d/new-tag", i)] = c.newTag.TagName
 					}
 					message := fmt.Sprintf("Successfully updated application '%s'", app)
 					_, err = updateConf.KubeClient.CreateApplicationEvent(&updateConf.UpdateApp.Application, "ImagesUpdated", message, annotations)

--- a/pkg/kube/kubernetes.go
+++ b/pkg/kube/kubernetes.go
@@ -6,16 +6,16 @@ import (
 	"context"
 	"fmt"
 	"os"
-    "time"
+	"time"
 
 	"github.com/argoproj-labs/argocd-image-updater/pkg/metrics"
 
+	appv1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/pkg/client/clientset/versioned"
-    appv1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
-    v1 "k8s.io/api/core/v1"
 )
 
 type KubernetesClient struct {
@@ -97,32 +97,32 @@ func (client *KubernetesClient) GetSecretField(namespace string, secretName stri
 
 // CreateApplicationevent creates a kubernetes event with a custom reason and message for an application.
 func (client *KubernetesClient) CreateApplicationEvent(app *appv1alpha1.Application, reason string, message string, annotations map[string]string) (*v1.Event, error) {
-    t := metav1.Time{Time: time.Now()}
+	t := metav1.Time{Time: time.Now()}
 
-    event := v1.Event{
-        ObjectMeta: metav1.ObjectMeta{
-            Name:        fmt.Sprintf("%v.%x", app.ObjectMeta.Name, t.UnixNano()),
-            Namespace:   client.Namespace,
-            Annotations: annotations,
-        },
-        Source: v1.EventSource{
-            Component: "ArgocdImageUpdater",
-        },
-        InvolvedObject: v1.ObjectReference{
-            Kind:            app.Kind,
-            APIVersion:      app.APIVersion,
-            Name:            app.ObjectMeta.Name,
-            Namespace:       app.ObjectMeta.Namespace,
-            ResourceVersion: app.ObjectMeta.ResourceVersion,
-            UID:             app.ObjectMeta.UID,
-        },
-        FirstTimestamp: t,
-        LastTimestamp:  t,
-        Count:          1,
-        Message:        message,
-        Type:           v1.EventTypeNormal,
-        Reason:         reason,
-    }
+	event := v1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        fmt.Sprintf("%v.%x", app.ObjectMeta.Name, t.UnixNano()),
+			Namespace:   client.Namespace,
+			Annotations: annotations,
+		},
+		Source: v1.EventSource{
+			Component: "ArgocdImageUpdater",
+		},
+		InvolvedObject: v1.ObjectReference{
+			Kind:            app.Kind,
+			APIVersion:      app.APIVersion,
+			Name:            app.ObjectMeta.Name,
+			Namespace:       app.ObjectMeta.Namespace,
+			ResourceVersion: app.ObjectMeta.ResourceVersion,
+			UID:             app.ObjectMeta.UID,
+		},
+		FirstTimestamp: t,
+		LastTimestamp:  t,
+		Count:          1,
+		Message:        message,
+		Type:           v1.EventTypeNormal,
+		Reason:         reason,
+	}
 
 	result, err := client.Clientset.CoreV1().Events(client.Namespace).Create(client.Context, &event, metav1.CreateOptions{})
 	if err != nil {

--- a/pkg/kube/kubernetes.go
+++ b/pkg/kube/kubernetes.go
@@ -6,13 +6,16 @@ import (
 	"context"
 	"fmt"
 	"os"
+    "time"
 
 	"github.com/argoproj-labs/argocd-image-updater/pkg/metrics"
 
 	"github.com/argoproj/argo-cd/pkg/client/clientset/versioned"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+    appv1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+    v1 "k8s.io/api/core/v1"
 )
 
 type KubernetesClient struct {
@@ -68,7 +71,7 @@ func NewKubernetesClientFromConfig(ctx context.Context, namespace string, kubeco
 
 // GetSecretData returns the raw data from named K8s secret in given namespace
 func (client *KubernetesClient) GetSecretData(namespace string, secretName string) (map[string][]byte, error) {
-	secret, err := client.Clientset.CoreV1().Secrets(namespace).Get(client.Context, secretName, v1.GetOptions{})
+	secret, err := client.Clientset.CoreV1().Secrets(namespace).Get(client.Context, secretName, metav1.GetOptions{})
 	metrics.Clients().IncreaseK8sClientRequest(1)
 	if err != nil {
 		metrics.Clients().IncreaseK8sClientRequest(1)
@@ -90,4 +93,40 @@ func (client *KubernetesClient) GetSecretField(namespace string, secretName stri
 	} else {
 		return string(data), nil
 	}
+}
+
+// CreateApplicationevent creates a kubernetes event with a custom reason and message for an application.
+func (client *KubernetesClient) CreateApplicationEvent(app *appv1alpha1.Application, reason string, message string, annotations map[string]string) (*v1.Event, error) {
+    t := metav1.Time{Time: time.Now()}
+
+    event := v1.Event{
+        ObjectMeta: metav1.ObjectMeta{
+            Name:        fmt.Sprintf("%v.%x", app.ObjectMeta.Name, t.UnixNano()),
+            Namespace:   client.Namespace,
+            Annotations: annotations,
+        },
+        Source: v1.EventSource{
+            Component: "ArgocdImageUpdater",
+        },
+        InvolvedObject: v1.ObjectReference{
+            Kind:            app.Kind,
+            APIVersion:      app.APIVersion,
+            Name:            app.ObjectMeta.Name,
+            Namespace:       app.ObjectMeta.Namespace,
+            ResourceVersion: app.ObjectMeta.ResourceVersion,
+            UID:             app.ObjectMeta.UID,
+        },
+        FirstTimestamp: t,
+        LastTimestamp:  t,
+        Count:          1,
+        Message:        message,
+        Type:           v1.EventTypeNormal,
+        Reason:         reason,
+    }
+
+	result, err := client.Clientset.CoreV1().Events(client.Namespace).Create(client.Context, &event, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
 }

--- a/pkg/kube/kubernetes_test.go
+++ b/pkg/kube/kubernetes_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"testing"
 
-	appv1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"github.com/argoproj-labs/argocd-image-updater/test/fake"
 	"github.com/argoproj-labs/argocd-image-updater/test/fixture"
+	appv1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -83,15 +83,15 @@ func Test_CreateApplicationEvent(t *testing.T) {
 				},
 			},
 		}
-        annotations := map[string]string {
-            "origin": "nginx:1.12.2",
-        }
+		annotations := map[string]string{
+			"origin": "nginx:1.12.2",
+		}
 		clientset := fake.NewFakeClientsetWithResources()
 		client := &KubernetesClient{Clientset: clientset, Namespace: "default"}
 		event, err := client.CreateApplicationEvent(application, "TestEvent", "test-message", annotations)
 		require.NoError(t, err)
 		require.NotNil(t, event)
-		assert.Equal(t, "ArgocdImageUpdater", string(event.Source.Component))
+		assert.Equal(t, "ArgocdImageUpdater", event.Source.Component)
 		assert.Equal(t, "default", client.Namespace)
 	})
 }

--- a/pkg/kube/kubernetes_test.go
+++ b/pkg/kube/kubernetes_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/argoproj-labs/argocd-image-updater/test/fake"
-	"github.com/argoproj-labs/argocd-image-updater/test/fixture"
 	appv1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/argoproj-labs/argocd-image-updater/test/fake"
+	"github.com/argoproj-labs/argocd-image-updater/test/fixture"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/pkg/kube/kubernetes_test.go
+++ b/pkg/kube/kubernetes_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	appv1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"github.com/argoproj-labs/argocd-image-updater/test/fake"
 	"github.com/argoproj-labs/argocd-image-updater/test/fixture"
 
@@ -64,5 +66,32 @@ func Test_GetDataFromSecrets(t *testing.T) {
 		data, err := client.GetSecretField("test-namespace", "test", "namespace")
 		require.Error(t, err)
 		require.Empty(t, data)
+	})
+}
+
+func Test_CreateApplicationEvent(t *testing.T) {
+	t.Run("Create Event", func(t *testing.T) {
+		application := &appv1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-app",
+				Namespace: "argocd",
+			},
+			Spec: appv1alpha1.ApplicationSpec{},
+			Status: appv1alpha1.ApplicationStatus{
+				Summary: appv1alpha1.ApplicationSummary{
+					Images: []string{"nginx:1.12.2", "that/image", "quay.io/dexidp/dex:v1.23.0"},
+				},
+			},
+		}
+        annotations := map[string]string {
+            "origin": "nginx:1.12.2",
+        }
+		clientset := fake.NewFakeClientsetWithResources()
+		client := &KubernetesClient{Clientset: clientset, Namespace: "default"}
+		event, err := client.CreateApplicationEvent(application, "TestEvent", "test-message", annotations)
+		require.NoError(t, err)
+		require.NotNil(t, event)
+		assert.Equal(t, "ArgocdImageUpdater", string(event.Source.Component))
+		assert.Equal(t, "default", client.Namespace)
 	})
 }


### PR DESCRIPTION
Sends an event on any image change (fixes #164)

I thought in re-using some argo-cd code, but finally I decided to copy and adapt it. It is the code related to send the event.

The namespace used is the one where argocd-image-updater is running in order to reduce the permissions required (a Role instead a ClusterRole).

I had to add some argo-cd dependencies to the kubernetes package, what is... ugly. Maybe you know a better way to do it.

Finally, understand this is my first golang contribution... I'm open to changes XD

NOTE: I didn't tested it under real fire. I have no docker repository accessible from my laptop.