### PR TITLE
default semver constraint for empty string

### DIFF
--- a/pkg/image/version.go
+++ b/pkg/image/version.go
@@ -123,6 +123,10 @@ func (img *ContainerImage) GetNewestVersionFromTags(vc *VersionConstraint, tagLi
 					return nil, err
 				}
 			}
+		} else if vc.Strategy == StrategySemVer {
+			// The is the special case where an empty string was passed in which
+			// is equivalent to * or >=0.0.0
+			semverConstraint, _ = semver.NewConstraint("*")
 		}
 	}
 


### PR DESCRIPTION
Closes https://github.com/argoproj-labs/argocd-image-updater/issues/556

This PR is to fix 2 issues:
1. current tags filtering behavior will skip semver constraint for prereleases versions (although they are valid semver versions) when there is no explicit constraint parsed from image tags (i.e. empty string) which is inconsistent with the [document description](https://argocd-image-updater.readthedocs.io/en/stable/basics/update-strategies/#semver-update-to-semantic-versions). 
https://github.com/argoproj-labs/argocd-image-updater/blob/master/pkg/image/version.go#L135-L147

3. some complex prerelease constraint rules are actually not supported until[semver > 3.2.0](https://github.com/Masterminds/semver/blob/master/constraints_test.go#L127)