### PR TITLE
feat: add ability to specify a different write and base branch

### DIFF
--- a/docs/configuration/applications.md
+++ b/docs/configuration/applications.md
@@ -244,7 +244,7 @@ The following variables are provided for this template:
   entry in this list is a struct providing the following information for
   each change:
   * `.Name` holds the full name of the image that was updated
-  * `.Name` holds the alias of the image that was updated
+  * `.Alias` holds the alias of the image that was updated
   * `.OldTag` holds the tag name or SHA digest previous to the update
   * `.NewTag` holds the tag name or SHA digest that was updated to
 * `.SHA1` is a unique SHA1 has representing these changes

--- a/docs/configuration/applications.md
+++ b/docs/configuration/applications.md
@@ -218,24 +218,28 @@ argocd-image-updater.argoproj.io/git-branch: main
 By default, Argo CD Imager Updater will checkout, commit, and push back to the
 same branch specified above. There are many scenarios where this is not
 desired or possible, such as when the default branch is protected. You can
-specify the annotation `argocd-image-updater.argoproj.io/git-write-branch`,
-which will create a new branch from the base branch (specified in the previous
-section), and push to this new branch instead.
+add a separate write-branch by modifying `argocd-image-updater.argoproj.io/git-branch`
+with additional data, which will create a new branch from the base branch, and
+push to this new branch instead:
+
+```yaml
+argocd-image-updater.argoproj.io/git-branch: base:target
+```
 
 A static branch name may not be desired for this value, so a simple template
 can be created (evaluating using the `text/template` Golang package) within
 the annotation. For example, the following would create a branch named
-`image-updater-foo/bar-1.1` in the event an image with the name `foo/bar`
-was updated to the new tag `1.1`.
+`image-updater-foo/bar-1.1` based on `main` in the event an image with
+the name `foo/bar` was updated to the new tag `1.1`.
 
 ```yaml
-argocd-image-updater.argoproj.io/git-write-branch: image-updater{{range .Images}}-{{.Name}}-{{.NewTag}}{{end}}
+argocd-image-updater.argoproj.io/git-branch: main:image-updater{{range .Images}}-{{.Name}}-{{.NewTag}}{{end}}
 ```
 
 Alternatively, to assure unique branch names you could use the SHA1 representation of the changes:
 
 ```yaml
-argocd-image-updater.argoproj.io/git-write-branch: image-updater-{{.SHA256}}
+argocd-image-updater.argoproj.io/git-branch: main:image-updater-{{.SHA256}}
 ```
 
 The following variables are provided for this template:

--- a/docs/configuration/applications.md
+++ b/docs/configuration/applications.md
@@ -226,6 +226,13 @@ push to this new branch instead:
 argocd-image-updater.argoproj.io/git-branch: base:target
 ```
 
+If you want to specify a write-branch but continue to use the target revision from the application
+specification, just omit the base branch name:
+
+```yaml
+argocd-image-updater.argoproj.io/git-branch: :target
+```
+
 A static branch name may not be desired for this value, so a simple template
 can be created (evaluating using the `text/template` Golang package) within
 the annotation. For example, the following would create a branch named

--- a/docs/configuration/applications.md
+++ b/docs/configuration/applications.md
@@ -235,7 +235,7 @@ argocd-image-updater.argoproj.io/git-write-branch: image-updater{{range .Images}
 Alternatively, to assure unique branch names you could use the SHA1 representation of the changes:
 
 ```yaml
-argocd-image-updater.argoproj.io/git-write-branch: image-updater-{{.SHA1}}
+argocd-image-updater.argoproj.io/git-write-branch: image-updater-{{.SHA256}}
 ```
 
 The following variables are provided for this template:
@@ -247,7 +247,7 @@ The following variables are provided for this template:
   * `.Alias` holds the alias of the image that was updated
   * `.OldTag` holds the tag name or SHA digest previous to the update
   * `.NewTag` holds the tag name or SHA digest that was updated to
-* `.SHA1` is a unique SHA1 has representing these changes
+* `.SHA256` is a unique SHA256 has representing these changes
 
 Please note that if the output of the template exceeds 255 characters (git branch name limit) it will be truncated.
 

--- a/docs/configuration/applications.md
+++ b/docs/configuration/applications.md
@@ -232,7 +232,13 @@ was updated to the new tag `1.1`.
 argocd-image-updater.argoproj.io/git-write-branch: image-updater{{range .Images}}-{{.Name}}-{{.NewTag}}{{end}}
 ```
 
