### PR TITLE
chore: Test successful update two images

### DIFF
--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -276,6 +276,7 @@ func UpdateApplication(updateConf *UpdateConfiguration, state *SyncIterationStat
 				containerImageNew := applicationImage.WithTag(latest)
 				imgCtx.Infof("Successfully updated image '%s' to '%s', but pending spec update (dry run=%v)", updateableImage.GetFullNameWithTag(), containerImageNew.GetFullNameWithTag(), updateConf.DryRun)
 				changeList = append(changeList, ChangeEntry{containerImageNew, updateableImage.ImageTag, containerImageNew.ImageTag})
+				result.NumImagesUpdated += 1
 			}
 		} else {
 			// We need to explicitly set the up-to-date images in the spec too, so
@@ -319,7 +320,6 @@ func UpdateApplication(updateConf *UpdateConfiguration, state *SyncIterationStat
 				result.NumImagesUpdated = 0
 			} else {
 				logCtx.Infof("Successfully updated the live application spec")
-				result.NumImagesUpdated += 1
 				if !updateConf.DisableKubeEvents && updateConf.KubeClient != nil {
 					annotations := map[string]string{}
 					for i, c := range changeList {

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -88,6 +88,67 @@ func Test_UpdateApplication(t *testing.T) {
 		assert.Equal(t, 1, res.NumImagesUpdated)
 	})
 
+	t.Run("Test successful update two images", func(t *testing.T) {
+		mockClientFn := func(endpoint *registry.RegistryEndpoint, username, password string) (registry.RegistryClient, error) {
+			regMock := regmock.RegistryClient{}
+			regMock.On("NewRepository", mock.MatchedBy(func(s string) bool {
+				return s == "jannfis/foobar" || s == "jannfis/barbar"
+			})).Return(nil)
+			regMock.On("Tags").Return([]string{"1.0.1"}, nil)
+			return &regMock, nil
+		}
+
+		argoClient := argomock.ArgoCD{}
+		argoClient.On("UpdateSpec", mock.Anything, mock.Anything).Return(nil, nil)
+
+		kubeClient := kube.KubernetesClient{
+			Clientset: fake.NewFakeKubeClient(),
+		}
+		appImages := &ApplicationImages{
+			Application: v1alpha1.Application{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "guestbook",
+					Namespace: "guestbook",
+				},
+				Spec: v1alpha1.ApplicationSpec{
+					Source: v1alpha1.ApplicationSource{
+						Kustomize: &v1alpha1.ApplicationSourceKustomize{
+							Images: v1alpha1.KustomizeImages{
+								"jannfis/foobar:1.0.0",
+								"jannfis/barbar:1.0.0",
+							},
+						},
+					},
+				},
+				Status: v1alpha1.ApplicationStatus{
+					SourceType: v1alpha1.ApplicationSourceTypeKustomize,
+					Summary: v1alpha1.ApplicationSummary{
+						Images: []string{
+							"jannfis/foobar:1.0.0",
+							"jannfis/barbar:1.0.0",
+						},
+					},
+				},
+			},
+			Images: image.ContainerImageList{
+				image.NewFromIdentifier("jannfis/foobar:~1.0.0"),
+				image.NewFromIdentifier("jannfis/barbar:~1.0.0"),
+			},
+		}
+		res := UpdateApplication(&UpdateConfiguration{
+			NewRegFN:   mockClientFn,
+			ArgoClient: &argoClient,
+			KubeClient: &kubeClient,
+			UpdateApp:  appImages,
+			DryRun:     false,
+		}, NewSyncIterationState())
+		assert.Equal(t, 0, res.NumErrors)
+		assert.Equal(t, 0, res.NumSkipped)
+		assert.Equal(t, 1, res.NumApplicationsProcessed)
+		assert.Equal(t, 2, res.NumImagesConsidered)
+		assert.Equal(t, 2, res.NumImagesUpdated)
+	})
+
 	t.Run("Test kustomize w/ different registry", func(t *testing.T) {
 		mockClientFn := func(endpoint *registry.RegistryEndpoint, username, password string) (registry.RegistryClient, error) {
 			regMock := regmock.RegistryClient{}


### PR DESCRIPTION
ADD a test case for Update Two Images, FIX `result.NumImagesUpdated`
