### PR TITLE
fix: Invalid image reference format when using digest strategy with helm charts

### DIFF
--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -376,7 +376,7 @@ func SetHelmImage(app *v1alpha1.Application, newImage *image.ContainerImage) err
 			mergeParams = append(mergeParams, p)
 		}
 		if hpImageTag != "" {
-			p := v1alpha1.HelmParameter{Name: hpImageTag, Value: newImage.ImageTag.String(), ForceString: true}
+			p := v1alpha1.HelmParameter{Name: hpImageTag, Value: newImage.GetFullTag(), ForceString: true}
 			mergeParams = append(mergeParams, p)
 		}
 	}

--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -376,7 +376,7 @@ func SetHelmImage(app *v1alpha1.Application, newImage *image.ContainerImage) err
 			mergeParams = append(mergeParams, p)
 		}
 		if hpImageTag != "" {
-			p := v1alpha1.HelmParameter{Name: hpImageTag, Value: newImage.GetFullTag(), ForceString: true}
+			p := v1alpha1.HelmParameter{Name: hpImageTag, Value: newImage.GetTagWithDigest(), ForceString: true}
 			mergeParams = append(mergeParams, p)
 		}
 	}

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -105,8 +105,8 @@ func (img *ContainerImage) GetFullNameWithTag() string {
 	return str
 }
 
-// GetFullTag returns tag name along with any tag digest set for the image
-func (img *ContainerImage) GetFullTag() string {
+// GetTagWithDigest returns tag name along with any tag digest set for the image
+func (img *ContainerImage) GetTagWithDigest() string {
 	str := ""
 	if img.ImageTag != nil {
 		if img.ImageTag.TagName != "" {

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -105,6 +105,24 @@ func (img *ContainerImage) GetFullNameWithTag() string {
 	return str
 }
 
+// GetFullTag returns tag name along with any tag digest set for the image
+func (img *ContainerImage) GetFullTag() string {
+	str := ""
+	if img.ImageTag != nil {
+		if img.ImageTag.TagName != "" {
+			str += img.ImageTag.TagName
+		}
+		if img.ImageTag.TagDigest != "" {
+			if str == "" {
+				str += "latest"
+			}
+			str += "@"
+			str += img.ImageTag.TagDigest
+		}
+	}
+	return str
+}
+
 func (img *ContainerImage) Original() string {
 	return img.original
 }

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -72,8 +72,18 @@ func Test_ParseImageTags(t *testing.T) {
 		require.NotNil(t, image.ImageTag)
 		assert.Empty(t, image.ImageTag.TagName)
 		assert.Equal(t, "sha256:abcde", image.ImageTag.TagDigest)
+		assert.Equal(t, "latest@sha256:abcde", image.GetTagWithDigest())
 		assert.Equal(t, "gcr.io/jannfis/test-image@sha256:abcde", image.GetFullNameWithTag())
 		assert.Equal(t, "gcr.io/jannfis/test-image", image.GetFullNameWithoutTag())
+	})
+
+	t.Run("Parse valid image name with tag and digest", func(t *testing.T) {
+		image := NewFromIdentifier("gcr.io/jannfis/test-image:test-tag@sha256:abcde")
+		require.NotNil(t, image.ImageTag)
+		assert.Empty(t, image.ImageTag.TagName)
+		assert.Equal(t, "sha256:abcde", image.ImageTag.TagDigest)
+		assert.Equal(t, "latest@sha256:abcde", image.GetTagWithDigest())
+		assert.Equal(t, "gcr.io/jannfis/test-image:test-tag@sha256:abcde", image.GetFullNameWithTag())
 	})
 
 	t.Run("Parse valid image name with source name and registry info", func(t *testing.T) {


### PR DESCRIPTION
Fixes #259 #210

When using digest update strategy, the helm image.tag parameter now composes a full tag of both the tag and the digest in the form:
```
sometag@sha256:<somelonghashstring>
```
This avoids invalid references in almost all helm charts that construct the image ref as `image.repository:image.tag`, that so far resulted to the invalid references of the form:
```
some/image:sha256:<somelonghashstring>
```