### PR TITLE
fix: Prevent nil pointer deref on emtpy tag with running image

### DIFF
--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/argoproj-labs/argocd-image-updater/ext/git"
 	"github.com/argoproj-labs/argocd-image-updater/pkg/common"
@@ -150,6 +151,13 @@ func UpdateApplication(updateConf *UpdateConfiguration, state *SyncIterationStat
 			log.WithContext().AddField("application", app).Debugf("Image '%s' seems not to be live in this application, skipping", applicationImage.ImageName)
 			result.NumSkipped += 1
 			continue
+		}
+
+		// In some cases, the running image has no tag set. We create a dummy
+		// tag, without name, digest and a timestamp of zero. This dummy tag
+		// will trigger an update on the first run.
+		if updateableImage.ImageTag == nil {
+			updateableImage.ImageTag = tag.NewImageTag("", time.Unix(0, 0), "")
 		}
 
 		result.NumImagesConsidered += 1

--- a/pkg/image/version.go
+++ b/pkg/image/version.go
@@ -81,7 +81,9 @@ func (img *ContainerImage) GetNewestVersionFromTags(vc *VersionConstraint, tagLi
 	var semverConstraint *semver.Constraints
 	var err error
 	if vc.SortMode == VersionSortSemVer {
-		if img.ImageTag != nil {
+		// TODO: Shall we really ensure a valid semver on the current tag?
+		// This prevents updating from a non-semver tag currently.
+		if img.ImageTag != nil && img.ImageTag.TagName != "" {
 			_, err := semver.NewVersion(img.ImageTag.TagName)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
This fixes a nil pointer dereference when there's an image without tag specification in the application's status.

Signed-off-by: jannfis <jann@mistrust.net>