### PR TITLE
feat: Assume app type when write-back-type is set to kustomize

### DIFF
--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -474,9 +474,14 @@ func IsValidApplicationType(app *v1alpha1.Application) bool {
 
 // getApplicationType returns the type of the application
 func getApplicationType(app *v1alpha1.Application) ApplicationType {
-	if app.Status.SourceType == v1alpha1.ApplicationSourceTypeKustomize {
+	sourceType := app.Status.SourceType
+	if st, set := app.Annotations[common.WriteBackTargetAnnotation]; set &&
+		strings.HasPrefix(st, common.KustomizationPrefix) {
+		sourceType = v1alpha1.ApplicationSourceTypeKustomize
+	}
+	if sourceType == v1alpha1.ApplicationSourceTypeKustomize {
 		return ApplicationTypeKustomize
-	} else if app.Status.SourceType == v1alpha1.ApplicationSourceTypeHelm {
+	} else if sourceType == v1alpha1.ApplicationSourceTypeHelm {
 		return ApplicationTypeHelm
 	} else {
 		return ApplicationTypeUnsupported

--- a/pkg/argocd/argocd_test.go
+++ b/pkg/argocd/argocd_test.go
@@ -137,6 +137,27 @@ func Test_GetApplicationType(t *testing.T) {
 		assert.Equal(t, "Unsupported", appType.String())
 	})
 
+	t.Run("Get application with kustomize target", func(t *testing.T) {
+		application := &v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "test-app",
+				Namespace: "argocd",
+				Annotations: map[string]string{
+					common.WriteBackTargetAnnotation: "kustomization:.",
+				},
+			},
+			Spec: v1alpha1.ApplicationSpec{},
+			Status: v1alpha1.ApplicationStatus{
+				SourceType: v1alpha1.ApplicationSourceTypePlugin,
+				Summary: v1alpha1.ApplicationSummary{
+					Images: []string{"nginx:1.12.2", "that/image", "quay.io/dexidp/dex:v1.23.0"},
+				},
+			},
+		}
+		appType := GetApplicationType(application)
+		assert.Equal(t, ApplicationTypeKustomize, appType)
+	})
+
 }
 
 func Test_FilterApplicationsForUpdate(t *testing.T) {


### PR DESCRIPTION
Recently started using tooling based on kustomize that is configured in Argo as a plugin. It stopped getting updates, so this is a workaround to continue to get kustomize updates.