### PR TITLE
feat: Add configMap to allow define parameters for SSH client

### DIFF
--- a/config/example-config-ssh-config.yaml
+++ b/config/example-config-ssh-config.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-image-updater-ssh-config
+  namespace: argocd
+data:
+  config: |
+    Host *
+          PubkeyAcceptedAlgorithms +ssh-rsa
+          HostkeyAlgorithms +ssh-rsa

--- a/manifests/base/config/argocd-image-updater-ssh-config.yaml
+++ b/manifests/base/config/argocd-image-updater-ssh-config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-image-updater-ssh-config
+  labels:
+    app.kubernetes.io/name: argocd-image-updater-ssh-config
+    app.kubernetes.io/part-of: argocd-image-updater

--- a/manifests/base/config/kustomization.yaml
+++ b/manifests/base/config/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
 - argocd-image-updater-cm.yaml
 - argocd-image-updater-secret.yaml
+- argocd-image-updater-ssh-config.yaml

--- a/manifests/base/deployment/argocd-image-updater-deployment.yaml
+++ b/manifests/base/deployment/argocd-image-updater-deployment.yaml
@@ -104,6 +104,8 @@ spec:
           name: image-updater-conf
         - mountPath: /app/config/ssh
           name: ssh-known-hosts
+        - mountPath: /app/.ssh
+          name: ssh-config
       serviceAccountName: argocd-image-updater
       volumes:
       - configMap:
@@ -119,3 +121,7 @@ spec:
           name: argocd-ssh-known-hosts-cm
           optional: true
         name: ssh-known-hosts
+      - configMap:
+          name: argocd-image-updater-ssh-config
+          optional: true
+        name: ssh-config

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -66,6 +66,14 @@ metadata:
   name: argocd-image-updater-config
 ---
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: argocd-image-updater-ssh-config
+    app.kubernetes.io/part-of: argocd-image-updater
+  name: argocd-image-updater-ssh-config
+---
+apiVersion: v1
 kind: Secret
 metadata:
   labels:
@@ -179,6 +187,8 @@ spec:
           name: image-updater-conf
         - mountPath: /app/config/ssh
           name: ssh-known-hosts
+        - mountPath: /app/.ssh
+          name: ssh-config
       serviceAccountName: argocd-image-updater
       volumes:
       - configMap:
@@ -194,3 +204,7 @@ spec:
           name: argocd-ssh-known-hosts-cm
           optional: true
         name: ssh-known-hosts
+      - configMap:
+          name: argocd-image-updater-ssh-config
+          optional: true
+        name: ssh-config


### PR DESCRIPTION
Since ssh-rsa has been deprecated since OpenSSH 8.2 but some git server are still using it like Azure DevOps, its necessary to bring back this feature.

Besisdes, since for internal networks, some people use not have too much concern about deprecated algorithms, this PR can give then hability to change the ssh client and make it compatible with their systems.

configMap example:

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: argocd-image-updater-ssh-config
  namespace: argocd
data:
  config: |
    Host *
          PubkeyAcceptedAlgorithms +ssh-rsa
          HostkeyAlgorithms +ssh-rsa
```

This will be loaded in /app/.ssh/config as default user home path in image.