### PR TITLE
fix: Don't set tag used as constraint for update if no tag was considered from registry

### DIFF
--- a/pkg/image/version.go
+++ b/pkg/image/version.go
@@ -134,13 +134,13 @@ func (img *ContainerImage) GetNewestVersionFromTags(vc *VersionConstraint, tagLi
 
 	logCtx.Debugf("found %d from %d tags eligible for consideration", len(considerTags), len(availableTags))
 
-	// Sort update candidates and return the most recent version in its original
-	// form, so we can later fetch it from the registry.
+	// If we found tags to consider, return the most recent tag found according
+	// to the update strategy.
 	if len(considerTags) > 0 {
 		return considerTags[len(considerTags)-1], nil
-	} else {
-		return img.ImageTag, nil
 	}
+
+	return nil, nil
 }
 
 // IsTagIgnored matches tag against the patterns in IgnoreList and returns true if one of them matches

--- a/pkg/image/version_test.go
+++ b/pkg/image/version_test.go
@@ -63,8 +63,7 @@ func Test_LatestVersion(t *testing.T) {
 		vc := VersionConstraint{Constraint: "~1.0"}
 		newTag, err := img.GetNewestVersionFromTags(&vc, tagList)
 		require.NoError(t, err)
-		require.NotNil(t, newTag)
-		assert.Equal(t, "1.0", newTag.TagName)
+		require.Nil(t, newTag)
 	})
 
 	t.Run("Find the latest version with a semver constraint that is invalid", func(t *testing.T) {


### PR DESCRIPTION
Do not return the original tag if no tag found in a repository was considered for being upgradeable to.

This fixes a scenario with `digest` update strategy, where a tag to track was specified as constraint but did not exist in the registry. This led to an update of the image to the (non-existing) tag, instead of just ignoring it.

Fixes #217

Signed-off-by: jannfis <jann@mistrust.net>