### PR TITLE
chore: Multi-arch distribution

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -1,0 +1,41 @@
+name: Build and push image
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+    types: [ labeled, unlabeled, opened, synchronize, reopened ]
+
+jobs:
+  publish:
+    if: github.repository == 'argoprojlabs/argocd-image-updater'
+    runs-on: ubuntu-latest
+    steps:
+      # build
+      - uses: actions/checkout@v2
+      - uses: docker/setup-qemu-action@v1
+      - uses: docker/setup-buildx-action@v1
+      - run: |
+          MULTIARCH=no
+          PUSH=no
+          if [[ "${{ github.event_name }}" == "push"; then
+            MULTIARCH=yes
+            PUSH=yes
+          elif "${{ contains(github.event.pull_request.labels.*.name, 'test-arm-image') }}" == "true" ]]; then
+            MULTIARCH=yes
+          fi
+          if [[ "${PUSH}" == "yes"; then
+            docker login --username "${DOCKER_USERNAME}" --password "${DOCKER_TOKEN}" quay.io
+          fi
+          if [[ "${MULTIARCH}" = "yes" ]]; then
+            IMAGE_PUSH=${PUSH} make multiarch-image
+          else
+            make image
+          fi
+        working-directory: ./argocd-image-updater
+        env:
+          DOCKER_USERNAME: ${{ secrets.QUAY_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.QUAY_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ IMAGE_PREFIX=${IMAGE_NAMESPACE}/
 else
 IMAGE_PREFIX=
 endif
+IMAGE_PUSH?=no
 OS?=$(shell go env GOOS)
 ARCH?=$(shell go env GOARCH)
 OUTDIR?=dist
@@ -21,6 +22,11 @@ LDFLAGS=
 RELEASE_IMAGE_PLATFORMS?=linux/amd64,linux/arm64
 
 VERSION_PACKAGE=github.com/argoproj-labs/argocd-image-updater/pkg/version
+ifeq ($(IMAGE_PUSH), yes)
+DOCKERX_PUSH=--push
+else
+DOCKERX_PUSH=
+endif
 
 override LDFLAGS += -extldflags "-static"
 override LDFLAGS += \
@@ -72,8 +78,8 @@ image: clean-image mod-vendor
 multiarch-image:
 	docker buildx build \
 		-t ${IMAGE_PREFIX}${IMAGE_NAME}:${IMAGE_TAG} \
-		--platform ${RELEASE_IMAGE_PLATFORMS} \
-		--load \
+		--progress plain \
+		--platform ${RELEASE_IMAGE_PLATFORMS} ${DOCKERX_PUSH} \
 		.
 
 .PHONY: image-push

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ BUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 
 LDFLAGS=
 
+RELEASE_IMAGE_PLATFORMS?=linux/amd64,linux/arm64
+
 VERSION_PACKAGE=github.com/argoproj-labs/argocd-image-updater/pkg/version
 
 override LDFLAGS += -extldflags "-static"
@@ -67,6 +69,13 @@ image: clean-image mod-vendor
 	docker build -t ${IMAGE_PREFIX}${IMAGE_NAME}:${IMAGE_TAG} .
 	rm -rf vendor/
 
+multiarch-image:
+	docker buildx build \
+		-t ${IMAGE_PREFIX}${IMAGE_NAME}:${IMAGE_TAG} \
+		--platform ${RELEASE_IMAGE_PLATFORMS} \
+		--load \
+		.
+
 .PHONY: image-push
 image-push: image
 	docker push ${IMAGE_PREFIX}${IMAGE_NAME}:${IMAGE_TAG}
@@ -77,6 +86,7 @@ release-binaries:
 	BINNAME=argocd-image-updater-linux_arm64 OUTDIR=dist/release OS=linux ARCH=arm64 make controller
 	BINNAME=argocd-image-updater-darwin_amd64 OUTDIR=dist/release OS=darwin ARCH=amd64 make controller
 	BINNAME=argocd-image-updater-darwin_arm64 OUTDIR=dist/release OS=darwin ARCH=arm64 make controller
+	BINNAME=argocd-image-updater-win64.exe OUTDIR=dist/release OS=windows ARCH=amd64 make controller
 
 .PHONY: extract-binary
 extract-binary:

--- a/hack/upload-multiarch-release-assets.sh
+++ b/hack/upload-multiarch-release-assets.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+set -eu
+set -o pipefail
+
+if ! test -f VERSION; then
+	echo "Error: VERSION file not found" >&2
+    exit 1
+fi
+
+TARGET_VERSION="v$(cat VERSION)"
+
+if ! test -d dist/release; then
+    echo "Error: dist/release directory does not exist" >&2
+    exit 1
+fi
+
+cd dist/release
+rm -f release-${TARGET_VERSION}.sha256 release-${TARGET_VERSION}.sha256.asc
+BINARIES=
+echo "*** Generating SHA256 checksums for binaries"
+for bin in argocd-image-updater-*; do
+    sha256sum $bin >> release-${TARGET_VERSION}.sha256
+    BINARIES="${BINARIES} $bin"
+done
+
+echo "*** Signing checksum file with GPG key"
+gpg -a --detach-sign release-${TARGET_VERSION}.sha256
+
+echo "*** Reverse verify signature"
+gpg -a --verify release-${TARGET_VERSION}.sha256.asc
+
+echo "*** Uploading release assets"
+for asset in ${BINARIES} ${TARGET_VERSION}.sha256 ${TARGET_VERSION}.sha256.asc; do
+    echo "     -> $asset"
+    echo gh release upload ${TARGET_VERSION} ${asset}
+done
+
+echo "Done."


### PR DESCRIPTION
PR adds support for building `linux/amd64` and `linux/arm64` container images for Argo CD Image Updater.

Also adds a Makefile target to build binaries for `linux/arm64`, `linux/arm`, `darwin/amd64`, `darwin/arm64` and `windows/amd64` and support signing release assets using PGP.