### PR TITLE
feat: Automatic inferring of registry from image prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,9 @@ mod-vendor:
 test:
 	go test -coverprofile coverage.out `go list ./... | egrep -v '(test|mocks|ext/)'`
 
+test-race:
+	go test -race -coverprofile coverage.out `go list ./... | egrep -v '(test|mocks|ext/)'`
+
 .PHONY: prereq
 prereq:
 	mkdir -p dist

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -839,11 +839,11 @@ func Test_UpdateApplication(t *testing.T) {
 		assert.Equal(t, 0, res.NumImagesUpdated)
 	})
 
-	t.Run("Error - unknown registry", func(t *testing.T) {
+	t.Run("Update from infered registry", func(t *testing.T) {
 		mockClientFn := func(endpoint *registry.RegistryEndpoint, username, password string) (registry.RegistryClient, error) {
 			regMock := regmock.RegistryClient{}
 			regMock.On("NewRepository", mock.Anything).Return(nil)
-			regMock.On("Tags", mock.Anything).Return([]string{"1.0.1"}, nil)
+			regMock.On("Tags", mock.Anything).Return([]string{"1.0.1", "1.0.2"}, nil)
 			return &regMock, nil
 		}
 
@@ -863,7 +863,7 @@ func Test_UpdateApplication(t *testing.T) {
 					Source: v1alpha1.ApplicationSource{
 						Kustomize: &v1alpha1.ApplicationSourceKustomize{
 							Images: v1alpha1.KustomizeImages{
-								"example.io/jannfis/foobar:1.0.1",
+								"example.io/jannfis/example:1.0.1",
 							},
 						},
 					},
@@ -872,13 +872,13 @@ func Test_UpdateApplication(t *testing.T) {
 					SourceType: v1alpha1.ApplicationSourceTypeKustomize,
 					Summary: v1alpha1.ApplicationSummary{
 						Images: []string{
-							"example.io/jannfis/foobar:1.0.1",
+							"example.io/jannfis/example:1.0.1",
 						},
 					},
 				},
 			},
 			Images: image.ContainerImageList{
-				image.NewFromIdentifier("example.io/jannfis/foobar:1.0.1"),
+				image.NewFromIdentifier("example.io/jannfis/example:1.0.x"),
 			},
 		}
 		res := UpdateApplication(&UpdateConfiguration{
@@ -888,11 +888,11 @@ func Test_UpdateApplication(t *testing.T) {
 			UpdateApp:  appImages,
 			DryRun:     false,
 		}, NewSyncIterationState())
-		assert.Equal(t, 1, res.NumErrors)
+		assert.Equal(t, 0, res.NumErrors)
 		assert.Equal(t, 0, res.NumSkipped)
 		assert.Equal(t, 1, res.NumApplicationsProcessed)
 		assert.Equal(t, 1, res.NumImagesConsidered)
-		assert.Equal(t, 0, res.NumImagesUpdated)
+		assert.Equal(t, 1, res.NumImagesUpdated)
 	})
 
 	t.Run("Test error on generic registry client failure", func(t *testing.T) {

--- a/pkg/registry/config.go
+++ b/pkg/registry/config.go
@@ -70,6 +70,7 @@ func LoadRegistryConfiguration(path string, clear bool) error {
 				return fmt.Errorf("cannot set registry %s as default - only one default registry allowed, currently set to %s", ep.RegistryPrefix, dep.RegistryPrefix)
 			}
 		}
+
 		if err := AddRegistryEndpoint(ep); err != nil {
 			return err
 		}
@@ -127,8 +128,12 @@ func ParseRegistryConfiguration(yamlSource string) (RegistryList, error) {
 func RestoreDefaultRegistryConfiguration() {
 	registryLock.Lock()
 	defer registryLock.Unlock()
+	defaultRegistry = nil
 	registries = make(map[string]*RegistryEndpoint)
 	for k, v := range registryTweaks {
 		registries[k] = v.DeepCopy()
+		if v.IsDefault {
+			SetDefaultRegistry(registries[k])
+		}
 	}
 }

--- a/pkg/registry/config.go
+++ b/pkg/registry/config.go
@@ -23,11 +23,18 @@ type RegistryConfiguration struct {
 	Insecure    bool          `yaml:"insecure,omitempty"`
 	DefaultNS   string        `yaml:"defaultns,omitempty"`
 	Limit       int           `yaml:"limit,omitempty"`
+	IsDefault   bool          `yaml:"default,omitempty"`
 }
 
 // RegistryList contains multiple RegistryConfiguration items
 type RegistryList struct {
 	Items []RegistryConfiguration `yaml:"registries"`
+}
+
+func clearRegistries() {
+	registryLock.Lock()
+	registries = make(map[string]*RegistryEndpoint)
+	registryLock.Unlock()
 }
 
 // LoadRegistryConfiguration loads a YAML-formatted registry configuration from
@@ -43,19 +50,33 @@ func LoadRegistryConfiguration(path string, clear bool) error {
 	}
 
 	if clear {
-		registryLock.Lock()
-		registries = make(map[string]*RegistryEndpoint)
-		registryLock.Unlock()
+		clearRegistries()
 	}
+
+	haveDefault := false
 
 	for _, reg := range registryList.Items {
 		tagSortMode := TagListSortFromString(reg.TagSortMode)
 		if tagSortMode != TagListSortUnsorted {
 			log.Warnf("Registry %s has tag sort mode set to %s, meta data retrieval will be disabled for this registry.", reg.ApiURL, tagSortMode)
 		}
-		err = AddRegistryEndpoint(reg.Prefix, reg.Name, reg.ApiURL, reg.Credentials, reg.DefaultNS, reg.Insecure, tagSortMode, reg.Limit, reg.CredsExpire)
-		if err != nil {
+		ep := NewRegistryEndpoint(reg.Prefix, reg.Name, reg.ApiURL, reg.Credentials, reg.DefaultNS, reg.Insecure, tagSortMode, reg.Limit, reg.CredsExpire)
+		if reg.IsDefault {
+			if haveDefault {
+				dep := GetDefaultRegistry()
+				if dep == nil {
+					panic("unexpected: default registry should be set, but is not")
+				}
+				return fmt.Errorf("cannot set registry %s as default - only one default registry allowed, currently set to %s", ep.RegistryPrefix, dep.RegistryPrefix)
+			}
+		}
+		if err := AddRegistryEndpoint(ep); err != nil {
 			return err
+		}
+
+		if reg.IsDefault {
+			SetDefaultRegistry(ep)
+			haveDefault = true
 		}
 	}
 
@@ -107,7 +128,7 @@ func RestoreDefaultRegistryConfiguration() {
 	registryLock.Lock()
 	defer registryLock.Unlock()
 	registries = make(map[string]*RegistryEndpoint)
-	for k, v := range defaultRegistries {
+	for k, v := range registryTweaks {
 		registries[k] = v.DeepCopy()
 	}
 }

--- a/pkg/registry/config_test.go
+++ b/pkg/registry/config_test.go
@@ -76,9 +76,9 @@ registries:
 
 func Test_LoadRegistryConfiguration(t *testing.T) {
 	t.Run("Load from valid location", func(t *testing.T) {
-		err := LoadRegistryConfiguration("../../config/example-config.yaml", false)
+		err := LoadRegistryConfiguration("../../config/example-config.yaml", true)
 		require.NoError(t, err)
-		assert.Len(t, registries, 5)
+		assert.Len(t, registries, 4)
 		reg, err := GetRegistryEndpoint("gcr.io")
 		require.NoError(t, err)
 		assert.Equal(t, "pullsecret:foo/bar", reg.Credentials)
@@ -90,5 +90,17 @@ func Test_LoadRegistryConfiguration(t *testing.T) {
 		reg, err = GetRegistryEndpoint("gcr.io")
 		require.NoError(t, err)
 		assert.Equal(t, "", reg.Credentials)
+	})
+
+	t.Run("Load from invalid location", func(t *testing.T) {
+		err := LoadRegistryConfiguration("../../test/testdata/registry/config/does-not-exist.yaml", true)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no such file or directory")
+	})
+
+	t.Run("Two defaults defined in same config", func(t *testing.T) {
+		err := LoadRegistryConfiguration("../../test/testdata/registry/config/two-defaults.yaml", true)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "cannot set registry")
 	})
 }

--- a/pkg/registry/config_test.go
+++ b/pkg/registry/config_test.go
@@ -75,6 +75,8 @@ registries:
 }
 
 func Test_LoadRegistryConfiguration(t *testing.T) {
+	RestoreDefaultRegistryConfiguration()
+
 	t.Run("Load from valid location", func(t *testing.T) {
 		err := LoadRegistryConfiguration("../../config/example-config.yaml", true)
 		require.NoError(t, err)
@@ -103,4 +105,6 @@ func Test_LoadRegistryConfiguration(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "cannot set registry")
 	})
+
+	RestoreDefaultRegistryConfiguration()
 }

--- a/pkg/registry/endpoints.go
+++ b/pkg/registry/endpoints.go
@@ -182,17 +182,17 @@ func inferRegistryEndpointFromPrefix(prefix string) *RegistryEndpoint {
 // GetRegistryEndpoint retrieves the endpoint information for the given prefix
 func GetRegistryEndpoint(prefix string) (*RegistryEndpoint, error) {
 	if prefix == "" {
-		for _, v := range registries {
-			if v.IsDefault {
-				return v, nil
-			}
+		if defaultRegistry == nil {
+			return nil, fmt.Errorf("no default endpoint configured")
+		} else {
+			return defaultRegistry, nil
 		}
-		return nil, fmt.Errorf("no default endpoint configured")
 	}
 
 	registryLock.RLock()
 	registry, ok := registries[prefix]
 	registryLock.RUnlock()
+
 	if ok {
 		return registry, nil
 	} else {
@@ -212,8 +212,10 @@ func GetRegistryEndpoint(prefix string) (*RegistryEndpoint, error) {
 
 // SetDefaultRegistry sets a given registry endpoint as the default
 func SetDefaultRegistry(ep *RegistryEndpoint) {
+	log.Debugf("Setting default registry endpoint to %s", ep.RegistryPrefix)
 	ep.IsDefault = true
 	if defaultRegistry != nil {
+		log.Debugf("Previous default registry was %s", defaultRegistry.RegistryPrefix)
 		defaultRegistry.IsDefault = false
 	}
 	defaultRegistry = ep
@@ -222,6 +224,11 @@ func SetDefaultRegistry(ep *RegistryEndpoint) {
 // GetDefaultRegistry returns the registry endpoint that is set as default,
 // or nil if no default registry endpoint is set
 func GetDefaultRegistry() *RegistryEndpoint {
+	if defaultRegistry != nil {
+		log.Debugf("Getting default registry endpoint: %s", defaultRegistry.RegistryPrefix)
+	} else {
+		log.Debugf("No default registry defined.")
+	}
 	return defaultRegistry
 }
 

--- a/pkg/registry/endpoints.go
+++ b/pkg/registry/endpoints.go
@@ -85,76 +85,50 @@ type RegistryEndpoint struct {
 	TagListSort    TagListSort
 	Cache          cache.ImageTagCache
 	Limiter        ratelimit.Limiter
+	IsDefault      bool
 	lock           sync.RWMutex
+	limit          int
 }
 
-// Map of configured registries, pre-filled with some well-known registries
-var defaultRegistries map[string]*RegistryEndpoint = map[string]*RegistryEndpoint{
-	"": {
+// registryTweaks should contain a list of registries whose settings cannot be
+// infered by just looking at the image prefix. Prominent example here is the
+// Docker Hub registry, which is refered to as docker.io from the image, but
+// its API endpoint is https://registry-1.docker.io (and not https://docker.io)
+var registryTweaks map[string]*RegistryEndpoint = map[string]*RegistryEndpoint{
+	"docker.io": {
 		RegistryName:   "Docker Hub",
-		RegistryPrefix: "",
+		RegistryPrefix: "docker.io",
 		RegistryAPI:    "https://registry-1.docker.io",
 		Ping:           true,
 		Insecure:       false,
 		DefaultNS:      "library",
 		Cache:          cache.NewMemCache(),
 		Limiter:        ratelimit.New(RateLimitDefault),
-	},
-	"gcr.io": {
-		RegistryName:   "Google Container Registry",
-		RegistryPrefix: "gcr.io",
-		RegistryAPI:    "https://gcr.io",
-		Ping:           false,
-		Insecure:       false,
-		Cache:          cache.NewMemCache(),
-		Limiter:        ratelimit.New(RateLimitDefault),
-	},
-	"quay.io": {
-		RegistryName:   "RedHat Quay",
-		RegistryPrefix: "quay.io",
-		RegistryAPI:    "https://quay.io",
-		Ping:           false,
-		Insecure:       false,
-		Cache:          cache.NewMemCache(),
-		Limiter:        ratelimit.New(RateLimitDefault),
-	},
-	"docker.pkg.github.com": {
-		RegistryName:   "GitHub packages",
-		RegistryPrefix: "docker.pkg.github.com",
-		RegistryAPI:    "https://docker.pkg.github.com",
-		Ping:           false,
-		Insecure:       false,
-		Cache:          cache.NewMemCache(),
-		Limiter:        ratelimit.New(RateLimitDefault),
-	},
-	"ghcr.io": {
-		RegistryName:   "GitHub Container Registry",
-		RegistryPrefix: "ghcr.io",
-		RegistryAPI:    "https://ghcr.io",
-		Ping:           false,
-		Insecure:       false,
-		Cache:          cache.NewMemCache(),
-		Limiter:        ratelimit.New(RateLimitDefault),
+		IsDefault:      true,
 	},
 }
 
 var registries map[string]*RegistryEndpoint = make(map[string]*RegistryEndpoint)
 
+// Default registry points to the registry that is to be used as the default,
+// e.g. when no registry prefix is given for a certain image.
+var defaultRegistry *RegistryEndpoint
+
 // Simple RW mutex for concurrent access to registries map
 var registryLock sync.RWMutex
 
 func AddRegistryEndpointFromConfig(epc RegistryConfiguration) error {
-	return AddRegistryEndpoint(epc.Prefix, epc.Name, epc.ApiURL, epc.Credentials, epc.DefaultNS, epc.Insecure, TagListSortFromString(epc.TagSortMode), epc.Limit, epc.CredsExpire)
+	ep := NewRegistryEndpoint(epc.Prefix, epc.Name, epc.ApiURL, epc.Credentials, epc.DefaultNS, epc.Insecure, TagListSortFromString(epc.TagSortMode), epc.Limit, epc.CredsExpire)
+	return AddRegistryEndpoint(ep)
 }
 
-// AddRegistryEndpoint adds registry endpoint information with the given details
-func AddRegistryEndpoint(prefix, name, apiUrl, credentials, defaultNS string, insecure bool, tagListSort TagListSort, limit int, credsExpire time.Duration) error {
-	registryLock.Lock()
-	defer registryLock.Unlock()
+// NewRegistryEndpoint returns an endpoint object with the given configuration
+// pre-populated and a fresh cache.
+func NewRegistryEndpoint(prefix, name, apiUrl, credentials, defaultNS string, insecure bool, tagListSort TagListSort, limit int, credsExpire time.Duration) *RegistryEndpoint {
 	if limit <= 0 {
 		limit = RateLimitNone
 	}
-	registries[prefix] = &RegistryEndpoint{
+	ep := &RegistryEndpoint{
 		RegistryName:   name,
 		RegistryPrefix: prefix,
 		RegistryAPI:    strings.TrimSuffix(apiUrl, "/"),
@@ -165,28 +139,90 @@ func AddRegistryEndpoint(prefix, name, apiUrl, credentials, defaultNS string, in
 		DefaultNS:      defaultNS,
 		TagListSort:    tagListSort,
 		Limiter:        ratelimit.New(limit),
+		limit:          limit,
 	}
+	return ep
+}
+
+// AddRegistryEndpoint adds registry endpoint information with the given details
+func AddRegistryEndpoint(ep *RegistryEndpoint) error {
+	prefix := ep.RegistryPrefix
+
+	registryLock.Lock()
+	// If the endpoint is supposed to be the default endpoint, make sure that
+	// any previously set default endpoint is unset.
+	if ep.IsDefault {
+		if dep := GetDefaultRegistry(); dep != nil {
+			dep.IsDefault = false
+		}
+		SetDefaultRegistry(ep)
+	}
+	registries[prefix] = ep
+	registryLock.Unlock()
 
 	logCtx := log.WithContext()
-	logCtx.AddField("registry", registries[prefix].RegistryAPI)
-	logCtx.AddField("prefix", registries[prefix].RegistryPrefix)
-	if limit != RateLimitNone {
-		logCtx.Debugf("setting rate limit to %d requests per second", limit)
+	logCtx.AddField("registry", ep.RegistryAPI)
+	logCtx.AddField("prefix", ep.RegistryPrefix)
+	if ep.limit != RateLimitNone {
+		logCtx.Debugf("setting rate limit to %d requests per second", ep.limit)
 	} else {
 		logCtx.Debugf("rate limiting is disabled")
 	}
 	return nil
 }
 
+// inferRegistryEndpointFromPrefix returns a registry endpoint with the API
+// URL infered from the prefix and adds it to the list of the configured
+// registries.
+func inferRegistryEndpointFromPrefix(prefix string) *RegistryEndpoint {
+	apiURL := "https://" + prefix
+	return NewRegistryEndpoint(prefix, prefix, apiURL, "", "", false, TagListSortUnsorted, 20, 0)
+}
+
 // GetRegistryEndpoint retrieves the endpoint information for the given prefix
 func GetRegistryEndpoint(prefix string) (*RegistryEndpoint, error) {
+	if prefix == "" {
+		for _, v := range registries {
+			if v.IsDefault {
+				return v, nil
+			}
+		}
+		return nil, fmt.Errorf("no default endpoint configured")
+	}
+
 	registryLock.RLock()
-	defer registryLock.RUnlock()
-	if registry, ok := registries[prefix]; ok {
+	registry, ok := registries[prefix]
+	registryLock.RUnlock()
+	if ok {
 		return registry, nil
 	} else {
-		return nil, fmt.Errorf("no registry with prefix '%s' configured", prefix)
+		var err error
+		ep := inferRegistryEndpointFromPrefix(prefix)
+		if ep != nil {
+			err = AddRegistryEndpoint(ep)
+		} else {
+			err = fmt.Errorf("could not infer registry configuration from prefix %s", prefix)
+		}
+		if err == nil {
+			log.Debugf("Infered registry from prefix %s to use API %s", prefix, ep.RegistryAPI)
+		}
+		return ep, err
 	}
+}
+
+// SetDefaultRegistry sets a given registry endpoint as the default
+func SetDefaultRegistry(ep *RegistryEndpoint) {
+	ep.IsDefault = true
+	if defaultRegistry != nil {
+		defaultRegistry.IsDefault = false
+	}
+	defaultRegistry = ep
+}
+
+// GetDefaultRegistry returns the registry endpoint that is set as default,
+// or nil if no default registry endpoint is set
+func GetDefaultRegistry() *RegistryEndpoint {
+	return defaultRegistry
 }
 
 // SetRegistryEndpointCredentials allows to change the credentials used for
@@ -229,6 +265,8 @@ func (ep *RegistryEndpoint) DeepCopy() *RegistryEndpoint {
 	newEp.Limiter = ep.Limiter
 	newEp.CredsExpire = ep.CredsExpire
 	newEp.CredsUpdated = ep.CredsUpdated
+	newEp.IsDefault = ep.IsDefault
+	newEp.limit = ep.limit
 	ep.lock.RUnlock()
 	return newEp
 }
@@ -245,8 +283,16 @@ func (ep *RegistryEndpoint) GetTransport() *http.Transport {
 	}
 }
 
+// init initializes the registry configuration
 func init() {
-	for k, v := range defaultRegistries {
+	for k, v := range registryTweaks {
 		registries[k] = v.DeepCopy()
+		if v.IsDefault {
+			if defaultRegistry == nil {
+				defaultRegistry = v
+			} else {
+				panic("only one default registry can be configured")
+			}
+		}
 	}
 }

--- a/test/testdata/registry/config/two-defaults.yaml
+++ b/test/testdata/registry/config/two-defaults.yaml
@@ -1,0 +1,9 @@
+registries:
+- name: "Reg One"
+  prefix: regone.io
+  api_url: "https://regone.io"
+  default: true
+- name: "Reg Two"
+  prefix: regtwo.io
+  api_url: "https://regtwo.io"
+  default: true


### PR DESCRIPTION
This new feature allows the registry API to be inferred from an image's prefix. E.g. if the image name is `my.custom.registry/some/image`, Argo CD Image Updater now won't require a dedicated configuration for the registry `my.custom.registry`, but instead assume the Docker registry API's endpoint at `https://my.custom.registry/v2`.

This works as long as the API is available via HTTPS on the same host as the registry's prefix and as long as you won't need any custom configuration for your registry, such as modified TLS settings.

Signed-off-by: jannfis <jann@mistrust.net>