### PR TITLE
fix: Fix registry authentication when URL has slash suffix

### DIFF
--- a/pkg/registry/endpoints.go
+++ b/pkg/registry/endpoints.go
@@ -152,7 +152,7 @@ func AddRegistryEndpoint(prefix, name, apiUrl, credentials, defaultNS string, in
 	logCtx.AddField("registry", registries[prefix].RegistryAPI)
 	logCtx.AddField("prefix", registries[prefix].RegistryPrefix)
 	if limit != RateLimitNone {
-		logCtx.Debugf("setting rate limit to %d requests per second", registries[prefix].RegistryAPI, limit)
+		logCtx.Debugf("setting rate limit to %d requests per second", limit)
 	} else {
 		logCtx.Debugf("rate limiting is disabled")
 	}

--- a/pkg/registry/endpoints.go
+++ b/pkg/registry/endpoints.go
@@ -135,11 +135,10 @@ func AddRegistryEndpoint(prefix, name, apiUrl, credentials, defaultNS string, in
 	if limit <= 0 {
 		limit = RateLimitNone
 	}
-	log.Debugf("rate limit for %s is %d", apiUrl, limit)
 	registries[prefix] = &RegistryEndpoint{
 		RegistryName:   name,
 		RegistryPrefix: prefix,
-		RegistryAPI:    apiUrl,
+		RegistryAPI:    strings.TrimSuffix(apiUrl, "/"),
 		Credentials:    credentials,
 		CredsExpire:    credsExpire,
 		Cache:          cache.NewMemCache(),
@@ -147,6 +146,15 @@ func AddRegistryEndpoint(prefix, name, apiUrl, credentials, defaultNS string, in
 		DefaultNS:      defaultNS,
 		TagListSort:    tagListSort,
 		Limiter:        ratelimit.New(limit),
+	}
+
+	logCtx := log.WithContext()
+	logCtx.AddField("registry", registries[prefix].RegistryAPI)
+	logCtx.AddField("prefix", registries[prefix].RegistryPrefix)
+	if limit != RateLimitNone {
+		logCtx.Debugf("setting rate limit to %d requests per second", registries[prefix].RegistryAPI, limit)
+	} else {
+		logCtx.Debugf("rate limiting is disabled")
 	}
 	return nil
 }


### PR DESCRIPTION
Related to #329

Previously, when a registry's API URL was specified with a trailing slash, authentication would fail due to an invalid request being sent to the registry for the `/v2` endpoint. This change removes any trailing slash from the URL before using it. Also, handle authentication errors early on.