### PR TITLE
feat: Application-wide image options

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -75,15 +75,15 @@ argocd-image-updater test nginx --allow-tags '^1.19.\d+(\-.*)*$' --update-strate
 				SortMode:   image.VersionSortSemVer,
 			}
 
-			vc.SortMode = image.ParseUpdateStrategy(strategy)
+			img := image.NewFromIdentifier(args[0])
+			vc.SortMode = img.ParseUpdateStrategy(strategy)
 
 			if allowTags != "" {
-				vc.MatchFunc, vc.MatchArgs = image.ParseMatchfunc(allowTags)
+				vc.MatchFunc, vc.MatchArgs = img.ParseMatchfunc(allowTags)
 			}
 
 			vc.IgnoreList = ignoreTags
 
-			img := image.NewFromIdentifier(args[0])
 			log.WithContext().
 				AddField("registry", img.RegistryURL).
 				AddField("image_name", img.ImageName).

--- a/docs/configuration/images.md
+++ b/docs/configuration/images.md
@@ -114,6 +114,7 @@ Argo CD Image Updater can update images according to the following strategies:
 |--------|-----------|
 |`semver`| Update to the tag with the highest allowed semantic version|
 |`latest`| Update to the tag with the most recent creation date|
+|`digest`| Update to the SHA256 digest of a given tag|
 |`name`  | Update to the tag with the latest entry from an alphabetically sorted list|
 
 You can define the update strategy for each image independently by setting the
@@ -410,14 +411,10 @@ with specific configuration.
 The following annotations are available. Please note, all annotations must be
 prefixed with `argocd-image-updater.argoproj.io/`.
 
-|Annotation name|Default value|Description|
-|---------------|-------|-----------|
-|`update-strategy`|`semver`|The update strategy to be used for the image|
-|`<image_alias>.allow-tags`|*any*|A function to match tag names from registry against to be considered for update|
-|`<image_alias>.ignore-tags`|*none*|A comma-separated list of glob patterns that when match ignore a certain tag from the registry|
-|`<image_alias>.pull-secret`|*none*|A reference to a secret to be used as registry credentials for this image|
-|`<image_alias>.helm.image-spec`|*none*|Name of the Helm parameter to specify the canonical name of the image, i.e. holds `image/name:1.0`. If this is set, other Helm parameter related options will be ignored.|
-|`<image_alias>.helm.image-name`|`image.name`|Name of the Helm parameter used for specifying the image name, i.e. holds `image/name`|
-|`<image_alias>.helm.image-tag`|`image.tag`|Name of the Helm parameter used for specifying the image tag, i.e. holds `1.0`|
-|`<image_alias>.kustomize.image-name`|*original name of image*|Name of Kustomize image parameter to set during updates|
-
+|Annotation name|Description|
+|---------------|-----------|
+|`update-strategy`|The update strategy to be used for all images|
+|`force-update`|If set to "true" (with quotes), even images that are not currently deployed will be updated|
+|`allow-tags`|A function to match tag names from registry against to be considered for update|
+|`ignore-tags`|A comma-separated list of glob patterns that when match ignore a certain tag from the registry|
+|`pull-secret`|A reference to a secret to be used as registry credentials for this image|

