### PR TITLE
feat(manifests): add ssh volume mounts and volume

### DIFF
--- a/manifests/base/deployment/argocd-image-updater-deployment.yaml
+++ b/manifests/base/deployment/argocd-image-updater-deployment.yaml
@@ -98,16 +98,21 @@ spec:
           initialDelaySeconds: 3
           periodSeconds: 30
         volumeMounts:
-        - name: image-updater-conf
-          mountPath: /app/config
+        - mountPath: /app/config
+          name: image-updater-conf
+        - mountPath: /app/config/ssh
+          name: ssh-known-hosts
       serviceAccountName: argocd-image-updater
       volumes:
-      - name: image-updater-conf
-        configMap:
-          name: argocd-image-updater-config
-          optional: true
+      - configMap:
           items:
           - key: registries.conf
             path: registries.conf
           - key: git.commit-message-template
             path: commit.template
+          name: argocd-image-updater-config
+          optional: true
+        name: image-updater-conf
+      - configMap:
+          name: argocd-ssh-known-hosts-cm
+        name: ssh-known-hosts

--- a/manifests/base/deployment/argocd-image-updater-deployment.yaml
+++ b/manifests/base/deployment/argocd-image-updater-deployment.yaml
@@ -115,4 +115,5 @@ spec:
         name: image-updater-conf
       - configMap:
           name: argocd-ssh-known-hosts-cm
+          optional: true
         name: ssh-known-hosts

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -175,6 +175,8 @@ spec:
         volumeMounts:
         - mountPath: /app/config
           name: image-updater-conf
+        - mountPath: /app/config/ssh
+          name: ssh-known-hosts
       serviceAccountName: argocd-image-updater
       volumes:
       - configMap:
@@ -186,3 +188,6 @@ spec:
           name: argocd-image-updater-config
           optional: true
         name: image-updater-conf
+      - configMap:
+          name: argocd-ssh-known-hosts-cm
+        name: ssh-known-hosts

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -190,4 +190,5 @@ spec:
         name: image-updater-conf
       - configMap:
           name: argocd-ssh-known-hosts-cm
+          optional: true
         name: ssh-known-hosts


### PR DESCRIPTION
The default behavior of image updater is to use argocd credentials. If it is setup with ssh, this volume mounts and volume are needed in order for image updater to be able to commit to the repository