### PR TITLE
fix: Use existing registry requests failed metric

### DIFF
--- a/config/example-grafana-dashboard.json
+++ b/config/example-grafana-dashboard.json
@@ -515,7 +515,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum by (registry) (increase(argocd_image_updater_registry_errors_total[1m]))",
+          "expr": "sum by (registry) (increase(argocd_image_updater_registry_requests_failed_total[1m]))",
           "interval": "",
           "legendFormat": "{{registry}} | errors",
           "refId": "B"

--- a/docs/install/start.md
+++ b/docs/install/start.md
@@ -306,7 +306,7 @@ The following metrics are being made available:
 * Number of requests to the container registries (successful and failed)
 
     * `argocd_image_updater_registry_requests_total`
-    * `argocd_image_updater_registry_errors_total`
+    * `argocd_image_updater_registry_requests_failed_total`
 
 A (very) rudimentary example dashboard definition for Grafana is provided
 [here](https://github.com/argoproj-labs/argocd-image-updater/tree/master/config)


### PR DESCRIPTION
This PR fixes the issue raised at https://github.com/argoproj-labs/argocd-image-updater/issues/314

The documentation and the grafana dashboard example are pointing to a not implemented metric instead point to the correct one `argocd_image_updater_registry_requests_failed_total`