### PR TITLE
chore: Log out warning about tagsortmode

### DIFF
--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -202,6 +202,12 @@ func UpdateApplication(updateConf *UpdateConfiguration, state *SyncIterationStat
 			WithMetadata(vc.Strategy.NeedsMetadata()).
 			WithLogger(imgCtx.AddField("application", app))
 
+		// If a strategy needs meta-data and tagsortmode is set for the
+		// registry, let the user know.
+		if rep.TagListSort > registry.TagListSortUnsorted && vc.Strategy.NeedsMetadata() {
+			imgCtx.Infof("taglistsort is set to '%s' but update strategy '%s' requires metadata. Results may not be what you expect.", rep.TagListSort.String(), vc.Strategy.String())
+		}
+
 		// The endpoint can provide default credentials for pulling images
 		err = rep.SetEndpointCredentials(updateConf.KubeClient)
 		if err != nil {

--- a/pkg/image/version.go
+++ b/pkg/image/version.go
@@ -24,6 +24,21 @@ const (
 	StrategyDigest UpdateStrategy = 3
 )
 
+func (us UpdateStrategy) String() string {
+	switch us {
+	case StrategySemVer:
+		return "semver"
+	case StrategyLatest:
+		return "latest"
+	case StrategyName:
+		return "name"
+	case StrategyDigest:
+		return "digest"
+	}
+
+	return "unknown"
+}
+
 // ConstraintMatchMode defines how the constraint should be matched
 type ConstraintMatchMode int
 

--- a/pkg/registry/config.go
+++ b/pkg/registry/config.go
@@ -50,6 +50,9 @@ func LoadRegistryConfiguration(path string, clear bool) error {
 
 	for _, reg := range registryList.Items {
 		tagSortMode := TagListSortFromString(reg.TagSortMode)
+		if tagSortMode != TagListSortUnsorted {
+			log.Warnf("Registry %s has tag sort mode set to %s, meta data retrieval will be disabled for this registry.", reg.ApiURL, tagSortMode)
+		}
 		err = AddRegistryEndpoint(reg.Prefix, reg.Name, reg.ApiURL, reg.Credentials, reg.DefaultNS, reg.Insecure, tagSortMode, reg.Limit, reg.CredsExpire)
 		if err != nil {
 			return err
@@ -85,9 +88,7 @@ func ParseRegistryConfiguration(yamlSource string) (RegistryList, error) {
 		}
 
 		if err == nil {
-			switch registry.TagSortMode {
-			case "latest-first", "latest-last", "none", "":
-			default:
+			if tls := TagListSortFromString(registry.TagSortMode); tls == TagListSortUnknown {
 				err = fmt.Errorf("unknown tag sort mode for registry %s: %s", registry.Name, registry.TagSortMode)
 			}
 		}

--- a/pkg/registry/endpoints.go
+++ b/pkg/registry/endpoints.go
@@ -19,9 +19,14 @@ import (
 type TagListSort int
 
 const (
-	SortUnsorted    TagListSort = 0
-	SortLatestFirst TagListSort = 1
-	SortLatestLast  TagListSort = 2
+	TagListSortUnknown           TagListSort = -1
+	TagListSortUnsorted          TagListSort = 0
+	TagListSortLatestFirst       TagListSort = 1
+	TagListSortLatestLast        TagListSort = 2
+	TagListSortUnsortedString    string      = "unsorted"
+	TagListSortLatestFirstString string      = "latest-first"
+	TagListSortLatestLastString  string      = "latest-last"
+	TagListSortUnknownString     string      = "unknown"
 )
 
 const (
@@ -31,22 +36,36 @@ const (
 
 // IsTimeSorted returns whether a tag list is time sorted
 func (tls TagListSort) IsTimeSorted() bool {
-	return tls == SortLatestFirst || tls == SortLatestLast
+	return tls == TagListSortLatestFirst || tls == TagListSortLatestLast
 }
 
 // TagListSortFromString gets the TagListSort value from a given string
 func TagListSortFromString(tls string) TagListSort {
 	switch strings.ToLower(tls) {
 	case "latest-first":
-		return SortLatestFirst
+		return TagListSortLatestFirst
 	case "latest-last":
-		return SortLatestLast
+		return TagListSortLatestLast
 	case "none", "":
-		return SortUnsorted
+		return TagListSortUnsorted
 	default:
 		log.Warnf("unknown tag list sort mode: %s", tls)
-		return SortUnsorted
+		return TagListSortUnknown
 	}
+}
+
+// String returns the string representation of a TagListSort value
+func (tls TagListSort) String() string {
+	switch tls {
+	case TagListSortLatestFirst:
+		return TagListSortLatestFirstString
+	case TagListSortLatestLast:
+		return TagListSortLatestLastString
+	case TagListSortUnsorted:
+		return TagListSortUnsortedString
+	}
+
+	return TagListSortUnknownString
 }
 
 // RegistryEndpoint holds information on how to access any specific registry API

--- a/pkg/registry/endpoints_test.go
+++ b/pkg/registry/endpoints_test.go
@@ -31,7 +31,7 @@ func Test_GetEndpoints(t *testing.T) {
 
 func Test_AddEndpoint(t *testing.T) {
 	t.Run("Add new endpoint", func(t *testing.T) {
-		err := AddRegistryEndpoint("example.com", "Example", "https://example.com", "", "", false, SortUnsorted, 5, 0)
+		err := AddRegistryEndpoint("example.com", "Example", "https://example.com", "", "", false, TagListSortUnsorted, 5, 0)
 		require.NoError(t, err)
 	})
 	t.Run("Get example.com endpoint", func(t *testing.T) {
@@ -43,17 +43,17 @@ func Test_AddEndpoint(t *testing.T) {
 		assert.Equal(t, ep.RegistryAPI, "https://example.com")
 		assert.Equal(t, ep.Insecure, false)
 		assert.Equal(t, ep.DefaultNS, "")
-		assert.Equal(t, ep.TagListSort, SortUnsorted)
+		assert.Equal(t, ep.TagListSort, TagListSortUnsorted)
 	})
 	t.Run("Change existing endpoint", func(t *testing.T) {
-		err := AddRegistryEndpoint("example.com", "Example", "https://example.com", "", "library", true, SortLatestFirst, 5, 0)
+		err := AddRegistryEndpoint("example.com", "Example", "https://example.com", "", "library", true, TagListSortLatestFirst, 5, 0)
 		require.NoError(t, err)
 		ep, err := GetRegistryEndpoint("example.com")
 		require.NoError(t, err)
 		require.NotNil(t, ep)
 		assert.Equal(t, ep.Insecure, true)
 		assert.Equal(t, ep.DefaultNS, "library")
-		assert.Equal(t, ep.TagListSort, SortLatestFirst)
+		assert.Equal(t, ep.TagListSort, TagListSortLatestFirst)
 	})
 }
 
@@ -122,22 +122,22 @@ func Test_DeepCopy(t *testing.T) {
 func Test_GetTagListSortFromString(t *testing.T) {
 	t.Run("Get latest-first sorting", func(t *testing.T) {
 		tls := TagListSortFromString("latest-first")
-		assert.Equal(t, SortLatestFirst, tls)
+		assert.Equal(t, TagListSortLatestFirst, tls)
 	})
 	t.Run("Get latest-last sorting", func(t *testing.T) {
 		tls := TagListSortFromString("latest-last")
-		assert.Equal(t, SortLatestLast, tls)
+		assert.Equal(t, TagListSortLatestLast, tls)
 	})
 	t.Run("Get none sorting explicit", func(t *testing.T) {
 		tls := TagListSortFromString("none")
-		assert.Equal(t, SortUnsorted, tls)
+		assert.Equal(t, TagListSortUnsorted, tls)
 	})
 	t.Run("Get none sorting implicit", func(t *testing.T) {
 		tls := TagListSortFromString("")
-		assert.Equal(t, SortUnsorted, tls)
+		assert.Equal(t, TagListSortUnsorted, tls)
 	})
-	t.Run("Get none sorting from unknown", func(t *testing.T) {
+	t.Run("Get unknown sorting from unknown string", func(t *testing.T) {
 		tls := TagListSortFromString("unknown")
-		assert.Equal(t, SortUnsorted, tls)
+		assert.Equal(t, TagListSortUnknown, tls)
 	})
 }

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -83,9 +83,9 @@ func (endpoint *RegistryEndpoint) GetTags(img *image.ContainerImage, regClient R
 	if (vc.Strategy != image.StrategyLatest && vc.Strategy != image.StrategyDigest) || endpoint.TagListSort.IsTimeSorted() {
 		for i, tagStr := range tags {
 			var ts int
-			if endpoint.TagListSort == SortLatestFirst {
+			if endpoint.TagListSort == TagListSortLatestFirst {
 				ts = len(tags) - i
-			} else if endpoint.TagListSort == SortLatestLast {
+			} else if endpoint.TagListSort == TagListSortLatestLast {
 				ts = i
 			}
 			imgTag := tag.NewImageTag(tagStr, time.Unix(int64(ts), 0), "")


### PR DESCRIPTION
We have bad examples in the docs regarding `tagsortmode` registry setting.

This change logs a warning if user has specified `tagsortmode` in the configuration.

Also, some refactoring included.

Signed-off-by: jannfis <jann@mistrust.net>