-One top-level variable is provided for this template:
+Alternatively, to assure unique branch names you could use the SHA1 representation of the changes:
+
+```yaml
+argocd-image-updater.argoproj.io/git-write-branch: image-updater-{{.SHA1}}
+```
+
+The following varaibles are provided for this template:
 
 * `.Images` is a list of changes that were performed by the update. Each
   entry in this list is a struct providing the following information for
@@ -241,6 +247,9 @@ One top-level variable is provided for this template:
   * `.Name` holds the alias of the image that was updated
   * `.OldTag` holds the tag name or SHA digest previous to the update
   * `.NewTag` holds the tag name or SHA digest that was updated to
+* `.SHA1` is a unique SHA1 has representing these changes
+
+Please note that if the output of the template exceeds 255 characters (git branch name limit) it will be truncated.
 
 #### Specifying the user and email address for commits
 

--- a/docs/configuration/applications.md
+++ b/docs/configuration/applications.md
@@ -213,7 +213,7 @@ following would use GitHub's default `main` branch:
 argocd-image-updater.argoproj.io/git-branch: main
 ```
 
-#### Specifying a seperate base and commit branch
+#### Specifying a separate base and commit branch
 
 By default, Argo CD Imager Updater will checkout, commit, and push back to the
 same branch specified above. There are many scenarios where this is not

--- a/docs/configuration/applications.md
+++ b/docs/configuration/applications.md
@@ -238,7 +238,7 @@ Alternatively, to assure unique branch names you could use the SHA1 representati
 argocd-image-updater.argoproj.io/git-write-branch: image-updater-{{.SHA1}}
 ```
 
-The following varaibles are provided for this template:
+The following variables are provided for this template:
 
 * `.Images` is a list of changes that were performed by the update. Each
   entry in this list is a struct providing the following information for

