### PR TITLE
feat: Support app-wide update-strategy annotations

### DIFF
--- a/docs/configuration/images.md
+++ b/docs/configuration/images.md
@@ -402,3 +402,21 @@ must be prefixed with `argocd-image-updater.argoproj.io`.
 |`<image_alias>.helm.image-name`|`image.name`|Name of the Helm parameter used for specifying the image name, i.e. holds `image/name`|
 |`<image_alias>.helm.image-tag`|`image.tag`|Name of the Helm parameter used for specifying the image tag, i.e. holds `1.0`|
 |`<image_alias>.kustomize.image-name`|*original name of image*|Name of Kustomize image parameter to set during updates|
+
+### Application-wide defaults
+
+If you want to update multiple images in an Application, that all share common
+settings (such as, update strategy, allowed tags, etc), you can define common
+options. These options are valid for all images, unless an image overrides it
+with specific configuration.
+
+The following annotations are available. Please note, all annotations must be
+prefixed with `argocd-image-updater.argoproj.io/`.
+
+|Annotation name|Description|
+|---------------|-----------|
+|`update-strategy`|The update strategy to be used for all images|
+|`force-update`|If set to "true" (with quotes), even images that are not currently deployed will be updated|
+|`allow-tags`|A function to match tag names from registry against to be considered for update|
+|`ignore-tags`|A comma-separated list of glob patterns that when match ignore a certain tag from the registry|
+|`pull-secret`|A reference to a secret to be used as registry credentials for this image|

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -419,7 +419,7 @@ func Test_UpdateApplication(t *testing.T) {
 					Name:      "guestbook",
 					Namespace: "guestbook",
 					Annotations: map[string]string{
-						fmt.Sprintf(common.SecretListAnnotation, "dummy"): "secret:foo/bar#creds",
+						fmt.Sprintf(common.PullSecretAnnotation, "dummy"): "secret:foo/bar#creds",
 					},
 				},
 				Spec: v1alpha1.ApplicationSpec{

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -26,19 +26,24 @@ const (
 	KustomizeApplicationNameAnnotation = ImageUpdaterAnnotationPrefix + "/%s.kustomize.image-name"
 )
 
-// Upgrade strategy related annotations
+// Image specific configuration annotations
 const (
 	OldMatchOptionAnnotation    = ImageUpdaterAnnotationPrefix + "/%s.tag-match" // Deprecated and will be removed
 	AllowTagsOptionAnnotation   = ImageUpdaterAnnotationPrefix + "/%s.allow-tags"
 	IgnoreTagsOptionAnnotation  = ImageUpdaterAnnotationPrefix + "/%s.ignore-tags"
 	ForceUpdateOptionAnnotation = ImageUpdaterAnnotationPrefix + "/%s.force-update"
 	UpdateStrategyAnnotation    = ImageUpdaterAnnotationPrefix + "/%s.update-strategy"
+	SecretListAnnotation        = ImageUpdaterAnnotationPrefix + "/%s.pull-secret"
 	PlatformsAnnotation         = ImageUpdaterAnnotationPrefix + "/%s.platforms"
 )
 
-// Image pull secret related annotations
+// Application-wide update strategy related annotations
 const (
-	SecretListAnnotation = ImageUpdaterAnnotationPrefix + "/%s.pull-secret"
+	ApplicationWideAllowTagsOptionAnnotation   = ImageUpdaterAnnotationPrefix + "/allow-tags"
+	ApplicationWideIgnoreTagsOptionAnnotation  = ImageUpdaterAnnotationPrefix + "/ignore-tags"
+	ApplicationWideForceUpdateOptionAnnotation = ImageUpdaterAnnotationPrefix + "/force-update"
+	ApplicationWideUpdateStrategyAnnotation    = ImageUpdaterAnnotationPrefix + "/update-strategy"
+	ApplicationWideSecretListAnnotation        = ImageUpdaterAnnotationPrefix + "/pull-secret"
 )
 
 // Application update configuration related annotations

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -33,7 +33,7 @@ const (
 	IgnoreTagsOptionAnnotation  = ImageUpdaterAnnotationPrefix + "/%s.ignore-tags"
 	ForceUpdateOptionAnnotation = ImageUpdaterAnnotationPrefix + "/%s.force-update"
 	UpdateStrategyAnnotation    = ImageUpdaterAnnotationPrefix + "/%s.update-strategy"
-	SecretListAnnotation        = ImageUpdaterAnnotationPrefix + "/%s.pull-secret"
+	PullSecretAnnotation        = ImageUpdaterAnnotationPrefix + "/%s.pull-secret"
 	PlatformsAnnotation         = ImageUpdaterAnnotationPrefix + "/%s.platforms"
 )
 
@@ -43,7 +43,7 @@ const (
 	ApplicationWideIgnoreTagsOptionAnnotation  = ImageUpdaterAnnotationPrefix + "/ignore-tags"
 	ApplicationWideForceUpdateOptionAnnotation = ImageUpdaterAnnotationPrefix + "/force-update"
 	ApplicationWideUpdateStrategyAnnotation    = ImageUpdaterAnnotationPrefix + "/update-strategy"
-	ApplicationWideSecretListAnnotation        = ImageUpdaterAnnotationPrefix + "/pull-secret"
+	ApplicationWidePullSecretAnnotation        = ImageUpdaterAnnotationPrefix + "/pull-secret"
 )
 
 // Application update configuration related annotations

--- a/pkg/image/options.go
+++ b/pkg/image/options.go
@@ -176,8 +176,8 @@ func (img *ContainerImage) ParseMatchfunc(val string) (MatchFuncFn, interface{})
 // GetParameterPullSecret retrieves an image's pull secret credentials
 func (img *ContainerImage) GetParameterPullSecret(annotations map[string]string) *CredentialSource {
 	pullSecretAnnotations := []string{
-		fmt.Sprintf(common.SecretListAnnotation, img.normalizedSymbolicName()),
-		common.ApplicationWideSecretListAnnotation,
+		fmt.Sprintf(common.PullSecretAnnotation, img.normalizedSymbolicName()),
+		common.ApplicationWidePullSecretAnnotation,
 	}
 	var pullSecretVal = ""
 	for _, key := range pullSecretAnnotations {

--- a/pkg/image/options_test.go
+++ b/pkg/image/options_test.go
@@ -203,7 +203,7 @@ func Test_GetMatchOption(t *testing.T) {
 func Test_GetSecretOption(t *testing.T) {
 	t.Run("Get cred source from annotation", func(t *testing.T) {
 		annotations := map[string]string{
-			fmt.Sprintf(common.SecretListAnnotation, "dummy"): "pullsecret:foo/bar",
+			fmt.Sprintf(common.PullSecretAnnotation, "dummy"): "pullsecret:foo/bar",
 		}
 		img := NewFromIdentifier("dummy=foo/bar:1.12")
 		credSrc := img.GetParameterPullSecret(annotations)
@@ -216,7 +216,7 @@ func Test_GetSecretOption(t *testing.T) {
 
 	t.Run("Invalid reference in annotation", func(t *testing.T) {
 		annotations := map[string]string{
-			fmt.Sprintf(common.SecretListAnnotation, "dummy"): "foo/bar",
+			fmt.Sprintf(common.PullSecretAnnotation, "dummy"): "foo/bar",
 		}
 		img := NewFromIdentifier("dummy=foo/bar:1.12")
 		credSrc := img.GetParameterPullSecret(annotations)
@@ -225,8 +225,8 @@ func Test_GetSecretOption(t *testing.T) {
 
 	t.Run("Prefer cred source from image-specific annotation", func(t *testing.T) {
 		annotations := map[string]string{
-			fmt.Sprintf(common.SecretListAnnotation, "dummy"): "pullsecret:image/specific",
-			common.ApplicationWideSecretListAnnotation:        "pullsecret:app/wide",
+			fmt.Sprintf(common.PullSecretAnnotation, "dummy"): "pullsecret:image/specific",
+			common.ApplicationWidePullSecretAnnotation:        "pullsecret:app/wide",
 		}
 		img := NewFromIdentifier("dummy=foo/bar:1.12")
 		credSrc := img.GetParameterPullSecret(annotations)
@@ -239,7 +239,7 @@ func Test_GetSecretOption(t *testing.T) {
 
 	t.Run("Get cred source from application-wide annotation", func(t *testing.T) {
 		annotations := map[string]string{
-			common.ApplicationWideSecretListAnnotation: "pullsecret:app/wide",
+			common.ApplicationWidePullSecretAnnotation: "pullsecret:app/wide",
 		}
 		img := NewFromIdentifier("dummy=foo/bar:1.12")
 		credSrc := img.GetParameterPullSecret(annotations)


### PR DESCRIPTION
# Problem

Currently, you're forced to specify e.g the update strategy per image, although it might be the same for all:

```yaml
# ...
metadata:
  annotations:
    argocd-image-updater.argoproj.io/image-list: frontend=my-fancy-frontend, backend=my-fancy-backend
    argocd-image-updater.argoproj.io/frontend.update-strategy: name
    argocd-image-updater.argoproj.io/backend.update-strategy: name
# ...
```

# Proposal

This PR adds four new annotations to allow you to specify update-strategy related options for all images in a ArgoCD application.

* `argocd-image-updater.argoproj.io/allow-tags`
* `argocd-image-updater.argoproj.io/ignore-tags`
* `argocd-image-updater.argoproj.io/force-update`
* `argocd-image-updater.argoproj.io/update-strategy`
* `argocd-image-updater.argoproj.io/pull-secret`

<sub>(**Note:** I am using the update-strategy annotations for all of my following examples, but the handling is the same of all of them)</sub>

With these new annotations you can use only one annotations to specify it for all of them:

```yaml
# ...
metadata:
  annotations:
    argocd-image-updater.argoproj.io/image-list: frontend=my-fancy-frontend, backend=my-fancy-backend
    argocd-image-updater.argoproj.io/update-strategy: name
# ...
```

You can still override the app-wide configuration by adding the image-based annotation:

```yaml
# ...
metadata:
  annotations:
    argocd-image-updater.argoproj.io/image-list: frontend=my-fancy-frontend, backend=my-fancy-backend
    argocd-image-updater.argoproj.io/update-strategy: name
    argocd-image-updater.argoproj.io/frontend.update-strategy: semver
# ...
```

### Order

When configuring these annotations, that's the order of how the options get evaluated:

| # | Annotation | Description |
| :-: | --- | --- |
| 1 | `argocd-image-updater.argoproj.io/<alias>.<option>` | for specific image |
| 2 | `argocd-image-updater.argoproj.io/update-strategy` | for all images (app-wide) |
| 3 | _-/-_ | default |

# Additional changes

* Renamed `SecretListAnnotation` to `PullSecretAnnotation`
* Renamed `ApplicationWideSecretListAnnotation` to `ApplicationWidePullSecretAnnotation`