### PR TITLE
fix: Do not retrieve metadata for all tags with digest strategy

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -51,10 +51,18 @@ func (endpoint *RegistryEndpoint) GetTags(img *image.ContainerImage, regClient R
 
 	tags := []string{}
 
-	// Loop through tags, removing those we do not want
-	if vc.MatchFunc != nil || len(vc.IgnoreList) > 0 {
+	// For digest strategy, we do require a version constraint
+	if vc.SortMode == image.VersionSortDigest {
+		if vc.Constraint == "" {
+			return nil, fmt.Errorf("cannot use digest strategy for image %s without a version constraint", img.Original())
+		}
+	}
+
+	// Loop through tags, removing those we do not want. If update strategy is
+	// digest, all but the constraint tag are ignored.
+	if vc.MatchFunc != nil || len(vc.IgnoreList) > 0 || vc.SortMode == image.VersionSortDigest {
 		for _, t := range tTags {
-			if (vc.MatchFunc != nil && !vc.MatchFunc(t, vc.MatchArgs)) || vc.IsTagIgnored(t) {
+			if (vc.MatchFunc != nil && !vc.MatchFunc(t, vc.MatchArgs)) || vc.IsTagIgnored(t) || (vc.SortMode == image.VersionSortDigest && t != vc.Constraint) {
 				log.Tracef("Removing tag %s because it either didn't match defined pattern or is ignored", t)
 			} else {
 				tags = append(tags, t)

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -52,10 +52,9 @@ func (endpoint *RegistryEndpoint) GetTags(img *image.ContainerImage, regClient R
 	tags := []string{}
 
 	// For digest strategy, we do require a version constraint
-	if vc.SortMode == image.VersionSortDigest {
-		if vc.Constraint == "" {
-			return nil, fmt.Errorf("cannot use digest strategy for image %s without a version constraint", img.Original())
-		}
+	if vc.SortMode == image.VersionSortDigest && vc.Constraint == "" {
+		return nil, fmt.Errorf("cannot use digest strategy for image %s without a version constraint", img.Original())
+	}
 	}
 
 	// Loop through tags, removing those we do not want. If update strategy is

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -55,7 +55,6 @@ func (endpoint *RegistryEndpoint) GetTags(img *image.ContainerImage, regClient R
 	if vc.SortMode == image.VersionSortDigest && vc.Constraint == "" {
 		return nil, fmt.Errorf("cannot use digest strategy for image %s without a version constraint", img.Original())
 	}
-	}
 
 	// Loop through tags, removing those we do not want. If update strategy is
 	// digest, all but the constraint tag are ignored.


### PR DESCRIPTION
When using digest update strategy, the Image Updater would have fetched metadata for all tags returned by the registry. For digest strategy, caching is also disabled and this leads to too many requests to the registry.

Now, only metadata for the tag specified in the version constraint is fetched. All other tags are skipped.

Fixes #313