### PR TITLE
fix: Doc error --docker-server

### DIFF
--- a/docs/basics/authentication.md
+++ b/docs/basics/authentication.md
@@ -112,7 +112,7 @@ create a pull secret for Docker Hub named `dockerhub-secret` in the namespace
 kubectl create -n argocd secret docker-registry dockerhub-secret \
   --docker-username someuser \
   --docker-password s0m3p4ssw0rd \
-  --docker-registry "https://registry-1.docker.io"
+  --docker-server "https://registry-1.docker.io"
 ```
 
 This secret could then be referred to as


### PR DESCRIPTION
Small fix, the flag `--docker-registry` is not a valid flag but `--docker-server` is.
Referring to the official Kubernetes documentation here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-secret-by-providing-credentials-on-the-command-line

