### PR TITLE
fix(manifests): Set deployment strategy to recreate to prevent concurrent replicas

### DIFF
--- a/manifests/base/deployment/argocd-image-updater-deployment.yaml
+++ b/manifests/base/deployment/argocd-image-updater-deployment.yaml
@@ -10,6 +10,8 @@ spec:
   selector:
    matchLabels:
     app.kubernetes.io/name: argocd-image-updater
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -85,6 +85,8 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: argocd-image-updater
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:


### PR DESCRIPTION
Set `strategy: Recreate` to stop rolling deployments with concurrent replicas

- Fixes #359

---

Looks like the workflow uses Kustomize 2.0.2. Newer versions replace `bases` with `resources` (see  b432ebe), which seems to [cause the `make manifests` check to fail](https://github.com/argoproj-labs/argocd-image-updater/runs/4909466408?check_suite_focus=true).

I used the following which failed, so I reverted the change it made.

```
{Version:kustomize/v4.4.1 GitCommit:b2d65ddc98e09187a8e38adc27c30bab078c1dbf BuildDate:2021-11-11T23:27:14Z GoOs:darwin GoArch:amd64}
```