### PR TITLE
docs: Added warning about existing tag in semver

### DIFF
--- a/docs/basics/update-strategies.md
+++ b/docs/basics/update-strategies.md
@@ -77,6 +77,10 @@ The above example would update to any new tag pushed to the registry matching
 this constraint, e.g. `1.2.5`, `1.2.12` etc, but not to a new minor version
 (e.g. `1.3`).
 
+!!!warning "A note on the current image tag"
+    For semver strategy to work, the current application tag must already follow
+    semver. Otherwise no comparison can happen by the updater. See discussion at [#270](https://github.com/argoproj-labs/argocd-image-updater/issues/270) for more details.
+
 Likewise, to allow updates to any minor release within the major version `1`,
 use
 
@@ -100,6 +104,8 @@ Image Updater will pick the highest version number found in the registry.
 
 Argo CD Image Updater will omit any tags from your registry that do not match 
 a semantic version when using the `semver` update strategy.
+
+
 
 ### <a name="strategy-latest"></a>latest/newest-build - Update to the most recently built image
 


### PR DESCRIPTION
Signed-off-by: Kostis Kapelonis <kostis@codefresh.io>

When changing from latest to semver strategy, users must be careful and make sure that the existing
tag is already following semver

Otherwise trying to change from tag "rc1" to "1.0" or something similar doesn't work