### PR TITLE
docs: Fixed typo

### DIFF
--- a/docs/configuration/registries.md
+++ b/docs/configuration/registries.md
@@ -118,10 +118,10 @@ data:
       prefix: quay.io
       credentials: env:REGISTRY_SECRET
     - name: GitHub Container Registry
-      api_url: https://gcr.io
+      api_url: https://ghcr.io
       ping: no
-      prefix: gcr.io
-      credentials: ext:/custom/gcr-creds.sh.io
+      prefix: ghcr.io
+      credentials: ext:/custom/ghcr-creds.sh.io
       credsexpire: 5h
 ```
 


### PR DESCRIPTION
The code block used `gcr` for GitHub Container Registry, changed them to `ghcr`