### PR TITLE
feat: use HTTP_PROXY for registry endpoint

### DIFF
--- a/pkg/registry/endpoints.go
+++ b/pkg/registry/endpoints.go
@@ -212,7 +212,10 @@ func (ep *RegistryEndpoint) GetTransport() *http.Transport {
 	if ep.Insecure {
 		tlsC.InsecureSkipVerify = true
 	}
-	return &http.Transport{TLSClientConfig: tlsC}
+	return &http.Transport{
+		Proxy:           http.ProxyFromEnvironment,
+		TLSClientConfig: tlsC,
+	}
 }
 
 func init() {


### PR DESCRIPTION
use HTTP_PROXY in transport object for registry endpoint if defined in environment