### PR TITLE
docs(registries): add env example

### DIFF
--- a/docs/configuration/registries.md
+++ b/docs/configuration/registries.md
@@ -153,6 +153,10 @@ properties are optional, unless otherwise stated:
 
 The following is an example that configures two registries.
 
+```bash
+export REGISTRY_SECRET="login:password"
+```
+
 ```yaml
 registries:
 - name: Docker Hub


### PR DESCRIPTION
Docs lacks an example of the credentials environment variable, making it unclear whether it should contain dockerconfig, a login:password pair, or something else. 
This Pull Request aims to address this issue by providing the necessary example.