### PR TITLE
chore: update golangci-lint version in CI

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.32
+          version: v1.44.2
           args: --timeout 5m
   test:
     name: Ensure unit tests are passing

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.44.2
+          version: v1.46.2
           args: --timeout 5m
   test:
     name: Ensure unit tests are passing


### PR DESCRIPTION
CI is failing on open PRs due to an older version of `golangci-lint` being used
According to https://github.com/golangci/golangci-lint/issues/2374 older versions of golangci-lint are not compatible with go v1.18

Error message is: 
```
Running [/home/runner/golangci-lint-1.32.2-linux-amd64/golangci-lint run --out-format=github-actions --timeout 5m] in [] ...
  level=warning msg="[runner] Can't run linter goanalysis_metalinter: buildir: failed to load package goarch: could not load export data: cannot import \"internal/goarch\" (unknown iexport format version 2), export data is newer version - update tool"
  level=warning msg="[runner] Can't run linter unused: buildir: failed to load package goarch: could not load export data: cannot import \"internal/goarch\" (unknown iexport format version 2), export data is newer version - update tool"
  level=error msg="Running error: buildir: failed to load package goarch: could not load export data: cannot import \"internal/goarch\" (unknown iexport format version 2), export data is newer version - update tool"
```

This PR updates the version to `v1.46.2`