### PR TITLE
Remote base repo URL in Note is incorrect for Kustomize base config

### DIFF
--- a/docs/install/installation.md
+++ b/docs/install/installation.md
@@ -19,7 +19,7 @@ Argo CD is running. Don't worry, without any configuration, it will not start me
     We also provide a Kustomize base in addition to the plain Kubernetes YAML
     manifests. You can use it as remote base and create overlays with your
     configuration on top of it. The remote base's URL is
-    `https://github.com/argoproj-labs/argocd-image-updater/manifests/base`
+    `https://github.com/argoproj-labs/argocd-image-updater/tree/master/manifests/base`
 
 ### Apply the installation manifests
 


### PR DESCRIPTION
The correct URL for ArgoCD-image-updater have changed, that refer to base which holds kustomize based configuration. Old URL in Note section will give 404 error on GitHub page. 

Current wrong URL `(https://github.com/argoproj-labs/argocd-image-updater/manifests/base)`  that given 404. 