### PR TITLE
feat: support filtering apps by label in CLI

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -40,6 +40,7 @@ type ImageUpdaterConfig struct {
 	MetricsPort         int
 	RegistriesConf      string
 	AppNamePatterns     []string
+	AppLabel            string
 	GitCommitUser       string
 	GitCommitMail       string
 	GitCommitMessage    *template.Template

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -218,6 +218,7 @@ func newRunCommand() *cobra.Command {
 	runCmd.Flags().IntVar(&cfg.MaxConcurrency, "max-concurrency", 10, "maximum number of update threads to run concurrently")
 	runCmd.Flags().StringVar(&cfg.ArgocdNamespace, "argocd-namespace", "", "namespace where ArgoCD runs in (current namespace by default)")
 	runCmd.Flags().StringSliceVar(&cfg.AppNamePatterns, "match-application-name", nil, "patterns to match application name against")
+	runCmd.Flags().StringVar(&cfg.AppLabel, "match-application-label", "", "label to match application labels against")
 	runCmd.Flags().BoolVar(&warmUpCache, "warmup-cache", true, "whether to perform a cache warm-up on startup")
 	runCmd.Flags().StringVar(&cfg.GitCommitUser, "git-commit-user", env.GetStringVal("GIT_COMMIT_USER", "argocd-image-updater"), "Username to use for Git commits")
 	runCmd.Flags().StringVar(&cfg.GitCommitMail, "git-commit-email", env.GetStringVal("GIT_COMMIT_EMAIL", "noreply@argoproj.io"), "E-Mail address to use for Git commits")
@@ -259,7 +260,7 @@ func runImageUpdater(cfg *ImageUpdaterConfig, warmUp bool) (argocd.ImageUpdaterR
 
 	// Get the list of applications that are allowed for updates, that is, those
 	// applications which have correct annotation.
-	appList, err := argocd.FilterApplicationsForUpdate(apps, cfg.AppNamePatterns)
+	appList, err := argocd.FilterApplicationsForUpdate(apps, cfg.AppNamePatterns, cfg.AppLabel)
 	if err != nil {
 		return result, err
 	}

--- a/docs/install/running.md
+++ b/docs/install/running.md
@@ -116,6 +116,16 @@ style wildcards, i.e. `*-staging` would match any application name with a
 suffix of `-staging`. Can be specified multiple times to define more than
 one pattern, from which at least one has to match.
 
+**--match-application-label *label* **
+
+Only process applications that have a valid annotation and match the given
+*label*. The *label* is a string that matches the standard kubernetes label 
+syntax of `key=value`. For e.g, `custom.label/name=xyz` would be a valid label
+that can be supplied through this parameter. Any applications carrying this 
+exact label will be considered as candidates for image updates. This parameter
+currently does not support patten matching on label values (e.g `customer.label/name=*-staging`)
+and only accepts a single label to match applications against. 
+
 **--max-concurrency *number* **
 
 Process a maximum of *number* applications concurrently. To disable concurrent


### PR DESCRIPTION
This PR addresses issue #258 
It adds a new CLI parameter `--match-application-label` which accepts a string label input to match applications against
It currently only accepts a single label to filter against, and does not support pattern matching on label values, but those enhancements can be made in future PRs 

steps to test out PR:
- create annotated apps containing 1 or more labels 
- set up argocd-image-updater account & token as per documented steps
- run argocd-image-updater binary with additional  parameter `--match-application-label` and supply desired label

application should be updated with new image after sync