### PR TITLE
feat(chart-updater): continuous deployment of OCI Helm chart type application

### DIFF
--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -8,6 +8,8 @@ const ImageUpdaterAnnotationPrefix = "argocd-image-updater.argoproj.io"
 // allowed for updates.
 const ImageUpdaterAnnotation = ImageUpdaterAnnotationPrefix + "/image-list"
 
+const ChartVersionAnnotation = ImageUpdaterAnnotationPrefix + "/chart-version"
+
 // Defaults for Helm parameter names
 const (
 	DefaultHelmImageName = "image.name"


### PR DESCRIPTION
Hi! There is a proposal to implement continuous deployment at the higher logical level than updating images: watch for a new helm chart versions and perform update (and included images will be updated as well). This proposal and possible solutions has been described in-depth in this issue: https://github.com/argoproj/argo-cd/issues/8475.

In this PR I've created MVP to try one solution to the problem and get your feedback if possible.

## How it works

Update application targetRevision for an OCI helm chart when new chart version arrives into the container registry based on semver constraints.

