### PR TITLE
Push new commits if new image is found

### DIFF
--- a/ext/git/client.go
+++ b/ext/git/client.go
@@ -65,6 +65,7 @@ type Client interface {
 	VerifyCommitSignature(string) (string, error)
 	Commit(pathSpec string, opts *CommitOptions) error
 	Branch(sourceBranch string, targetBranch string) error
+	RemoteBranches() ([]string, error)
 	Push(remote string, branch string, force bool) error
 	Add(path string) error
 	SymRefToBranch(symRef string) (string, error)
@@ -363,6 +364,22 @@ func (m *nativeGitClient) LsLargeFiles() ([]string, error) {
 	}
 	ss := strings.Split(out, "\n")
 	return ss, nil
+}
+
+// RemoteBranches lists all remote branches
+func (m *nativeGitClient) RemoteBranches() ([]string, error) {
+	out, err := m.runCmd("branch", "-r")
+	if err != nil {
+		return nil, err
+	}
+	ss := strings.Split(out, "\n")
+
+	var trimmed []string
+	for _, s := range ss {
+		trimmed = append(trimmed, strings.TrimSpace(s))
+	}
+
+	return trimmed, nil
 }
 
 // Checkout checkout specified revision

--- a/ext/git/git_test.go
+++ b/ext/git/git_test.go
@@ -267,6 +267,10 @@ func TestLFSClient(t *testing.T) {
 	err = client.Checkout(commitSHA)
 	assert.NoError(t, err)
 
+	remoteBranches, err := client.RemoteBranches()
+	assert.NoError(t, err)
+	assert.Contains(t, remoteBranches, "origin/master")
+
 	largeFiles, err := client.LsLargeFiles()
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(largeFiles))

--- a/ext/git/mocks/Client.go
+++ b/ext/git/mocks/Client.go
@@ -89,6 +89,29 @@ func (_m *Client) CommitSHA() (string, error) {
 	return r0, r1
 }
 
+// RemoteBranches lists all remote branches
+func (_m *Client) RemoteBranches() ([]string, error) {
+	ret := _m.Called()
+	
+	var r0 []string
+	if rf, ok := ret.Get(0).(func() []string); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Config provides a mock function with given fields: username, email
 func (_m *Client) Config(username string, email string) error {
 	ret := _m.Called(username, email)

--- a/pkg/argocd/git.go
+++ b/pkg/argocd/git.go
@@ -196,8 +196,17 @@ func commitChangesGit(app *v1alpha1.Application, wbc *WriteBackConfig, changeLis
 	if wbc.GitWriteBranch != "" {
 		logCtx.Debugf("Using branch template: %s", wbc.GitWriteBranch)
 		pushBranch = TemplateBranchName(wbc.GitWriteBranch, changeList)
-		if pushBranch != "" {
+
+		remoteBranches, err := gitC.RemoteBranches()
+		if err != nil {
+			return err
+		}
+
+		if pushBranch != "" && hasBranchOnRemote(remoteBranches, pushBranch) {
+			// Use fetched branch.
+		} else if pushBranch != "" {
 			logCtx.Debugf("Creating branch '%s' and using that for push operations", pushBranch)
+
 			err = gitC.Branch(checkOutBranch, pushBranch)
 			if err != nil {
 				return err
@@ -397,6 +406,15 @@ func parseImageOverride(str v1alpha1.KustomizeImage) types.Image {
 		NewTag:  tagName,
 		Digest:  tagDigest,
 	}
+}
+
+func hasBranchOnRemote(remoteBranches []string, branch string) bool {
+	for _, remoteBranch := range remoteBranches {
+		if remoteBranch == "origin/"+branch {
+			return true
+		}
+	}
+	return false
 }
 
 var _ changeWriter = writeKustomization


### PR DESCRIPTION
If `pushBranch` is designated, image updater continues to emit error messages like below after pushing a branch initially.

```
time="2022-03-29T11:03:47Z" level=error msg="Could not update application spec: could not push image-updater-katainaka0503/argocd-image-updater-test-app-0.0.4 to origin: `git push origin image-updater-katainaka0503/argocd-image-updater-test-app-0.0.4` failed exit status 1: To https://github.com/katainaka0503/argocd-image-updater-test.git\n ! [rejected]        image-updater-katainaka0503/argocd-image-updater-test-app-0.0.4 -> image-updater-katainaka0503/argocd-image-updater-test-app-0.0.4 (non-fast-forward)\nerror: failed to push some refs to 'https://github.com/katainaka0503/argocd-image-updater-test.git'\nhint: Updates were rejected because the tip of your current branch is behind\nhint: its remote counterpart. Integrate the remote changes (e.g.\nhint: 'git pull ...') before pushing again.\nhint: See the 'Note about fast-forwards' in 'git push --help' for details." application=test
```

This PR allows the image updater to update the branch if designated branch is found on the remote repository.

