### PR TITLE
fix: Allow insecure registry access

### DIFF
--- a/pkg/registry/endpoints.go
+++ b/pkg/registry/endpoints.go
@@ -1,8 +1,10 @@
 package registry
 
 import (
+	"crypto/tls"
 	"fmt"
 	"math"
+	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -202,6 +204,15 @@ func (ep *RegistryEndpoint) DeepCopy() *RegistryEndpoint {
 	newEp.CredsUpdated = ep.CredsUpdated
 	ep.lock.RUnlock()
 	return newEp
+}
+
+// GetTransport returns a transport object for this endpoint
+func (ep *RegistryEndpoint) GetTransport() *http.Transport {
+	tlsC := &tls.Config{}
+	if ep.Insecure {
+		tlsC.InsecureSkipVerify = true
+	}
+	return &http.Transport{TLSClientConfig: tlsC}
 }
 
 func init() {


### PR DESCRIPTION
PR https://github.com/argoproj-labs/argocd-image-updater/pull/249 introduced a new mechanism to access registries in order to support OCI registries and images.

Unfortunately, this broke the insecure registry access (e.g. ignoring the remote's TLS certificate validity).

This PR brings it back.