### PR TITLE
Documentation: ArgoCD apps in any namespace incompatibility

### DIFF
--- a/docs/configuration/applications.md
+++ b/docs/configuration/applications.md
@@ -22,6 +22,11 @@ only resources of kind `application.argoproj.io`, that is, your Argo CD
 `Application` resources. Annotations on other kinds of resources will have no
 effect and will not be considered.
 
+!!!warning
+    Argo CD Image Updater is not currently compatible with the
+    [Argo CD Applications in any namespace](https://argo-cd.readthedocs.io/en/stable/operator-manual/app-any-namespace/)
+    feature. All `Application` resources must be declared in Argo CD control plane's namespace (which is usually argocd.)
+
 As explained earlier, your Argo CD applications must be of either `Kustomize`
 or `Helm` type. Other types of applications will be ignored.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,14 +8,18 @@ that are managed by
     Argo CD Image Updater is under active development.
 
     You are welcome to test it out on non-critical environments, and of
-    course to 
+    course to
     [contribute](./contributing/start.md) by many means.
 
     There will be (probably a lot of) breaking changes from release to
     release as development progresses until version 1.0. We will do our
     best to indicate any breaking change and how to un-break it in the
     respective
-    [release notes](https://github.com/argoproj-labs/argocd-image-updater/releases)
+    [release notes](https://github.com/argoproj-labs/argocd-image-updater/releases).
+
+    Argo CD Image Updater is not currently compatible with
+    [Argo CD Applications in any namespace](https://argo-cd.readthedocs.io/en/stable/operator-manual/app-any-namespace/).
+
 
 ## Overview
 


### PR DESCRIPTION
For those using [Applications in any namespace](https://argo-cd.readthedocs.io/en/stable/operator-manual/app-any-namespace), the docs should mention that Image Updater is not compatible with any `Application` resources installed in namespaces other than `argocd`. 