--- a/pkg/argocd/git.go
+++ b/pkg/argocd/git.go
@@ -82,7 +82,7 @@ func TemplateBranchName(branchName string, changeList []ChangeEntry) string {
 
 	type branchNameTemplate struct {
 		Images []imageChange
-		SHA256   string
+		SHA256 string
 	}
 
 	// Let's add a unique hash to the template
@@ -192,8 +192,8 @@ func commitChangesGit(app *v1alpha1.Application, wbc *WriteBackConfig, changeLis
 	}
 
 	// The push branch is by default the same as the checkout branch, unless
-	// specified with the git-write-branch annotation, in which case a new
-	// branch will be made following a template that can use the list of
+	// specified after a : separator git-branch annotation, in which case a
+	// new branch will be made following a template that can use the list of
 	// changed images.
 	pushBranch := checkOutBranch
 

--- a/pkg/argocd/git.go
+++ b/pkg/argocd/git.go
@@ -94,7 +94,11 @@ func TemplateBranchName(branchName string, changeList []ChangeEntry) string {
 	for _, c := range changeList {
 		changes = append(changes, imageChange{c.Image.ImageName, c.Image.ImageAlias, c.OldTag.String(), c.NewTag.String()})
 		id := fmt.Sprintf("%v-%v-%v,", c.Image.ImageName, c.OldTag.String(), c.NewTag.String())
-		hasher.Write([]byte(id))
+		_, hasherErr := hasher.Write([]byte(id))
+		if hasherErr != nil {
+			log.Errorf("could not write image string to hasher: %v", hasherErr)
+			return ""
+		}
 	}
 
 	tplData := branchNameTemplate{

--- a/pkg/argocd/git.go
+++ b/pkg/argocd/git.go
@@ -72,10 +72,10 @@ func TemplateBranchName(branchName string, changeList []ChangeEntry) string {
 	}
 
 	type imageChange struct {
-		Name  		string
-		Alias  		string
-		OldTag 		string
-		NewTag 		string
+		Name   string
+		Alias  string
+		OldTag string
+		NewTag string
 	}
 
 	type branchNameTemplate struct {
@@ -89,7 +89,7 @@ func TemplateBranchName(branchName string, changeList []ChangeEntry) string {
 		changes = append(changes, imageChange{c.Image.ImageName, c.Image.ImageAlias, c.OldTag.String(), c.NewTag.String()})
 	}
 
-	tplData := branchNameTemplate {
+	tplData := branchNameTemplate{
 		Images: changes,
 	}
 
@@ -176,9 +176,9 @@ func commitChangesGit(app *v1alpha1.Application, wbc *WriteBackConfig, changeLis
 	pushBranch := checkOutBranch
 
 	if wbc.GitWriteBranch != "" {
-		log.Debugf("Using branch template: %s", wbc.GitWriteBranch,)
+		log.Debugf("Using branch template: %s", wbc.GitWriteBranch)
 		pushBranch = TemplateBranchName(wbc.GitWriteBranch, changeList)
-		if (pushBranch != "") {
+		if pushBranch != "" {
 			log.Debugf("Creating branch '%s' and using that for push operations", pushBranch)
 			err = gitC.Branch(checkOutBranch, pushBranch)
 			if err != nil {

--- a/pkg/argocd/git_test.go
+++ b/pkg/argocd/git_test.go
@@ -76,6 +76,33 @@ func Test_TemplateBranchName(t *testing.T) {
 		assert.NotEmpty(t, r)
 		assert.Equal(t, exp, r)
 	})
+	t.Run("Template branch name with hash", func(t *testing.T) {
+		exp := `image-updater-1cec79355bbe50a50ece77a6ecc3503e0ae1fd41`
+		tpl := "image-updater-{{ .SHA1 }}"
+		cl := []ChangeEntry{
+			{
+				Image:  image.NewFromIdentifier("foo/bar"),
+				OldTag: tag.NewImageTag("1.0", time.Now(), ""),
+				NewTag: tag.NewImageTag("1.1", time.Now(), ""),
+			},
+		}
+		r := TemplateBranchName(tpl, cl)
+		assert.NotEmpty(t, r)
+		assert.Equal(t, exp, r)
+	})
+	t.Run("Template branch over 255 chars", func(t *testing.T) {
+		tpl := "image-updater-lorem-ipsum-dolor-sit-amet-consectetur-" +
+			"adipiscing-elit-phasellus-imperdiet-vitae-elit-quis-pulvinar-" +
+			"suspendisse-pulvinar-lacus-vel-semper-congue-enim-purus-posuere-" +
+			"orci-ut-vulputate-mi-ipsum-quis-ipsum-quisque-elit-arcu-lobortis-" +
+			"in-blandit-vel-pharetra-vel-urna-aliquam-euismod-elit-vel-mi"
+		exp := tpl[:255]
+		cl := []ChangeEntry{}
+		r := TemplateBranchName(tpl, cl)
+		assert.NotEmpty(t, r)
+		assert.Equal(t, exp, r)
+		assert.Len(t, r, 255)
+	})
 }
 
 func Test_parseImageOverride(t *testing.T) {

--- a/pkg/argocd/git_test.go
+++ b/pkg/argocd/git_test.go
@@ -45,7 +45,7 @@ updates image bar/baz tag '2.0' to '2.1'
 func Test_TemplateBranchName(t *testing.T) {
 	t.Run("Template branch name with image name", func(t *testing.T) {
 		exp := `image-updater-foo/bar-1.1-bar/baz-2.1`
-		tpl :=  "image-updater{{range .Images}}-{{.Name}}-{{.NewTag}}{{end}}"
+		tpl := "image-updater{{range .Images}}-{{.Name}}-{{.NewTag}}{{end}}"
 		cl := []ChangeEntry{
 			{
 				Image:  image.NewFromIdentifier("foo/bar"),
@@ -64,7 +64,7 @@ func Test_TemplateBranchName(t *testing.T) {
 	})
 	t.Run("Template branch name with alias", func(t *testing.T) {
 		exp := `image-updater-bar-1.1`
-		tpl :=  "image-updater{{range .Images}}-{{.Alias}}-{{.NewTag}}{{end}}"
+		tpl := "image-updater{{range .Images}}-{{.Alias}}-{{.NewTag}}{{end}}"
 		cl := []ChangeEntry{
 			{
 				Image:  image.NewFromIdentifier("bar=0001.dkr.ecr.us-east-1.amazonaws.com/bar"),

--- a/pkg/argocd/git_test.go
+++ b/pkg/argocd/git_test.go
@@ -42,6 +42,42 @@ updates image bar/baz tag '2.0' to '2.1'
 	})
 }
 
+func Test_TemplateBranchName(t *testing.T) {
+	t.Run("Template branch name with image name", func(t *testing.T) {
+		exp := `image-updater-foo/bar-1.1-bar/baz-2.1`
+		tpl :=  "image-updater{{range .Images}}-{{.Name}}-{{.NewTag}}{{end}}"
+		cl := []ChangeEntry{
+			{
+				Image:  image.NewFromIdentifier("foo/bar"),
+				OldTag: tag.NewImageTag("1.0", time.Now(), ""),
+				NewTag: tag.NewImageTag("1.1", time.Now(), ""),
+			},
+			{
+				Image:  image.NewFromIdentifier("bar/baz"),
+				OldTag: tag.NewImageTag("2.0", time.Now(), ""),
+				NewTag: tag.NewImageTag("2.1", time.Now(), ""),
+			},
+		}
+		r := TemplateBranchName(tpl, cl)
+		assert.NotEmpty(t, r)
+		assert.Equal(t, exp, r)
+	})
+	t.Run("Template branch name with alias", func(t *testing.T) {
+		exp := `image-updater-bar-1.1`
+		tpl :=  "image-updater{{range .Images}}-{{.Alias}}-{{.NewTag}}{{end}}"
+		cl := []ChangeEntry{
+			{
+				Image:  image.NewFromIdentifier("bar=0001.dkr.ecr.us-east-1.amazonaws.com/bar"),
+				OldTag: tag.NewImageTag("1.0", time.Now(), ""),
+				NewTag: tag.NewImageTag("1.1", time.Now(), ""),
+			},
+		}
+		r := TemplateBranchName(tpl, cl)
+		assert.NotEmpty(t, r)
+		assert.Equal(t, exp, r)
+	})
+}
+
 func Test_parseImageOverride(t *testing.T) {
 	cases := []struct {
 		name     string

--- a/pkg/argocd/git_test.go
+++ b/pkg/argocd/git_test.go
@@ -78,7 +78,7 @@ func Test_TemplateBranchName(t *testing.T) {
 	})
 	t.Run("Template branch name with hash", func(t *testing.T) {
 		exp := `image-updater-1cec79355bbe50a50ece77a6ecc3503e0ae1fd41`
-		tpl := "image-updater-{{ .SHA1 }}"
+		tpl := "image-updater-{{.SHA1}}"
 		cl := []ChangeEntry{
 			{
 				Image:  image.NewFromIdentifier("foo/bar"),

--- a/pkg/argocd/git_test.go
+++ b/pkg/argocd/git_test.go
@@ -77,8 +77,9 @@ func Test_TemplateBranchName(t *testing.T) {
 		assert.Equal(t, exp, r)
 	})
 	t.Run("Template branch name with hash", func(t *testing.T) {
-		exp := `image-updater-1cec79355bbe50a50ece77a6ecc3503e0ae1fd41`
-		tpl := "image-updater-{{.SHA1}}"
+		// Expected value generated from https://emn178.github.io/online-tools/sha256.html
+		exp := `image-updater-0fcc2782543e4bb067c174c21bf44eb947f3e55c0d62c403e359c1c209cbd041`
+		tpl := "image-updater-{{.SHA256}}"
 		cl := []ChangeEntry{
 			{
 				Image:  image.NewFromIdentifier("foo/bar"),

--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -448,11 +448,14 @@ func parseTarget(target string, sourcePath string) (kustomizeBase string) {
 func parseGitConfig(app *v1alpha1.Application, kubeClient *kube.KubernetesClient, wbc *WriteBackConfig, creds string) error {
 	branch, ok := app.Annotations[common.GitBranchAnnotation]
 	if ok {
-		wbc.GitBranch = strings.TrimSpace(branch)
-	}
-	writebranch, ok := app.Annotations[common.GitWriteBranchAnnotation]
-	if ok {
-		wbc.GitWriteBranch = strings.TrimSpace(writebranch)
+		branches := strings.Split(strings.TrimSpace(branch), ":")
+		if len(branches) > 2 {
+			return fmt.Errorf("invalid format for git-branch annotation: %v", branch)
+		}
+		wbc.GitBranch = branches[0]
+		if len(branches) == 2 {
+			wbc.GitWriteBranch = branches[1]
+		}
 	}
 	credsSource, err := getGitCredsSource(creds, kubeClient)
 	if err != nil {

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -1241,7 +1241,7 @@ func Test_GetWriteBackConfig(t *testing.T) {
 				Annotations: map[string]string{
 					"argocd-image-updater.argoproj.io/image-list":        "nginx",
 					"argocd-image-updater.argoproj.io/write-back-method": "git",
-					"argocd-image-updater.argoproj.io/git-branch":        "mybranch",
+					"argocd-image-updater.argoproj.io/git-branch":        "mybranch:mytargetbranch",
 				},
 			},
 			Spec: v1alpha1.ApplicationSpec{
@@ -1266,6 +1266,8 @@ func Test_GetWriteBackConfig(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, wbc)
 		assert.Equal(t, wbc.Method, WriteBackGit)
+		assert.Equal(t, "mybranch", wbc.GitBranch)
+		assert.Equal(t, "mytargetbranch", wbc.GitWriteBranch)
 	})
 
 	t.Run("Valid write-back config - argocd", func(t *testing.T) {

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -44,6 +44,7 @@ const (
 const (
 	WriteBackMethodAnnotation = ImageUpdaterAnnotationPrefix + "/write-back-method"
 	GitBranchAnnotation       = ImageUpdaterAnnotationPrefix + "/git-branch"
+	GitWriteBranchAnnotation  = ImageUpdaterAnnotationPrefix + "/git-write-branch"
 	WriteBackTargetAnnotation = ImageUpdaterAnnotationPrefix + "/write-back-target"
 	KustomizationPrefix       = "kustomization"
 )

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -44,7 +44,6 @@ const (
 const (
 	WriteBackMethodAnnotation = ImageUpdaterAnnotationPrefix + "/write-back-method"
 	GitBranchAnnotation       = ImageUpdaterAnnotationPrefix + "/git-branch"
-	GitWriteBranchAnnotation  = ImageUpdaterAnnotationPrefix + "/git-write-branch"
 	WriteBackTargetAnnotation = ImageUpdaterAnnotationPrefix + "/write-back-target"
 	KustomizationPrefix       = "kustomization"
 )


### PR DESCRIPTION
This add new functionality by adding a write-branch to `argocd-image-updater.argoproj.io/git-branch` using a separator, which will be used to push back changes to the target repository. The branch from the Application's spec or specified with the existing `git-branch` annotation will be used as the base branch for checkout.

Further, this annotation can use Golang templating to allow for dynamic branch names based off of the changes.

This could integrate with various CI/CD (such as GitHub Actions) to automatically create a pull request.

This varies slightly from the suggestion in #198, though sill resolves the issue. Rather than adding a new annotation to specify the base branch, we're specifying a write branch. This decision was made for ease of implementation, as rather than having to add a new annotation and change an existing one, a user will only need to add a new annotation.