### PR TITLE
fix: Get tags from correct registry/image with a different kustomize image

### DIFF
--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -223,7 +223,7 @@ func UpdateApplication(updateConf *UpdateConfiguration, state *SyncIterationStat
 		}
 
 		// Get list of available image tags from the repository
-		tags, err := rep.GetTags(updateableImage, regClient, &vc)
+		tags, err := rep.GetTags(applicationImage, regClient, &vc)
 		if err != nil {
 			imgCtx.Errorf("Could not get tags from registry: %v", err)
 			result.NumErrors += 1

--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -263,17 +263,17 @@ func UpdateApplication(updateConf *UpdateConfiguration, state *SyncIterationStat
 
 		if needsUpdate(updateableImage, applicationImage, latest) {
 
-			imgCtx.Infof("Setting new image to %s", updateableImage.WithTag(latest).String())
+			imgCtx.Infof("Setting new image to %s", applicationImage.WithTag(latest).GetFullNameWithTag())
 			needUpdate = true
 
-			err = setAppImage(&updateConf.UpdateApp.Application, updateableImage.WithTag(latest))
+			err = setAppImage(&updateConf.UpdateApp.Application, applicationImage.WithTag(latest))
 
 			if err != nil {
 				imgCtx.Errorf("Error while trying to update image: %v", err)
 				result.NumErrors += 1
 				continue
 			} else {
-				containerImageNew := updateableImage.WithTag(latest)
+				containerImageNew := applicationImage.WithTag(latest)
 				imgCtx.Infof("Successfully updated image '%s' to '%s', but pending spec update (dry run=%v)", updateableImage.GetFullNameWithTag(), containerImageNew.GetFullNameWithTag(), updateConf.DryRun)
 				changeList = append(changeList, ChangeEntry{containerImageNew, updateableImage.ImageTag, containerImageNew.ImageTag})
 			}

--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -177,7 +177,7 @@ func UpdateApplication(updateConf *UpdateConfiguration, state *SyncIterationStat
 
 		imgCtx.Debugf("Considering this image for update")
 
-		rep, err := registry.GetRegistryEndpoint(updateableImage.RegistryURL)
+		rep, err := registry.GetRegistryEndpoint(applicationImage.RegistryURL)
 		if err != nil {
 			imgCtx.Errorf("Could not get registry endpoint from configuration: %v", err)
 			result.NumErrors += 1
@@ -223,7 +223,7 @@ func UpdateApplication(updateConf *UpdateConfiguration, state *SyncIterationStat
 		}
 
 		// Get list of available image tags from the repository
-		tags, err := rep.GetTags(applicationImage, regClient, &vc)
+		tags, err := rep.GetTags(updateableImage, regClient, &vc)
 		if err != nil {
 			imgCtx.Errorf("Could not get tags from registry: %v", err)
 			result.NumErrors += 1
@@ -266,7 +266,7 @@ func UpdateApplication(updateConf *UpdateConfiguration, state *SyncIterationStat
 			imgCtx.Infof("Setting new image to %s", updateableImage.WithTag(latest).String())
 			needUpdate = true
 
-			err = setAppImage(&updateConf.UpdateApp.Application, applicationImage.WithTag(latest))
+			err = setAppImage(&updateConf.UpdateApp.Application, updateableImage.WithTag(latest))
 
 			if err != nil {
 				imgCtx.Errorf("Error while trying to update image: %v", err)

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -33,7 +33,9 @@ func Test_UpdateApplication(t *testing.T) {
 	t.Run("Test successful update", func(t *testing.T) {
 		mockClientFn := func(endpoint *registry.RegistryEndpoint, username, password string) (registry.RegistryClient, error) {
 			regMock := regmock.RegistryClient{}
-			regMock.On("Tags", mock.Anything).Return([]string{"1.0.1"}, nil)
+			regMock.On("Tags", mock.MatchedBy(func(s string) bool {
+				return s == "jannfis/foobar"
+			})).Return([]string{"1.0.1"}, nil)
 			return &regMock, nil
 		}
 

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -85,6 +85,67 @@ func Test_UpdateApplication(t *testing.T) {
 		assert.Equal(t, 1, res.NumImagesUpdated)
 	})
 
+	t.Run("Test kustomize w/ different registry", func(t *testing.T) {
+		mockClientFn := func(endpoint *registry.RegistryEndpoint, username, password string) (registry.RegistryClient, error) {
+			regMock := regmock.RegistryClient{}
+			assert.Equal(t, endpoint.RegistryPrefix, "quay.io")
+			regMock.On("Tags", mock.Anything).Return([]string{"1.0.1"}, nil)
+			return &regMock, nil
+		}
+
+		argoClient := argomock.ArgoCD{}
+		argoClient.On("UpdateSpec", mock.Anything, mock.Anything).Return(nil, nil)
+
+		kubeClient := kube.KubernetesClient{
+			Clientset: fake.NewFakeKubeClient(),
+		}
+		appImages := &ApplicationImages{
+			Application: v1alpha1.Application{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "guestbook",
+					Namespace: "guestbook",
+					Annotations: map[string]string{
+						"argocd-image-updater.argoproj.io/image-list":                  "foobar=quay.io/jannfis/foobar:~1.0.0",
+						"argocd-image-updater.argoproj.io/foobar.kustomize.image-name": "jannfis/foobar",
+						"argocd-image-updater.argoproj.io/foobar.force-update":         "true",
+					},
+				},
+				Spec: v1alpha1.ApplicationSpec{
+					Source: v1alpha1.ApplicationSource{
+						Kustomize: &v1alpha1.ApplicationSourceKustomize{
+							Images: v1alpha1.KustomizeImages{
+								"jannfis/foobar:1.0.0",
+							},
+						},
+					},
+				},
+				Status: v1alpha1.ApplicationStatus{
+					SourceType: v1alpha1.ApplicationSourceTypeKustomize,
+					Summary: v1alpha1.ApplicationSummary{
+						Images: []string{
+							"jannfis/foobar:1.0.0",
+						},
+					},
+				},
+			},
+			Images: image.ContainerImageList{
+				image.NewFromIdentifier("quay.io/jannfis/foobar"),
+			},
+		}
+		res := UpdateApplication(&UpdateConfiguration{
+			NewRegFN:   mockClientFn,
+			ArgoClient: &argoClient,
+			KubeClient: &kubeClient,
+			UpdateApp:  appImages,
+			DryRun:     false,
+		}, NewSyncIterationState())
+		assert.Equal(t, 0, res.NumErrors)
+		assert.Equal(t, 0, res.NumSkipped)
+		assert.Equal(t, 1, res.NumApplicationsProcessed)
+		assert.Equal(t, 1, res.NumImagesConsidered)
+		assert.Equal(t, 1, res.NumImagesUpdated)
+	})
+
 	t.Run("Test successful update when no tag is set in running workload", func(t *testing.T) {
 		mockClientFn := func(endpoint *registry.RegistryEndpoint, username, password string) (registry.RegistryClient, error) {
 			regMock := regmock.RegistryClient{}


### PR DESCRIPTION
Fixes #244 