--- a/docs/configuration/images.md
+++ b/docs/configuration/images.md
@@ -61,7 +61,6 @@ of the [Semver library](https://github.com/Masterminds/semver) we're using.
     [filtering tags](#filtering-tags)
     below.
 
-
 ### Forcing Image Updates
 
 By default, Image Updater will only update an image that is actually used in your Application
@@ -74,7 +73,6 @@ you may force an update:
 argocd-image-updater.argoproj.io/image-list: myalias=some/image
 argocd-image-updater.argoproj.io/myalias.force-update: "true"
 ```
-
 
 ## Assigning aliases to images
 
@@ -135,7 +133,6 @@ strategy `semver` will be used.
     and these will count into your pull limits. So unless you are not affected
     by these pull limits, it is **not recommended** to use the `latest` update
     strategy with images hosted on Docker Hub.
-
 
 ## Filtering tags
 
@@ -389,7 +386,7 @@ argocd-image-updater.argoproj.io/baralias.helm.image-tag: bar.tag
 
 The following is a complete list of available annotations to control the
 update strategy and set options for images. Please note, all annotations
-must be prefixed with `argocd-image-updater.argoproj.io`.
+must be prefixed with `argocd-image-updater.argoproj.io/`.
 
 |Annotation name|Default value|Description|
 |---------------|-------|-----------|
@@ -402,3 +399,25 @@ must be prefixed with `argocd-image-updater.argoproj.io`.
 |`<image_alias>.helm.image-name`|`image.name`|Name of the Helm parameter used for specifying the image name, i.e. holds `image/name`|
 |`<image_alias>.helm.image-tag`|`image.tag`|Name of the Helm parameter used for specifying the image tag, i.e. holds `1.0`|
 |`<image_alias>.kustomize.image-name`|*original name of image*|Name of Kustomize image parameter to set during updates|
+
+### Application-wide defaults
+
+If you want to update multiple images in an Application, that all share common
+settings (such as, update strategy, allowed tags, etc), you can define common
+options. These options are valid for all images, unless an image overrides it
+with specific configuration.
+
+The following annotations are available. Please note, all annotations must be
+prefixed with `argocd-image-updater.argoproj.io/`.
+
+|Annotation name|Default value|Description|
+|---------------|-------|-----------|
+|`update-strategy`|`semver`|The update strategy to be used for the image|
+|`<image_alias>.allow-tags`|*any*|A function to match tag names from registry against to be considered for update|
+|`<image_alias>.ignore-tags`|*none*|A comma-separated list of glob patterns that when match ignore a certain tag from the registry|
+|`<image_alias>.pull-secret`|*none*|A reference to a secret to be used as registry credentials for this image|
+|`<image_alias>.helm.image-spec`|*none*|Name of the Helm parameter to specify the canonical name of the image, i.e. holds `image/name:1.0`. If this is set, other Helm parameter related options will be ignored.|
+|`<image_alias>.helm.image-name`|`image.name`|Name of the Helm parameter used for specifying the image name, i.e. holds `image/name`|
+|`<image_alias>.helm.image-tag`|`image.tag`|Name of the Helm parameter used for specifying the image tag, i.e. holds `1.0`|
+|`<image_alias>.kustomize.image-name`|*original name of image*|Name of Kustomize image parameter to set during updates|
+

--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -194,7 +194,7 @@ func UpdateApplication(updateConf *UpdateConfiguration, state *SyncIterationStat
 		}
 
 		vc.SortMode = applicationImage.GetParameterUpdateStrategy(updateConf.UpdateApp.Application.Annotations)
-		vc.MatchFunc, vc.MatchArgs = applicationImage.GetParameterMatch(updateConf.UpdateApp.Application.Annotations)
+		vc.MatchFunc, vc.MatchArgs = applicationImage.GetParameterAllowTags(updateConf.UpdateApp.Application.Annotations)
 		vc.IgnoreList = applicationImage.GetParameterIgnoreTags(updateConf.UpdateApp.Application.Annotations)
 
 		// The endpoint can provide default credentials for pulling images

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -26,13 +26,23 @@ const (
 	KustomizeApplicationNameAnnotation = ImageUpdaterAnnotationPrefix + "/%s.kustomize.image-name"
 )
 
-// Upgrade strategy related annotations
+// Image specific configuratoin annotations
 const (
 	OldMatchOptionAnnotation    = ImageUpdaterAnnotationPrefix + "/%s.tag-match" // Deprecated and will be removed
 	AllowTagsOptionAnnotation   = ImageUpdaterAnnotationPrefix + "/%s.allow-tags"
 	IgnoreTagsOptionAnnotation  = ImageUpdaterAnnotationPrefix + "/%s.ignore-tags"
 	ForceUpdateOptionAnnotation = ImageUpdaterAnnotationPrefix + "/%s.force-update"
 	UpdateStrategyAnnotation    = ImageUpdaterAnnotationPrefix + "/%s.update-strategy"
+)
+
+// Default configuration annotations per app
+const (
+	DefaultAllowTagsOptionAnnotation   = ImageUpdaterAnnotationPrefix + "/allow-tags"
+	DefaultIgnoreTagsOptionAnnotation  = ImageUpdaterAnnotationPrefix + "/ignore-tags"
+	DefaultForceUpdateOptionAnnotation = ImageUpdaterAnnotationPrefix + "/force-update"
+	DefaultUpdateStrategyAnnotation    = ImageUpdaterAnnotationPrefix + "/update-strategy"
+	DefaultSecretListAnnotation        = ImageUpdaterAnnotationPrefix + "/pull-secret"
+	DefaultUpdateStrategyValue         = "semver"
 )
 
 // Image pull secret related annotations

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/argoproj-labs/argocd-image-updater/pkg/log"
 	"github.com/argoproj-labs/argocd-image-updater/pkg/tag"
 
 	"github.com/distribution/distribution/v3/reference"
@@ -21,6 +22,14 @@ type ContainerImage struct {
 }
 
 type ContainerImageList []*ContainerImage
+
+// LogContext returns a log context set up for current image
+func (img *ContainerImage) LogContext() *log.LogContext {
+	return log.WithContext().
+		AddField("image_name", img.ImageName).
+		AddField("image_alias", img.ImageAlias).
+		AddField("image_registry", img.RegistryURL)
+}
 
 // NewFromIdentifier parses an image identifier and returns a populated ContainerImage
 func NewFromIdentifier(identifier string) *ContainerImage {

--- a/pkg/image/options.go
+++ b/pkg/image/options.go
@@ -9,73 +9,67 @@ import (
 	"github.com/argoproj-labs/argocd-image-updater/pkg/log"
 )
 
+// Helper to get value of an annotation, with a possible default key set
+func getAnnotationWithDefault(annotations map[string]string, key, defaultKey, defaultValue string) string {
+	val, ok := annotations[key]
+	if !ok {
+		if defaultKey == "" {
+			return defaultValue
+		}
+		val, ok = annotations[defaultKey]
+		if !ok {
+			return defaultValue
+		}
+	}
+	return val
+}
+
 // GetParameterHelmImageName gets the value for image-name option for the image
 // from a set of annotations
 func (img *ContainerImage) GetParameterHelmImageName(annotations map[string]string) string {
 	key := fmt.Sprintf(common.HelmParamImageNameAnnotation, img.normalizedSymbolicName())
-	val, ok := annotations[key]
-	if !ok {
-		return ""
-	}
-	return val
+	return getAnnotationWithDefault(annotations, key, "", "")
 }
 
 // GetParameterHelmImageTag gets the value for image-tag option for the image
 // from a set of annotations
 func (img *ContainerImage) GetParameterHelmImageTag(annotations map[string]string) string {
 	key := fmt.Sprintf(common.HelmParamImageTagAnnotation, img.normalizedSymbolicName())
-	val, ok := annotations[key]
-	if !ok {
-		return ""
-	}
-	return val
+	return getAnnotationWithDefault(annotations, key, "", "")
 }
 
 // GetParameterHelmImageSpec gets the value for image-spec option for the image
 // from a set of annotations
 func (img *ContainerImage) GetParameterHelmImageSpec(annotations map[string]string) string {
 	key := fmt.Sprintf(common.HelmParamImageSpecAnnotation, img.normalizedSymbolicName())
-	val, ok := annotations[key]
-	if !ok {
-		return ""
-	}
-	return val
+	return getAnnotationWithDefault(annotations, key, "", "")
 }
 
 // GetParameterKustomizeImageName gets the value for image-spec option for the
 // image from a set of annotations
 func (img *ContainerImage) GetParameterKustomizeImageName(annotations map[string]string) string {
 	key := fmt.Sprintf(common.KustomizeApplicationNameAnnotation, img.normalizedSymbolicName())
-	val, ok := annotations[key]
-	if !ok {
-		return ""
-	}
-	return val
+	return getAnnotationWithDefault(annotations, key, "", "")
 }
 
 // HasForceUpdateOptionAnnotation gets the value for force-update option for the
 // image from a set of annotations
 func (img *ContainerImage) HasForceUpdateOptionAnnotation(annotations map[string]string) bool {
 	key := fmt.Sprintf(common.ForceUpdateOptionAnnotation, img.normalizedSymbolicName())
-	val, ok := annotations[key]
-	return ok && val == "true"
+	val := getAnnotationWithDefault(annotations, key, common.DefaultForceUpdateOptionAnnotation, "false")
+	return val == "true"
 }
 
 // GetParameterSort gets and validates the value for the sort option for the
 // image from a set of annotations
 func (img *ContainerImage) GetParameterUpdateStrategy(annotations map[string]string) VersionSortMode {
 	key := fmt.Sprintf(common.UpdateStrategyAnnotation, img.normalizedSymbolicName())
-	val, ok := annotations[key]
-	if !ok {
-		// Default is sort by version
-		log.Tracef("No sort option %s found", key)
-		return VersionSortSemVer
-	}
-	log.Tracef("found update strategy %s in %s", val, key)
-	return ParseUpdateStrategy(val)
+	val := getAnnotationWithDefault(annotations, key, common.DefaultUpdateStrategyAnnotation, common.DefaultUpdateStrategyValue)
+	return img.ParseUpdateStrategy(val)
 }
 
-func ParseUpdateStrategy(val string) VersionSortMode {
+// ParseUpdateStrategy returns the update strategy from a string identifier
+func (img *ContainerImage) ParseUpdateStrategy(val string) VersionSortMode {
 	switch strings.ToLower(val) {
 	case "semver":
 		return VersionSortSemVer
@@ -86,7 +80,7 @@ func ParseUpdateStrategy(val string) VersionSortMode {
 	case "digest":
 		return VersionSortDigest
 	default:
-		log.Warnf("Unknown sort option %s -- using semver", val)
+		img.LogContext().Warnf("Unknown sort option %s -- using semver", val)
 		return VersionSortSemVer
 	}
 
@@ -96,27 +90,25 @@ func ParseUpdateStrategy(val string) VersionSortMode {
 // tag names. If an invalid option is found, it returns MatchFuncNone as the
 // default, to prevent accidental matches.
 func (img *ContainerImage) GetParameterMatch(annotations map[string]string) (MatchFuncFn, interface{}) {
-
 	key := fmt.Sprintf(common.AllowTagsOptionAnnotation, img.normalizedSymbolicName())
-	val, ok := annotations[key]
-	if !ok {
-		// The old match-tag annotation is deprecated and will be subject to removal
-		// in a future version.
+	val := getAnnotationWithDefault(annotations, key, common.DefaultAllowTagsOptionAnnotation, "")
+	if val == "" {
+		// DEPRECATED: This code will be removed
 		key = fmt.Sprintf(common.OldMatchOptionAnnotation, img.normalizedSymbolicName())
-		val, ok = annotations[key]
-		if !ok {
-			log.Tracef("No match annotation %s found", key)
+		val = getAnnotationWithDefault(annotations, key, "", "")
+		if val == "" {
+			img.LogContext().Tracef("No match annotation %s found", key)
 			return MatchFuncAny, ""
 		} else {
-			log.Warnf("The 'tag-match' annotation is deprecated and subject to removal. Please use 'allow-tags' annotation instead.")
+			img.LogContext().Warnf("The 'tag-match' annotation is deprecated and subject to removal. Please use 'allow-tags' annotation instead.")
 		}
 	}
 
-	return ParseMatchfunc(val)
+	return img.ParseMatchfunc(val)
 }
 
 // ParseMatchfunc returns a matcher function and its argument from given value
-func ParseMatchfunc(val string) (MatchFuncFn, interface{}) {
+func (img *ContainerImage) ParseMatchfunc(val string) (MatchFuncFn, interface{}) {
 	// The special value "any" doesn't take any parameter
 	if strings.ToLower(val) == "any" {
 		return MatchFuncAny, nil
@@ -124,7 +116,7 @@ func ParseMatchfunc(val string) (MatchFuncFn, interface{}) {
 
 	opt := strings.SplitN(val, ":", 2)
 	if len(opt) != 2 {
-		log.Warnf("Invalid match option syntax '%s', ignoring", val)
+		img.LogContext().Warnf("Invalid match option syntax '%s', ignoring", val)
 		return MatchFuncNone, nil
 	}
 	switch strings.ToLower(opt[0]) {
@@ -136,7 +128,7 @@ func ParseMatchfunc(val string) (MatchFuncFn, interface{}) {
 		}
 		return MatchFuncRegexp, re
 	default:
-		log.Warnf("Unknown match function: %s", opt[0])
+		img.LogContext().Warnf("Unknown match function: %s", opt[0])
 		return MatchFuncNone, nil
 	}
 }
@@ -144,14 +136,14 @@ func ParseMatchfunc(val string) (MatchFuncFn, interface{}) {
 // GetParameterPullSecret retrieves an image's pull secret credentials
 func (img *ContainerImage) GetParameterPullSecret(annotations map[string]string) *CredentialSource {
 	key := fmt.Sprintf(common.SecretListAnnotation, img.normalizedSymbolicName())
-	val, ok := annotations[key]
-	if !ok {
-		log.Tracef("No secret annotation %s found", key)
+	val := getAnnotationWithDefault(annotations, key, common.DefaultSecretListAnnotation, "")
+	if val == "" {
+		img.LogContext().Tracef("No secret annotation %s found", key)
 		return nil
 	}
 	credSrc, err := ParseCredentialSource(val, false)
 	if err != nil {
-		log.Warnf("Invalid credential reference specified: %s", val)
+		img.LogContext().Warnf("Invalid credential reference specified: %s", val)
 		return nil
 	}
 	return credSrc
@@ -160,9 +152,9 @@ func (img *ContainerImage) GetParameterPullSecret(annotations map[string]string)
 // GetParameterIgnoreTags retrieves a list of tags to ignore from a comma-separated string
 func (img *ContainerImage) GetParameterIgnoreTags(annotations map[string]string) []string {
 	key := fmt.Sprintf(common.IgnoreTagsOptionAnnotation, img.normalizedSymbolicName())
-	val, ok := annotations[key]
-	if !ok {
-		log.Tracef("No ignore-tags annotation %s found", key)
+	val := getAnnotationWithDefault(annotations, key, common.DefaultIgnoreTagsOptionAnnotation, "")
+	if val == "" {
+		img.LogContext().Tracef("No ignore-tags annotation %s found", key)
 		return nil
 	}
 	ignoreList := make([]string, 0)
@@ -177,6 +169,8 @@ func (img *ContainerImage) GetParameterIgnoreTags(annotations map[string]string)
 	return ignoreList
 }
 
+// normalizedSymbolicName returns the image's alias with all slash characters
+// replaced by an underscore
 func (img *ContainerImage) normalizedSymbolicName() string {
 	return strings.ReplaceAll(img.ImageAlias, "/", "_")
 }

--- a/pkg/image/options.go
+++ b/pkg/image/options.go
@@ -86,10 +86,10 @@ func (img *ContainerImage) ParseUpdateStrategy(val string) VersionSortMode {
 
 }
 
-// GetParameterMatch returns the match function and pattern to use for matching
+// GetParameterAllowTags returns the match function and pattern to use for matching
 // tag names. If an invalid option is found, it returns MatchFuncNone as the
 // default, to prevent accidental matches.
-func (img *ContainerImage) GetParameterMatch(annotations map[string]string) (MatchFuncFn, interface{}) {
+func (img *ContainerImage) GetParameterAllowTags(annotations map[string]string) (MatchFuncFn, interface{}) {
 	key := fmt.Sprintf(common.AllowTagsOptionAnnotation, img.normalizedSymbolicName())
 	val := getAnnotationWithDefault(annotations, key, common.DefaultAllowTagsOptionAnnotation, "")
 	if val == "" {

--- a/pkg/image/options_test.go
+++ b/pkg/image/options_test.go
@@ -172,11 +172,7 @@ func Test_GetMatchOption(t *testing.T) {
 
 	t.Run("Get default allow-tags option", func(t *testing.T) {
 		annotations := map[string]string{
-			common.DefaultUpdateStrategyAnnotation:    "latest",
-			common.DefaultSecretListAnnotation:        "env:FOOBAR",
-			common.DefaultForceUpdateOptionAnnotation: "true",
-			common.DefaultAllowTagsOptionAnnotation:   "regexp:^foo$",
-			common.DefaultIgnoreTagsOptionAnnotation:  "foo-*",
+			common.DefaultAllowTagsOptionAnnotation: "regexp:^foo$",
 		}
 		img := NewFromIdentifier("dummy=foo/bar:1.12")
 		matchFunc, matchArgs := img.GetParameterAllowTags(annotations)
@@ -187,13 +183,8 @@ func Test_GetMatchOption(t *testing.T) {
 
 	t.Run("Specific allow-tags overrides default", func(t *testing.T) {
 		annotations := map[string]string{
-			fmt.Sprintf(common.UpdateStrategyAnnotation, "dummy"):  "digest",
-			common.DefaultUpdateStrategyAnnotation:                 "latest",
-			common.DefaultSecretListAnnotation:                     "env:FOOBAR",
-			common.DefaultForceUpdateOptionAnnotation:              "true",
 			fmt.Sprintf(common.AllowTagsOptionAnnotation, "dummy"): "regexp:^bar$",
 			common.DefaultAllowTagsOptionAnnotation:                "regexp:^foo$",
-			common.DefaultIgnoreTagsOptionAnnotation:               "foo-*",
 		}
 		img := NewFromIdentifier("dummy=foo/bar:1.12")
 		matchFunc, matchArgs := img.GetParameterAllowTags(annotations)
@@ -266,5 +257,32 @@ func Test_GetIgnoreTags(t *testing.T) {
 		assert.Equal(t, "tag2", tags[1])
 		assert.Equal(t, "tag3", tags[2])
 		assert.Equal(t, "tag4", tags[3])
+	})
+}
+
+func Test_getAnnotationWithDefault(t *testing.T) {
+	annotations := map[string]string{
+		"foo": "bar",
+		"bar": "foo",
+	}
+
+	t.Run("Get existing annotation without default requested", func(t *testing.T) {
+		r := getAnnotationWithDefault(annotations, "foo", "", "baz")
+		assert.Equal(t, r, "bar")
+	})
+
+	t.Run("Get existing annotation with default specified", func(t *testing.T) {
+		r := getAnnotationWithDefault(annotations, "foo", "bar", "baz")
+		assert.Equal(t, r, "bar")
+	})
+
+	t.Run("Get non-existing annotation with default specified", func(t *testing.T) {
+		r := getAnnotationWithDefault(annotations, "foofoo", "bar", "baz")
+		assert.Equal(t, r, "foo")
+	})
+
+	t.Run("Get non-existing annotation with non-existing default specified", func(t *testing.T) {
+		r := getAnnotationWithDefault(annotations, "foofoo", "barbar", "baz")
+		assert.Equal(t, r, "baz")
 	})
 }

--- a/pkg/image/options_test.go
+++ b/pkg/image/options_test.go
@@ -73,7 +73,7 @@ func Test_GetKustomizeOptions(t *testing.T) {
 	})
 }
 
-func Test_GetSortOption(t *testing.T) {
+func Test_GetUpdateStrategy(t *testing.T) {
 
 	t.Run("Get update strategy semver for configured application", func(t *testing.T) {
 		annotations := map[string]string{
@@ -120,11 +120,7 @@ func Test_GetSortOption(t *testing.T) {
 
 	t.Run("Get default update strategy", func(t *testing.T) {
 		annotations := map[string]string{
-			common.DefaultUpdateStrategyAnnotation:    "latest",
-			common.DefaultSecretListAnnotation:        "env:FOOBAR",
-			common.DefaultForceUpdateOptionAnnotation: "true",
-			common.DefaultAllowTagsOptionAnnotation:   "regexp:^.*$",
-			common.DefaultIgnoreTagsOptionAnnotation:  "foo-*",
+			common.DefaultUpdateStrategyAnnotation: "latest",
 		}
 		img := NewFromIdentifier("dummy=foo/bar:1.12")
 		assert.Equal(t, img.GetParameterUpdateStrategy(annotations), VersionSortLatest)
@@ -134,10 +130,6 @@ func Test_GetSortOption(t *testing.T) {
 		annotations := map[string]string{
 			fmt.Sprintf(common.UpdateStrategyAnnotation, "dummy"): "digest",
 			common.DefaultUpdateStrategyAnnotation:                "latest",
-			common.DefaultSecretListAnnotation:                    "env:FOOBAR",
-			common.DefaultForceUpdateOptionAnnotation:             "true",
-			common.DefaultAllowTagsOptionAnnotation:               "regexp:^.*$",
-			common.DefaultIgnoreTagsOptionAnnotation:              "foo-*",
 		}
 		img := NewFromIdentifier("dummy=foo/bar:1.12")
 		assert.Equal(t, img.GetParameterUpdateStrategy(annotations), VersionSortDigest)
@@ -151,7 +143,7 @@ func Test_GetMatchOption(t *testing.T) {
 			fmt.Sprintf(common.AllowTagsOptionAnnotation, "dummy"): "regexp:a-z",
 		}
 		img := NewFromIdentifier("dummy=foo/bar:1.12")
-		matchFunc, matchArgs := img.GetParameterMatch(annotations)
+		matchFunc, matchArgs := img.GetParameterAllowTags(annotations)
 		require.NotNil(t, matchFunc)
 		require.NotNil(t, matchArgs)
 		assert.IsType(t, &regexp.Regexp{}, matchArgs)
@@ -162,7 +154,7 @@ func Test_GetMatchOption(t *testing.T) {
 			fmt.Sprintf(common.AllowTagsOptionAnnotation, "dummy"): `regexp:/foo\`,
 		}
 		img := NewFromIdentifier("dummy=foo/bar:1.12")
-		matchFunc, matchArgs := img.GetParameterMatch(annotations)
+		matchFunc, matchArgs := img.GetParameterAllowTags(annotations)
 		require.NotNil(t, matchFunc)
 		require.Nil(t, matchArgs)
 	})
@@ -172,7 +164,7 @@ func Test_GetMatchOption(t *testing.T) {
 			fmt.Sprintf(common.AllowTagsOptionAnnotation, "dummy"): "invalid",
 		}
 		img := NewFromIdentifier("dummy=foo/bar:1.12")
-		matchFunc, matchArgs := img.GetParameterMatch(annotations)
+		matchFunc, matchArgs := img.GetParameterAllowTags(annotations)
 		require.NotNil(t, matchFunc)
 		require.Equal(t, false, matchFunc("", nil))
 		assert.Nil(t, matchArgs)
@@ -187,7 +179,7 @@ func Test_GetMatchOption(t *testing.T) {
 			common.DefaultIgnoreTagsOptionAnnotation:  "foo-*",
 		}
 		img := NewFromIdentifier("dummy=foo/bar:1.12")
-		matchFunc, matchArgs := img.GetParameterMatch(annotations)
+		matchFunc, matchArgs := img.GetParameterAllowTags(annotations)
 		require.NotNil(t, MatchFuncRegexp, matchFunc)
 		require.IsType(t, &regexp.Regexp{}, matchArgs)
 		assert.True(t, matchFunc("foo", matchArgs))
@@ -204,7 +196,7 @@ func Test_GetMatchOption(t *testing.T) {
 			common.DefaultIgnoreTagsOptionAnnotation:               "foo-*",
 		}
 		img := NewFromIdentifier("dummy=foo/bar:1.12")
-		matchFunc, matchArgs := img.GetParameterMatch(annotations)
+		matchFunc, matchArgs := img.GetParameterAllowTags(annotations)
 		require.NotNil(t, MatchFuncRegexp, matchFunc)
 		require.IsType(t, &regexp.Regexp{}, matchArgs)
 		assert.False(t, matchFunc("foo", matchArgs))


### PR DESCRIPTION
PR introduces the following Application-wide image options:

* `argocd-image-updater.argoproj.io/update-strategy`
* `argocd-image-updater.argoproj.io/force-update`
* `argocd-image-updater.argoproj.io/allow-tags`
* `argocd-image-updater.argoproj.io/ignore-tags`
* `argocd-image-updater.argoproj.io/pull-secret`

This allows to specify above as defaults for all images within a given Application. An image specific option will override the Application-wide setting.

Partly addresses #320 