### PR TITLE
Name strategy regexp in example need to be correctd 

### DIFF
--- a/docs/basics/update-strategies.md
+++ b/docs/basics/update-strategies.md
@@ -278,7 +278,7 @@ for update, you will need additional configuration. For example,
 ```yaml
 argocd-image-updater.argoproj.io/image-list: myimage=some/image
 argocd-image-updater.argoproj.io/myimage.update-strategy: name
-argocd-image-updater.argoproj.io/myimage.allow-tags: regexp:^[0-9]{4}-[0-9]{2}[0-9]{2}$
+argocd-image-updater.argoproj.io/myimage.allow-tags: regexp:^[0-9]{4}-[0-9]{2}-[0-9]{2}$
 ```
 
 or 
@@ -286,7 +286,7 @@ or
 ```yaml
 argocd-image-updater.argoproj.io/image-list: myimage=some/image
 argocd-image-updater.argoproj.io/myimage.update-strategy: alphabetical
-argocd-image-updater.argoproj.io/myimage.allow-tags: regexp:^[0-9]{4}-[0-9]{2}[0-9]{2}$
+argocd-image-updater.argoproj.io/myimage.allow-tags: regexp:^[0-9]{4}-[0-9]{2}-[0-9]{2}$
 ```
 
 would only consider tags that match a given regular expression for update. In


### PR DESCRIPTION
Name strategy among Update strategies, have its example have a wrong regexp. Need correction to match format mentioned in last line `YYYY-MM-DD`.  Current one is this format YYYY-MMDD (which is not what, doc wish to show)