### PR TITLE
chore: Move container images to quay.io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-IMAGE_NAMESPACE?=argoprojlabs
+IMAGE_NAMESPACE?=quay.io/argoprojlabs
 IMAGE_NAME=argocd-image-updater
 IMAGE_TAG?=latest
 ifdef IMAGE_NAMESPACE

--- a/manifests/base/deployment/argocd-image-updater-deployment.yaml
+++ b/manifests/base/deployment/argocd-image-updater-deployment.yaml
@@ -19,7 +19,7 @@ spec:
       - command:
         - /usr/local/bin/argocd-image-updater
         - run
-        image: argoprojlabs/argocd-image-updater:latest
+        image: quay.io/argoprojlabs/argocd-image-updater:latest
         imagePullPolicy: Always
         env:
         - name: APPLICATIONS_API

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 images:
-- name: argoprojlabs/argocd-image-updater
+- name: quay.io/argoprojlabs/argocd-image-updater
   newTag: latest
 
 bases:


### PR DESCRIPTION
Moves the container image from Docker Hub to quay.io and adapts some scripts.

Signed-off-by: jannfis <jann@mistrust.net>