### PR TITLE
fix: modify SetKustomizeImage logic when use alias_name

### DIFF
--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -414,6 +414,17 @@ func SetKustomizeImage(app *v1alpha1.Application, newImage *image.ContainerImage
 		app.Spec.Source.Kustomize = &v1alpha1.ApplicationSourceKustomize{}
 	}
 
+	for i, kImg := range app.Spec.Source.Kustomize.Images {
+		curr := image.NewFromIdentifier(string(kImg))
+		override := image.NewFromIdentifier(ksImageParam)
+
+		if curr.ImageName == override.ImageName {
+			curr.ImageAlias = override.ImageAlias
+		}
+
+		app.Spec.Source.Kustomize.Images[i] = v1alpha1.KustomizeImage(curr.String())
+	}
+
 	app.Spec.Source.Kustomize.MergeImage(v1alpha1.KustomizeImage(ksImageParam))
 
 	return nil

--- a/pkg/argocd/argocd_test.go
+++ b/pkg/argocd/argocd_test.go
@@ -466,6 +466,41 @@ func Test_SetKustomizeImage(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("Test set Kustomize image parameters with alias name on Kustomize app with param already set", func(t *testing.T) {
+		app := &v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "test-app",
+				Namespace: "testns",
+				Annotations: map[string]string{
+					fmt.Sprintf(common.KustomizeApplicationNameAnnotation, "foobar"): "foobar",
+				},
+			},
+			Spec: v1alpha1.ApplicationSpec{
+				Source: v1alpha1.ApplicationSource{
+					Kustomize: &v1alpha1.ApplicationSourceKustomize{
+						Images: v1alpha1.KustomizeImages{
+							"jannfis/foobar:1.0.0",
+						},
+					},
+				},
+			},
+			Status: v1alpha1.ApplicationStatus{
+				SourceType: v1alpha1.ApplicationSourceTypeKustomize,
+				Summary: v1alpha1.ApplicationSummary{
+					Images: []string{
+						"jannfis/foobar:1.0.0",
+					},
+				},
+			},
+		}
+		img := image.NewFromIdentifier("foobar=jannfis/foobar:1.0.1")
+		err := SetKustomizeImage(app, img)
+		require.NoError(t, err)
+		require.NotNil(t, app.Spec.Source.Kustomize)
+		assert.Len(t, app.Spec.Source.Kustomize.Images, 1)
+		assert.Equal(t, v1alpha1.KustomizeImage("foobar=jannfis/foobar:1.0.1"), app.Spec.Source.Kustomize.Images[0])
+	})
+
 }
 
 func Test_SetHelmImage(t *testing.T) {


### PR DESCRIPTION
In the previous implementation, there was a problem that argocd-image-updater would create a new image when using newName of kustomize.
This is due to the fact that the current kustomize image information retrieved from the argucd API does not include the value of alias_name.
(`[<alias_name>=]<image_path>[:<version_constraint>]`)

So, in this PR, even if the current image information doesn't contain alias_name, we can update the kustomize image information appropriately

## ex. update kustomize images by argocd-image-updater

### manifest

application.yaml

```yaml
apiVersion: argoproj.io/v1alpha1
kind: Application
metadata:
  name: adservice
  annotations:
    argocd-image-updater.argoproj.io/image-list: adservice=nyuta01/adservice:^1.0.0
    argocd-image-updater.argoproj.io/write-back-target: kustomization
    argocd-image-updater.argoproj.io/adservice.kustomize.image-name: adservice
spec:
  project: default
  source:
    repoURL: git@github.com:nyuta01/xxx.git
    targetRevision: main
    path: xxx/adservice
...
```

xxx/adservice/kustomization.yaml

```yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization

resources:
- deployment.yaml

images:
- name: adservice
  newName: nyuta01/adservice
  newTag: v1.2.0
```

xxx/adservice/deployment.yaml

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: adservice
spec:
  selector:
    matchLabels:
      app: adservice
  template:
    metadata:
      labels:
        app: adservice
    spec:
      containers:
      - name: server
        image: adservice
...
```

### result

before
```yaml
images:
  - name: adservice
    newName: nyuta01/adservice
    newTag: v1.2.0
+  - name: nyuta01/adservice
+    newTag: v1.2.1

```

after 
```yaml
images:
  - name: adservice
    newName: nyuta01/adservice
-    newTag: v1.2.0
+    newTag: v1.2.1
```