### PR TITLE
fix: add basic authentication handler

### DIFF
--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -99,14 +99,15 @@ func (clt *registryClient) NewRepository(nameInRepository string) error {
 		return err
 	}
 
-	var transport http.RoundTripper = transport.NewTransport(
+	authTransport := transport.NewTransport(
 		clt.endpoint.GetTransport(), auth.NewAuthorizer(
 			challengeManager1,
-			auth.NewTokenHandler(nil, clt.creds, nameInRepository, "pull")))
+			auth.NewTokenHandler(nil, clt.creds, nameInRepository, "pull"),
+			auth.NewBasicHandler(clt.creds)))
 
 	rlt := &rateLimitTransport{
 		limiter:   clt.endpoint.Limiter,
-		transport: transport,
+		transport: authTransport,
 		endpoint:  clt.endpoint,
 	}
 


### PR DESCRIPTION
fixes #276

Seems to be an oversight in the upgrade to the distribution client. 