### PR TITLE
Allow use of in-cluster kube-client for test-command

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -60,11 +60,10 @@ argocd-image-updater test nginx --allow-tags '^1.19.\d+(\-.*)*$' --update-strate
 				log.Fatalf("could not set log level to %s: %v", logLevel, err)
 			}
 
-			ctx := context.Background()
-
 			var kubeClient *kube.KubernetesClient
 			var err error
-			if kubeConfig != "" {
+			if !disableKubernetes {
+				ctx := context.Background()
 				kubeClient, err = getKubeConfig(ctx, "", kubeConfig)
 				if err != nil {
 					log.Fatalf("could not create K8s client: %v", err)


### PR DESCRIPTION
This PR fixes the issue described in #288.

# With Kubernetes

For the following cases, I used the following `registries.conf`:

```yaml
registries:
  - name: myfancyregistry
    api_url: https://myfancyregistry.azurecr.io
    prefix: myfancyregistry.azurecr.io
    ping: yes
    credentials: secret:argocd/registry#auth
```

## In-cluster kube client \*\*NEW**

### Success

```
$ argocd-image-updater --registries-conf registries.conf test myfancyregistry.azurecr.io/example
DEBU[0000] Creating in-cluster Kubernetes client        
INFO[0000] getting image                                 image_name=example registry=myfancyregistry.azurecr.io
DEBU[0000] rate limit for https://myfancyregistry.azurecr.io is 2147483647 
INFO[0000] Loaded 1 registry configurations from registries.yaml 
INFO[0000] Fetching available tags and metadata from registry  image_name=example
INFO[0001] Found 2 tags in registry                      image_name=example
DEBU[0001] found 2 from 2 tags eligible for consideration  image=myfancyregistry.azurecr.io/example
INFO[0001] latest image according to constraint is myfancyregistry.azurecr.io/example:v0.0.1
```

### Failure

```
$ argocd-image-updater --registries-conf registries.conf test myfancyregistry.azurecr.io/example
DEBU[0000] Creating in-cluster Kubernetes client        
INFO[0000] getting image                                 image_name=example registry=myfancyregistry.azurecr.io
DEBU[0000] rate limit for https://myfancyregistry.azurecr.io is 2147483647 
INFO[0000] Loaded 1 registry configurations from registries.yaml 
FATA[0000] could not set registry credentials: could not fetch secret 'registry' from namespace 'argocd' (field: 'auth'): secrets "registry" not found
```

## Local kubeconfig

### Success

```
$ argocd-image-updater --registries-conf registries.conf test --kubeconfig ~/.kube/config myfancyregistry.azurecr.io/example
DEBU[0000] Creating Kubernetes client from /home/jan/.kube/config 
INFO[0000] getting image                                 image_name=example registry=myfancyregistry.azurecr.io
DEBU[0000] rate limit for https://myfancyregistry.azurecr.io is 2147483647 
INFO[0000] Loaded 1 registry configurations from registries.yaml 
INFO[0000] Fetching available tags and metadata from registry  image_name=example
INFO[0001] Found 2 tags in registry                      image_name=example
DEBU[0001] found 2 from 2 tags eligible for consideration  image=myfancyregistry.azurecr.io/example
INFO[0001] latest image according to constraint is myfancyregistry.azurecr.io/example:v0.0.1
```

### Failure

```
$ argocd-image-updater --registries-conf registries.conf test --kubeconfig ~/.kube/config myfancyregistry.azurecr.io/example
DEBU[0000] Creating Kubernetes client from /home/jan/.kube/config 
INFO[0000] getting image                                 image_name=example registry=myfancyregistry.azurecr.io
DEBU[0000] rate limit for https://myfancyregistry.azurecr.io is 2147483647 
INFO[0000] Loaded 1 registry configurations from registries.yaml 
FATA[0000] could not set registry credentials: could not fetch secret 'registry' from namespace 'argocd' (field: 'auth'): secrets "registry" not found
```

# Without Kubernetes

As we're now using `--disable-kubernetes`, we cannot use a kubernetes secrets for the `credentials`-option anymore. In this case, I am using an ENV-variable:

```yaml
registries:
  - name: myfancyregistry
    api_url: https://myfancyregistry.azurecr.io
    prefix: myfancyregistry.azurecr.io
    ping: yes
    credentials: env:REGISTRY_SECRET
```

### Success

```
$ REGISTRY_SECRET=user:password argocd-image-updater --registries-conf registries.conf test --disable-kubernetes 
INFO[0000] getting image                                 image_name=example registry=myfancyregistry.azurecr.io
DEBU[0000] rate limit for https://myfancyregistry.azurecr.io is 2147483647 
INFO[0000] Loaded 1 registry configurations from registries.yaml 
INFO[0000] Fetching available tags and metadata from registry  image_name=example
INFO[0000] Found 2 tags in registry                      image_name=example
DEBU[0000] found 2 from 2 tags eligible for consideration  image=myfancyregistry.azurecr.io/example
INFO[0000] latest image according to constraint is myfancyregistry.azurecr.io/example:v0.0.1
```

### Failure

```
$ REGISTRY_SECRET=user:password argocd-image-updater --registries-conf registries.conf test --disable-kubernetes ~/.kube/config myfancyregistry.azurecr.io/example
INFO[0000] getting image                                 image_name=example registry=myfancyregistry.azurecr.io
DEBU[0000] rate limit for https://myfancyregistry.azurecr.io is 2147483647 
INFO[0000] Loaded 1 registry configurations from registries.yaml 
WARN[0000] cannot use K8s credentials without Kubernetes client  registry="https://myfancyregistry.azurecr.io"
FATA[0000] could not set registry credentials: could not fetch image tags
```