### PR TITLE
fix: Hardcode buildDate so it can be updated by ld at build time

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -3,12 +3,11 @@ package version
 import (
 	"fmt"
 	"runtime"
-	"time"
 )
 
 var (
 	version    = "9.9.99"
-	buildDate  = time.Now().UTC().Format(time.RFC3339)
+	buildDate  = "1970-01-01T00:00:00Z"
 	gitCommit  = "unknown"
 	binaryName = "argocd-image-updater"
 )


### PR DESCRIPTION
Using the static string as done in `argocd`:

https://github.com/argoproj/argo-cd/blob/b37eee1054e42c873699460dd5e2447c2f9fe5a6/common/version.go#L12

Fixes #366 