### PR TITLE
fix: Fetch metadata for multi-arch images with latest strategy

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -102,6 +102,10 @@ argocd-image-updater test nginx --allow-tags '^1.19.\d+(\-.*)*$' --update-strate
 				vc.Options = vc.Options.WithPlatform(os, arch, variant)
 			}
 
+			if vc.SortMode == image.VersionSortLatest {
+				vc.Options = vc.Options.WithMetadata()
+			}
+
 			if registriesConfPath != "" {
 				if err := registry.LoadRegistryConfiguration(registriesConfPath, false); err != nil {
 					log.Fatalf("could not load registries configuration: %v", err)

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -99,11 +99,9 @@ argocd-image-updater test nginx --allow-tags '^1.19.\d+(\-.*)*$' --update-strate
 				if err != nil {
 					log.Fatalf("Platform %s: %v", platform, err)
 				}
-				vc.Options = vc.Options.WithPlatform(os, arch, variant)
-			}
-
-			if vc.SortMode == image.VersionSortLatest {
-				vc.Options = vc.Options.WithMetadata()
+				vc.Options = vc.Options.
+					WithPlatform(os, arch, variant).
+					WithMetadata(vc.SortMode.NeedsMetadata())
 			}
 
 			if registriesConfPath != "" {

--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -199,6 +199,10 @@ func UpdateApplication(updateConf *UpdateConfiguration, state *SyncIterationStat
 		vc.IgnoreList = applicationImage.GetParameterIgnoreTags(updateConf.UpdateApp.Application.Annotations)
 		vc.Options = applicationImage.GetPlatformOptions(updateConf.UpdateApp.Application.Annotations, updateConf.IgnorePlatforms)
 
+		if vc.SortMode == image.VersionSortLatest {
+			vc.Options = vc.Options.WithMetadata()
+		}
+
 		// The endpoint can provide default credentials for pulling images
 		err = rep.SetEndpointCredentials(updateConf.KubeClient)
 		if err != nil {

--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -197,11 +197,7 @@ func UpdateApplication(updateConf *UpdateConfiguration, state *SyncIterationStat
 		vc.SortMode = applicationImage.GetParameterUpdateStrategy(updateConf.UpdateApp.Application.Annotations)
 		vc.MatchFunc, vc.MatchArgs = applicationImage.GetParameterMatch(updateConf.UpdateApp.Application.Annotations)
 		vc.IgnoreList = applicationImage.GetParameterIgnoreTags(updateConf.UpdateApp.Application.Annotations)
-		vc.Options = applicationImage.GetPlatformOptions(updateConf.UpdateApp.Application.Annotations, updateConf.IgnorePlatforms)
-
-		if vc.SortMode == image.VersionSortLatest {
-			vc.Options = vc.Options.WithMetadata()
-		}
+		vc.Options = applicationImage.GetPlatformOptions(updateConf.UpdateApp.Application.Annotations, updateConf.IgnorePlatforms).WithMetadata(vc.SortMode.NeedsMetadata())
 
 		// The endpoint can provide default credentials for pulling images
 		err = rep.SetEndpointCredentials(updateConf.KubeClient)

--- a/pkg/image/version.go
+++ b/pkg/image/version.go
@@ -165,3 +165,13 @@ func (vsm VersionSortMode) IsCacheable() bool {
 		return true
 	}
 }
+
+// NeedsMetadata returns true if v requires image metadata to work correctly
+func (vsm VersionSortMode) NeedsMetadata() bool {
+	switch vsm {
+	case VersionSortLatest:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -75,13 +75,7 @@ func (o *ManifestOptions) WantsMetadata() bool {
 }
 
 // WithMetadata sets metadata to be requested
-func (o *ManifestOptions) WithMetadata() *ManifestOptions {
-	o.metadata = true
-	return o
-}
-
-// WithoutMetadata sets metadata not not be requested
-func (o *ManifestOptions) WithoutMetadata() *ManifestOptions {
-	o.metadata = false
+func (o *ManifestOptions) WithMetadata(val bool) *ManifestOptions {
+	o.metadata = val
 	return o
 }

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -70,7 +70,7 @@ func (o *ManifestOptions) Platforms() []string {
 }
 
 // WantsMetdata returns true if metadata should be requested
-func (o *ManifestOptions) WantsMetdata() bool {
+func (o *ManifestOptions) WantsMetadata() bool {
 	return o.metadata
 }
 

--- a/pkg/options/options_test.go
+++ b/pkg/options/options_test.go
@@ -42,15 +42,15 @@ func Test_WantsPlatform(t *testing.T) {
 func Test_WantsMetadata(t *testing.T) {
 	opts := NewManifestOptions()
 	t.Run("Empty options", func(t *testing.T) {
-		assert.False(t, opts.WantsMetdata())
+		assert.False(t, opts.WantsMetadata())
 	})
 	t.Run("Wants metadata", func(t *testing.T) {
 		opts = opts.WithMetadata()
-		assert.True(t, opts.WantsMetdata())
+		assert.True(t, opts.WantsMetadata())
 	})
 	t.Run("Does not want metadata", func(t *testing.T) {
 		opts = opts.WithoutMetadata()
-		assert.False(t, opts.WantsMetdata())
+		assert.False(t, opts.WantsMetadata())
 	})
 }
 

--- a/pkg/options/options_test.go
+++ b/pkg/options/options_test.go
@@ -45,11 +45,11 @@ func Test_WantsMetadata(t *testing.T) {
 		assert.False(t, opts.WantsMetadata())
 	})
 	t.Run("Wants metadata", func(t *testing.T) {
-		opts = opts.WithMetadata()
+		opts = opts.WithMetadata(true)
 		assert.True(t, opts.WantsMetadata())
 	})
 	t.Run("Does not want metadata", func(t *testing.T) {
-		opts = opts.WithoutMetadata()
+		opts = opts.WithMetadata(false)
 		assert.False(t, opts.WantsMetadata())
 	})
 }

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -276,7 +276,7 @@ func (client *registryClient) TagMetadata(manifest distribution.Manifest, opts *
 
 		// For some strategies, we do not need to fetch metadata for further
 		// processing.
-		if !opts.WantsMetdata() {
+		if !opts.WantsMetadata() {
 			return ti, nil
 		}
 


### PR DESCRIPTION
Small bugfix for `latest` update strategy and multi-arch images

Signed-off-by: jannfis <jann@mistrust.net>