### PR TITLE
fix: Use correct registry URL for parsing pull secrets

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -121,7 +121,7 @@ argocd-image-updater test nginx --allow-tags '^1.19.\d+(\-.*)*$' --update-strate
 				if err != nil {
 					log.Fatalf("could not parse credential definition '%s': %v", credentials, err)
 				}
-				creds, err = credSrc.FetchCredentials(img.RegistryURL, kubeClient)
+				creds, err = credSrc.FetchCredentials(ep.RegistryAPI, kubeClient)
 				if err != nil {
 					log.Fatalf("could not fetch credentials: %v", err)
 				}

--- a/pkg/image/credentials.go
+++ b/pkg/image/credentials.go
@@ -94,6 +94,7 @@ func ParseCredentialSource(credentialSource string, requirePrefix bool) (*Creden
 // the credential source.
 func (src *CredentialSource) FetchCredentials(registryURL string, kubeclient *kube.KubernetesClient) (*Credential, error) {
 	var creds Credential
+	log.Tracef("Fetching credentials for registry %s", registryURL)
 	switch src.Type {
 	case CredentialSourceEnv:
 		credEnv := os.Getenv(src.EnvName)
@@ -233,7 +234,7 @@ func parseDockerConfigJson(registryURL string, jsonSource string) (string, strin
 
 	for registry, authConf := range auths {
 		if !strings.HasPrefix(registry, registryURL) && !strings.HasPrefix(registry, regPrefix) {
-			log.Tracef("found registry %s in image pull secret, but we want %s - skipping", registry, registryURL)
+			log.Tracef("found registry %s in image pull secret, but we want %s (%s) - skipping", registry, registryURL, regPrefix)
 			continue
 		}
 		authEntry, ok := authConf.(map[string]interface{})


### PR DESCRIPTION
The `test` command incorrectly used only the prefix of the image as registry URL instead of the API URL set on the endpoint, resulting in invalid pull secrets.