### PR TITLE
fix: Request correct mediatype for v1 manifests

### DIFF
--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -156,7 +156,7 @@ func (clt *registryClient) Manifest(tagStr string) (distribution.Manifest, error
 	if err != nil {
 		return nil, err
 	}
-	mediaType := []string{ocischema.SchemaVersion.MediaType, schema1.SchemaVersion.MediaType, schema2.SchemaVersion.MediaType}
+	mediaType := []string{ocischema.SchemaVersion.MediaType, schema1.MediaTypeSignedManifest, schema2.SchemaVersion.MediaType}
 	manifest, err := manService.Get(
 		context.Background(),
 		digest.FromString(tagStr),


### PR DESCRIPTION
`schema1.SchemaVersion.MediaType` expands to the empty string, because it is not correctly initialized. This changes it to use a specific mediatype for the request.

Fixes #306 

Signed-off-by: jannfis <jann@mistrust.net>