### PR TITLE
chore: replace deprecated ioutils module - align go mod version with actions and Dockerfile

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"sync"
@@ -62,7 +61,7 @@ func newRunCommand() *cobra.Command {
 
 			// User can specify a path to a template used for Git commit messages
 			if commitMessagePath != "" {
-				tpl, err := ioutil.ReadFile(commitMessagePath)
+				tpl, err := os.ReadFile(commitMessagePath)
 				if err != nil {
 					if errors.Is(err, os.ErrNotExist) {
 						log.Warnf("commit message template at %s does not exist, using default", commitMessagePath)

--- a/cmd/template.go
+++ b/cmd/template.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"text/template"
 	"time"
 
@@ -37,7 +37,7 @@ If PATH is not given, will show you the default message that is used.
 				tplStr = common.DefaultGitCommitMessage
 			} else {
 				commitMessageTemplatePath = args[0]
-				tplData, err := ioutil.ReadFile(commitMessageTemplatePath)
+				tplData, err := os.ReadFile(commitMessageTemplatePath)
 				if err != nil {
 					log.Fatalf("%v", err)
 				}

--- a/ext/git/client.go
+++ b/ext/git/client.go
@@ -155,12 +155,12 @@ func NewClientExt(rawRepoURL string, root string, creds Creds, insecure bool, en
 
 // Returns a HTTP client object suitable for go-git to use using the following
 // pattern:
-// - If insecure is true, always returns a client with certificate verification
-//   turned off.
-// - If one or more custom certificates are stored for the repository, returns
-//   a client with those certificates in the list of root CAs used to verify
-//   the server's certificate.
-// - Otherwise (and on non-fatal errors), a default HTTP client is returned.
+//   - If insecure is true, always returns a client with certificate verification
+//     turned off.
+//   - If one or more custom certificates are stored for the repository, returns
+//     a client with those certificates in the list of root CAs used to verify
+//     the server's certificate.
+//   - Otherwise (and on non-fatal errors), a default HTTP client is returned.
 func GetRepoHTTPClient(repoURL string, insecure bool, creds Creds, proxyURL string) *http.Client {
 	// Default HTTP client
 	var customHTTPClient = &http.Client{

--- a/ext/git/creds.go
+++ b/ext/git/creds.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -118,10 +117,10 @@ func (c HTTPSCreds) Environ() (io.Closer, []string, error) {
 		// We need to actually create two temp files, one for storing cert data and
 		// another for storing the key. If we fail to create second fail, the first
 		// must be removed.
-		certFile, err := ioutil.TempFile(argoio.TempDir, "")
+		certFile, err := os.CreateTemp(argoio.TempDir, "")
 		if err == nil {
 			defer certFile.Close()
-			keyFile, err = ioutil.TempFile(argoio.TempDir, "")
+			keyFile, err = os.CreateTemp(argoio.TempDir, "")
 			if err != nil {
 				removeErr := os.Remove(certFile.Name())
 				if removeErr != nil {
@@ -204,7 +203,7 @@ func (f authFilePaths) Close() error {
 
 func (c SSHCreds) Environ() (io.Closer, []string, error) {
 	// use the SHM temp dir from util, more secure
-	file, err := ioutil.TempFile(argoio.TempDir, "")
+	file, err := os.CreateTemp(argoio.TempDir, "")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -275,10 +274,10 @@ func (g GitHubAppCreds) Environ() (io.Closer, []string, error) {
 		// We need to actually create two temp files, one for storing cert data and
 		// another for storing the key. If we fail to create second fail, the first
 		// must be removed.
-		certFile, err := ioutil.TempFile(argoio.TempDir, "")
+		certFile, err := os.CreateTemp(argoio.TempDir, "")
 		if err == nil {
 			defer certFile.Close()
-			keyFile, err = ioutil.TempFile(argoio.TempDir, "")
+			keyFile, err = os.CreateTemp(argoio.TempDir, "")
 			if err != nil {
 				removeErr := os.Remove(certFile.Name())
 				if removeErr != nil {

--- a/ext/git/git_test.go
+++ b/ext/git/git_test.go
@@ -2,7 +2,7 @@ package git
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -137,11 +137,11 @@ func TestCustomHTTPClient(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEqual(t, "", keyFile)
 
-	certData, err := ioutil.ReadFile(certFile)
+	certData, err := os.ReadFile(certFile)
 	assert.NoError(t, err)
 	assert.NotEqual(t, "", string(certData))
 
-	keyData, err := ioutil.ReadFile(keyFile)
+	keyData, err := os.ReadFile(keyFile)
 	assert.NoError(t, err)
 	assert.NotEqual(t, "", string(keyData))
 
@@ -245,7 +245,7 @@ func TestLFSClient(t *testing.T) {
 	// TODO(alexmt): dockerize tests in and enabled it
 	t.Skip()
 
-	tempDir, err := ioutil.TempDir("", "git-client-lfs-test-")
+	tempDir, err := os.MkdirTemp("", "git-client-lfs-test-")
 	assert.NoError(t, err)
 	if err == nil {
 		defer func() { _ = os.RemoveAll(tempDir) }()
@@ -275,7 +275,7 @@ func TestLFSClient(t *testing.T) {
 	assert.NoError(t, err)
 	if err == nil {
 		defer fileHandle.Close()
-		text, err := ioutil.ReadAll(fileHandle)
+		text, err := io.ReadAll(fileHandle)
 		assert.NoError(t, err)
 		if err == nil {
 			assert.Equal(t, "This is not a YAML, sorry.\n", string(text))
@@ -284,7 +284,7 @@ func TestLFSClient(t *testing.T) {
 }
 
 func TestVerifyCommitSignature(t *testing.T) {
-	p, err := ioutil.TempDir("", "test-verify-commit-sig")
+	p, err := os.MkdirTemp("", "test-verify-commit-sig")
 	if err != nil {
 		panic(err.Error())
 	}
@@ -343,7 +343,7 @@ func TestNewFactory(t *testing.T) {
 			test.Flaky(t)
 		}
 
-		dirName, err := ioutil.TempDir("", "git-client-test-")
+		dirName, err := os.MkdirTemp("", "git-client-test-")
 		assert.NoError(t, err)
 		defer func() { _ = os.RemoveAll(dirName) }()
 
@@ -381,7 +381,7 @@ func TestNewFactory(t *testing.T) {
 }
 
 func TestListRevisions(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test-list-revisions")
+	dir, err := os.MkdirTemp("", "test-list-revisions")
 	if err != nil {
 		panic(err.Error())
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/argoproj-labs/argocd-image-updater
 
-go 1.16
+go 1.17
 
 require (
 	github.com/Masterminds/semver v1.5.0
@@ -9,9 +9,7 @@ require (
 	github.com/argoproj/pkg v0.11.1-0.20211203175135-36c59d8fafe0
 	github.com/bradleyfalzon/ghinstallation v1.1.1
 	github.com/distribution/distribution/v3 v3.0.0-20220311160646-514cbd71bedb
-	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
 	github.com/go-git/go-git/v5 v5.2.0
-	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/prometheus/client_golang v1.11.0
@@ -21,7 +19,6 @@ require (
 	github.com/stretchr/testify v1.7.0
 	go.uber.org/ratelimit v0.1.1-0.20201110185707-e86515f0dda9
 	golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3
-	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v1.22.4
@@ -29,6 +26,134 @@ require (
 	k8s.io/client-go v11.0.1-0.20190816222228-6d55c1b1f1ca+incompatible
 	sigs.k8s.io/kustomize/api v0.8.11
 	sigs.k8s.io/kustomize/kyaml v0.11.0
+)
+
+require (
+	cloud.google.com/go v0.65.0 // indirect
+	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
+	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
+	github.com/Azure/go-autorest/autorest v0.11.24 // indirect
+	github.com/Azure/go-autorest/autorest/adal v0.9.18 // indirect
+	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
+	github.com/Azure/go-autorest/logger v0.2.1 // indirect
+	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
+	github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd // indirect
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/bombsimon/logrusr v1.0.0 // indirect
+	github.com/bradleyfalzon/ghinstallation/v2 v2.0.2 // indirect
+	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/chai2010/gettext-go v0.0.0-20170215093142-bf70f2a70fb1 // indirect
+	github.com/coreos/go-oidc v2.1.0+incompatible // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
+	github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/docker/distribution v2.7.1+incompatible // indirect
+	github.com/docker/go-metrics v0.0.1 // indirect
+	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
+	github.com/emicklei/go-restful v2.9.5+incompatible // indirect
+	github.com/emirpasic/gods v1.12.0 // indirect
+	github.com/evanphx/json-patch v4.11.0+incompatible // indirect
+	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
+	github.com/fatih/camelcase v1.0.0 // indirect
+	github.com/felixge/httpsnoop v1.0.1 // indirect
+	github.com/fvbommel/sortorder v1.0.1 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/go-errors/errors v1.0.1 // indirect
+	github.com/go-git/gcfg v1.5.0 // indirect
+	github.com/go-git/go-billy/v5 v5.0.0 // indirect
+	github.com/go-logr/logr v0.4.0 // indirect
+	github.com/go-openapi/jsonpointer v0.19.5 // indirect
+	github.com/go-openapi/jsonreference v0.19.5 // indirect
+	github.com/go-openapi/swag v0.19.14 // indirect
+	github.com/go-redis/cache/v8 v8.4.2 // indirect
+	github.com/go-redis/redis/v8 v8.11.3 // indirect
+	github.com/gobwas/glob v0.2.3 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/btree v1.0.1 // indirect
+	github.com/google/go-cmp v0.5.6 // indirect
+	github.com/google/go-github/v29 v29.0.2 // indirect
+	github.com/google/go-github/v38 v38.0.0 // indirect
+	github.com/google/go-querystring v1.1.0 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
+	github.com/google/uuid v1.1.2 // indirect
+	github.com/googleapis/gnostic v0.5.5 // indirect
+	github.com/gorilla/mux v1.8.0 // indirect
+	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
+	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.0 // indirect
+	github.com/imdario/mergo v0.3.10 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/jonboulle/clockwork v0.2.2 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.11 // indirect
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
+	github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd // indirect
+	github.com/klauspost/compress v1.13.5 // indirect
+	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
+	github.com/mailru/easyjson v0.7.6 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
+	github.com/moby/spdystream v0.2.0 // indirect
+	github.com/moby/term v0.0.0-20210610120745-9d4ed1856297 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/opencontainers/image-spec v1.0.2 // indirect
+	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/pquerna/cachecontrol v0.0.0-20180306154005-525d0eb5f91d // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.26.0 // indirect
+	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/robfig/cron v1.1.0 // indirect
+	github.com/russross/blackfriday v1.5.2 // indirect
+	github.com/sergi/go-diff v1.1.0 // indirect
+	github.com/stretchr/objx v0.2.0 // indirect
+	github.com/vmihailenco/go-tinylfu v0.2.1 // indirect
+	github.com/vmihailenco/msgpack/v5 v5.3.4 // indirect
+	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
+	github.com/xanzy/ssh-agent v0.2.1 // indirect
+	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
+	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
+	golang.org/x/exp v0.0.0-20210901193431-a062eea981d2 // indirect
+	golang.org/x/net v0.0.0-20211216030914-fe4d6282115f // indirect
+	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect
+	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 // indirect
+	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
+	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
+	google.golang.org/appengine v1.6.6 // indirect
+	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c // indirect
+	google.golang.org/grpc v1.38.0 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/square/go-jose.v2 v2.2.2 // indirect
+	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/apiserver v0.22.4 // indirect
+	k8s.io/cli-runtime v0.22.4 // indirect
+	k8s.io/component-base v0.22.4 // indirect
+	k8s.io/component-helpers v0.22.4 // indirect
+	k8s.io/klog/v2 v2.9.0 // indirect
+	k8s.io/kube-aggregator v0.22.2 // indirect
+	k8s.io/kube-openapi v0.0.0-20211109043538-20434351676c // indirect
+	k8s.io/kubectl v0.22.2 // indirect
+	k8s.io/kubernetes v1.22.2 // indirect
+	k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect
+	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
 replace (

--- a/pkg/argocd/git.go
+++ b/pkg/argocd/git.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -136,7 +135,7 @@ func commitChangesGit(app *v1alpha1.Application, wbc *WriteBackConfig, changeLis
 	}
 	var gitC git.Client
 	if wbc.GitClient == nil {
-		tempRoot, err := ioutil.TempDir(os.TempDir(), fmt.Sprintf("git-%s", app.Name))
+		tempRoot, err := os.MkdirTemp(os.TempDir(), fmt.Sprintf("git-%s", app.Name))
 		if err != nil {
 			return err
 		}
@@ -220,12 +219,12 @@ func commitChangesGit(app *v1alpha1.Application, wbc *WriteBackConfig, changeLis
 
 	commitOpts := &git.CommitOptions{}
 	if wbc.GitCommitMessage != "" {
-		cm, err := ioutil.TempFile("", "image-updater-commit-msg")
+		cm, err := os.CreateTemp("", "image-updater-commit-msg")
 		if err != nil {
 			return fmt.Errorf("cold not create temp file: %v", err)
 		}
 		logCtx.Debugf("Writing commit message to %s", cm.Name())
-		err = ioutil.WriteFile(cm.Name(), []byte(wbc.GitCommitMessage), 0600)
+		err = os.WriteFile(cm.Name(), []byte(wbc.GitCommitMessage), 0600)
 		if err != nil {
 			_ = cm.Close()
 			return fmt.Errorf("could not write commit message to %s: %v", cm.Name(), err)
@@ -269,7 +268,7 @@ func writeOverrides(app *v1alpha1.Application, wbc *WriteBackConfig, gitC git.Cl
 	// our generated new file is the same as the existing one, and if yes, we
 	// don't proceed further for commit.
 	if targetExists {
-		data, err := ioutil.ReadFile(targetFile)
+		data, err := os.ReadFile(targetFile)
 		if err != nil {
 			return err, false
 		}
@@ -279,7 +278,7 @@ func writeOverrides(app *v1alpha1.Application, wbc *WriteBackConfig, gitC git.Cl
 		}
 	}
 
-	err = ioutil.WriteFile(targetFile, override, 0600)
+	err = os.WriteFile(targetFile, override, 0600)
 	if err != nil {
 		return
 	}

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -3,7 +3,6 @@ package argocd
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1816,7 +1815,7 @@ func Test_CommitUpdates(t *testing.T) {
 		gitMock, dir, cleanup := mockGit(t)
 		defer cleanup()
 		kf := filepath.Join(dir, "kustomization.yml")
-		assert.NoError(t, ioutil.WriteFile(kf, []byte(`
+		assert.NoError(t, os.WriteFile(kf, []byte(`
 kind: Kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 
@@ -1838,7 +1837,7 @@ replacements: []
 
 		err = commitChanges(app, wbc, nil)
 		assert.NoError(t, err)
-		kust, err := ioutil.ReadFile(kf)
+		kust, err := os.ReadFile(kf)
 		assert.NoError(t, err)
 		assert.YAMLEq(t, `
 kind: Kustomization
@@ -1857,7 +1856,7 @@ replacements: []
 		app.Spec.Source.Kustomize.Images = v1alpha1.KustomizeImages{"foo:123", "bar=qux"}
 		err = commitChanges(app, wbc, nil)
 		assert.NoError(t, err)
-		kust, err = ioutil.ReadFile(kf)
+		kust, err = os.ReadFile(kf)
 		assert.NoError(t, err)
 		assert.YAMLEq(t, `
 kind: Kustomization
@@ -2044,7 +2043,7 @@ func Test_parseTarget(t *testing.T) {
 }
 
 func mockGit(t *testing.T) (gitMock *gitmock.Client, dir string, cleanup func()) {
-	dir, err := ioutil.TempDir("", "wb-kust")
+	dir, err := os.MkdirTemp("", "wb-kust")
 	assert.NoError(t, err)
 	gitMock = &gitmock.Client{}
 	gitMock.On("Root").Return(dir)

--- a/pkg/registry/config.go
+++ b/pkg/registry/config.go
@@ -2,7 +2,7 @@ package registry
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/argoproj-labs/argocd-image-updater/pkg/log"
@@ -40,7 +40,7 @@ func clearRegistries() {
 // LoadRegistryConfiguration loads a YAML-formatted registry configuration from
 // a given file at path.
 func LoadRegistryConfiguration(path string, clear bool) error {
-	registryBytes, err := ioutil.ReadFile(path)
+	registryBytes, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}

--- a/test/fixture/capture.go
+++ b/test/fixture/capture.go
@@ -1,7 +1,7 @@
 package fixture
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 )
 
@@ -22,7 +22,7 @@ func CaptureStdout(callback func()) (string, error) {
 
 	w.Close()
 
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 
 	if err != nil {
 		return "", err
@@ -46,7 +46,7 @@ func CaptureStderr(callback func()) (string, error) {
 	callback()
 	w.Close()
 
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 
 	if err != nil {
 		return "", err

--- a/test/fixture/fileutil.go
+++ b/test/fixture/fileutil.go
@@ -1,12 +1,12 @@
 package fixture
 
-// Fixture functions for tests related to files
+import "os"
 
-import "io/ioutil"
+// Fixture functions for tests related to files
 
 // MustReadFile must read a file from given path. Panics if it can't.
 func MustReadFile(path string) string {
-	retBytes, err := ioutil.ReadFile(path)
+	retBytes, err := os.ReadFile(path)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This PR replaces the deprecated ioutil functions to please newwer versions of golangci-lint and it aligns the go version in go.mod with the versions uses in github actions and Dockerfile