### PR TITLE
fix: Use endpoint's transport also for token handler

### DIFF
--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -105,7 +105,7 @@ func (clt *registryClient) NewRepository(nameInRepository string) error {
 	authTransport := transport.NewTransport(
 		clt.endpoint.GetTransport(), auth.NewAuthorizer(
 			challengeManager1,
-			auth.NewTokenHandler(nil, clt.creds, nameInRepository, "pull"),
+			auth.NewTokenHandler(clt.endpoint.GetTransport(), clt.creds, nameInRepository, "pull"),
 			auth.NewBasicHandler(clt.creds)))
 
 	rlt := &rateLimitTransport{


### PR DESCRIPTION
Use the registry endpoint's transport settings when fetching token for authentication.

Signed-off-by: jannfis <jann@mistrust.net>