### PR TITLE
Adds a new update strategy: manual

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -45,6 +45,7 @@ type ImageUpdaterConfig struct {
 	GitCommitMail       string
 	GitCommitMessage    *template.Template
 	DisableKubeEvents   bool
+	ManualTagValue      string
 }
 
 // newRootCommand implements the root command of argocd-image-updater

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -33,6 +33,7 @@ func newRunCommand() *cobra.Command {
 	var warmUpCache bool = true
 	var commitMessagePath string
 	var commitMessageTpl string
+
 	var runCmd = &cobra.Command{
 		Use:   "run",
 		Short: "Runs the argocd-image-updater with a set of options",
@@ -223,7 +224,7 @@ func newRunCommand() *cobra.Command {
 	runCmd.Flags().StringVar(&cfg.GitCommitMail, "git-commit-email", env.GetStringVal("GIT_COMMIT_EMAIL", "noreply@argoproj.io"), "E-Mail address to use for Git commits")
 	runCmd.Flags().StringVar(&commitMessagePath, "git-commit-message-path", defaultCommitTemplatePath, "Path to a template to use for Git commit messages")
 	runCmd.Flags().BoolVar(&cfg.DisableKubeEvents, "disable-kube-events", env.GetBoolVal("IMAGE_UPDATER_KUBE_EVENTS", false), "Disable kubernetes events")
-
+	runCmd.Flags().StringVar(&cfg.ManualTagValue, "manual-tag-value", "", "Defines the image tag that will be used to update the app")
 	return runCmd
 }
 
@@ -309,6 +310,7 @@ func runImageUpdater(cfg *ImageUpdaterConfig, warmUp bool) (argocd.ImageUpdaterR
 				GitCommitEmail:    cfg.GitCommitMail,
 				GitCommitMessage:  cfg.GitCommitMessage,
 				DisableKubeEvents: cfg.DisableKubeEvents,
+				ManualTagValue:    cfg.ManualTagValue,
 			}
 			res := argocd.UpdateApplication(upconf, syncState)
 			result.NumApplicationsProcessed += 1

--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -43,6 +43,7 @@ type UpdateConfiguration struct {
 	GitCommitMessage  *template.Template
 	DisableKubeEvents bool
 	IgnorePlatforms   bool
+	ManualTagValue    string
 }
 
 type GitCredsSource func(app *v1alpha1.Application) (git.Creds, error)
@@ -196,6 +197,12 @@ func UpdateApplication(updateConf *UpdateConfiguration, state *SyncIterationStat
 		}
 
 		vc.Strategy = applicationImage.GetParameterUpdateStrategy(updateConf.UpdateApp.Application.Annotations)
+		// If strategy is manual but no tag has been set, default to SemVer
+		if vc.Strategy == image.StrategyManual && updateConf.ManualTagValue == "" {
+			imgCtx.Infof("strategy is set to %s but it requires a tag defined via --manual-tag-value. Defaulting to %s strategy instead.", vc.Strategy.String(), image.StrategySemVer.String())
+			vc.Strategy = image.StrategySemVer
+		}
+
 		vc.MatchFunc, vc.MatchArgs = applicationImage.GetParameterMatch(updateConf.UpdateApp.Application.Annotations)
 		vc.IgnoreList = applicationImage.GetParameterIgnoreTags(updateConf.UpdateApp.Application.Annotations)
 		vc.Options = applicationImage.
@@ -234,13 +241,20 @@ func UpdateApplication(updateConf *UpdateConfiguration, state *SyncIterationStat
 			result.NumErrors += 1
 			continue
 		}
+		var tags *tag.ImageTagList = tag.NewImageTagList()
 
-		// Get list of available image tags from the repository
-		tags, err := rep.GetTags(applicationImage, regClient, &vc)
-		if err != nil {
-			imgCtx.Errorf("Could not get tags from registry: %v", err)
-			result.NumErrors += 1
-			continue
+		if vc.Strategy != image.StrategyManual {
+			// Get list of available image tags from the repository
+			tags, err = rep.GetTags(applicationImage, regClient, &vc)
+			if err != nil {
+				imgCtx.Errorf("Could not get tags from registry: %v", err)
+				result.NumErrors += 1
+				continue
+			}
+		} else {
+			manualTag := tag.NewImageTag(updateConf.ManualTagValue, time.Unix(0, 0), "")
+
+			tags.Add(manualTag)
 		}
 
 		imgCtx.Tracef("List of available tags found: %v", tags.Tags())

--- a/pkg/image/options.go
+++ b/pkg/image/options.go
@@ -112,6 +112,8 @@ func (img *ContainerImage) ParseUpdateStrategy(val string) UpdateStrategy {
 		return StrategyAlphabetical
 	case "digest":
 		return StrategyDigest
+	case "manual":
+		return StrategyManual
 	default:
 		logCtx.Warnf("Unknown sort option %s -- using semver", val)
 		return StrategySemVer

--- a/pkg/image/version.go
+++ b/pkg/image/version.go
@@ -22,6 +22,8 @@ const (
 	StrategyAlphabetical UpdateStrategy = 2
 	// VersionSortDigest uses latest digest of an image
 	StrategyDigest UpdateStrategy = 3
+	// VersionManual uses a user provided tag for an image
+	StrategyManual UpdateStrategy = 4
 )
 
 func (us UpdateStrategy) String() string {
@@ -34,6 +36,8 @@ func (us UpdateStrategy) String() string {
 		return "alphabetical"
 	case StrategyDigest:
 		return "digest"
+	case StrategyManual:
+		return "manual"
 	}
 
 	return "unknown"
@@ -92,6 +96,8 @@ func (img *ContainerImage) GetNewestVersionFromTags(vc *VersionConstraint, tagLi
 	case StrategyNewestBuild:
 		availableTags = tagList.SortByDate()
 	case StrategyDigest:
+		availableTags = tagList.SortAlphabetically()
+	case StrategyManual:
 		availableTags = tagList.SortAlphabetically()
 	}
 


### PR DESCRIPTION
When running argocd-image-updater as part of a pipeline, it will be handy to be able to manually specify the image tag that you want to configure on your files.

Example:

Let's say we have a pipeline that builds our app, the resulting container image will get a tag that will match the commit id that generated that pipeline execution. Something like `example-image:7b7d2504`.

Other pipelines/people may be working with that image and generating different tags, so using something like `latest` strategy won't work.

I want the pipeline to update my Argo APP so as soon as the image is tagged and pushed the app gets deployed to my env. In the past, we used this tool[1]. 

In the pipeline, the last step will be updating the files in git with the new tag generated.

[1] https://github.com/gitops-tools/image-updater