### PR TITLE
fix: Correct client ping endpoint

### DIFF
--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -260,7 +260,7 @@ func (client *registryClient) TagMetadata(manifest distribution.Manifest) (*tag.
 // Without this, tokenHandler and AuthorizationHandler won't work
 func ping(manager challenge.Manager, endpoint *RegistryEndpoint, versionHeader string) ([]auth.APIVersion, error) {
 	httpc := &http.Client{Transport: endpoint.GetTransport()}
-	resp, err := httpc.Get(endpoint.RegistryAPI + "/v2")
+	resp, err := httpc.Get(endpoint.RegistryAPI + "/v2/")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is to solve #276 

Before:
`Could not get tags from registry: unauthorized: authentication required`

Ping in `registry/client.go` gets a `404` from `https://ghcr.io/v2`
While `https://registry-1.docker.io/v2` get a `301` redirect to `/v2/` (That I assume the client follows)

So just a extra / at the end of the "ping" url and it's working with GitHub Container Registry.

Tested DockerHub and GitHub Container Registry.