### PR TITLE
Checkout after creating a new branch

### DIFF
--- a/pkg/argocd/git.go
+++ b/pkg/argocd/git.go
@@ -207,6 +207,10 @@ func commitChangesGit(app *v1alpha1.Application, wbc *WriteBackConfig, changeLis
 			if err != nil {
 				return err
 			}
+			err = gitC.Checkout(pushBranch)
+			if err != nil {
+				return err
+			}
 		} else {
 			return fmt.Errorf("Git branch name could not be created from the template: %s", wbc.GitWriteBranch)
 		}

--- a/pkg/argocd/git.go
+++ b/pkg/argocd/git.go
@@ -187,11 +187,6 @@ func commitChangesGit(app *v1alpha1.Application, wbc *WriteBackConfig, changeLis
 		}
 	}
 
-	err = gitC.Checkout(checkOutBranch)
-	if err != nil {
-		return err
-	}
-
 	// The push branch is by default the same as the checkout branch, unless
 	// specified after a : separator git-branch annotation, in which case a
 	// new branch will be made following a template that can use the list of
@@ -207,13 +202,14 @@ func commitChangesGit(app *v1alpha1.Application, wbc *WriteBackConfig, changeLis
 			if err != nil {
 				return err
 			}
-			err = gitC.Checkout(pushBranch)
-			if err != nil {
-				return err
-			}
 		} else {
 			return fmt.Errorf("Git branch name could not be created from the template: %s", wbc.GitWriteBranch)
 		}
+	}
+
+	err = gitC.Checkout(pushBranch)
+	if err != nil {
+		return err
 	}
 
 	if err, skip := write(app, wbc, gitC); err != nil {

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -1786,7 +1786,7 @@ func Test_CommitUpdates(t *testing.T) {
 		defer cleanup()
 		gitMock.On("Checkout", mock.Anything).Run(func(args mock.Arguments) {
 			args.Assert(t, "mydefaultbranch")
-		}).Return(nil)
+		}).Return(nil).Once()
 		gitMock.On("Add", mock.Anything).Return(nil)
 		gitMock.On("Branch", mock.Anything, mock.Anything).Return(nil)
 		gitMock.On("Commit", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -1806,6 +1806,7 @@ func Test_CommitUpdates(t *testing.T) {
 				NewTag: tag.NewImageTag("1.1", time.Now(), ""),
 			},
 		}
+		gitMock.On("Checkout", TemplateBranchName(wbc.GitWriteBranch, cl)).Return(nil).Once()
 
 		err = commitChanges(&app, wbc, cl)
 		assert.NoError(t, err)

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -1784,9 +1784,6 @@ func Test_CommitUpdates(t *testing.T) {
 	t.Run("Good commit to different than base branch", func(t *testing.T) {
 		gitMock, _, cleanup := mockGit(t)
 		defer cleanup()
-		gitMock.On("Checkout", mock.Anything).Run(func(args mock.Arguments) {
-			args.Assert(t, "mydefaultbranch")
-		}).Return(nil).Once()
 		gitMock.On("Add", mock.Anything).Return(nil)
 		gitMock.On("Branch", mock.Anything, mock.Anything).Return(nil)
 		gitMock.On("Commit", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -1806,7 +1803,7 @@ func Test_CommitUpdates(t *testing.T) {
 				NewTag: tag.NewImageTag("1.1", time.Now(), ""),
 			},
 		}
-		gitMock.On("Checkout", TemplateBranchName(wbc.GitWriteBranch, cl)).Return(nil).Once()
+		gitMock.On("Checkout", TemplateBranchName(wbc.GitWriteBranch, cl)).Return(nil)
 
 		err = commitChanges(&app, wbc, cl)
 		assert.NoError(t, err)


### PR DESCRIPTION
I'm a big fan of the new feature below. It will allow us more flexible GitOps operations.

https://github.com/argoproj-labs/argocd-image-updater/pull/304

However, I found a bug after trying the feature by myself on my local environment.

It seems after creating a new branch, `Argo CD` doesn't checkout the newly created branch. In the end, the new branch is pushed without any changes committed.

So, I've moved checkout process to after branch creation.