### PR TITLE
docs: Fixed ConfigMap name

### DIFF
--- a/docs/configuration/registries.md
+++ b/docs/configuration/registries.md
@@ -94,7 +94,7 @@ following semantics:
   if the `<image_alias>.sort-mode` is `latest` but will instead use the sorting
   from the tag list.
 
-If you want to take above example to the `argocd-image-updater-cm` ConfigMap,
+If you want to take above example to the `argocd-image-updater-config` ConfigMap,
 you need to define the key `registries.conf` in the data of the ConfigMap as
 below:
 


### PR DESCRIPTION
The docs mentioned `argocd-image-updater-cm` while the correct name is `argocd-image-updater-config`