### PR TITLE
ensure deterministic results for SortBySemVer()

### DIFF
--- a/pkg/tag/semver.go
+++ b/pkg/tag/semver.go
@@ -1,0 +1,31 @@
+package tag
+
+import "github.com/Masterminds/semver"
+
+// semverCollection is a replacement for semver.Collection that breaks version
+// comparison ties through a lexical comparison of the original version strings.
+// Using this, instead of semver.Collection, when sorting will yield
+// deterministic results that semver.Collection will not yield.
+type semverCollection []*semver.Version
+
+// Len returns the length of a collection. The number of Version instances
+// on the slice.
+func (s semverCollection) Len() int {
+	return len(s)
+}
+
+// Less is needed for the sort interface to compare two Version objects on the
+// slice. If checks if one is less than the other.
+func (s semverCollection) Less(i, j int) bool {
+	comp := s[i].Compare(s[j])
+	if comp != 0 {
+		return comp < 0
+	}
+	return s[i].Original() < s[j].Original()
+}
+
+// Swap is needed for the sort interface to replace the Version objects
+// at two different positions in the slice.
+func (s semverCollection) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}

--- a/pkg/tag/tag.go
+++ b/pkg/tag/tag.go
@@ -165,7 +165,7 @@ func (il ImageTagList) SortBySemVer() SortableImageTagList {
 		}
 		svl = append(svl, svi)
 	}
-	sort.Sort(semver.Collection(svl))
+	sort.Sort(semverCollection(svl))
 	for _, svi := range svl {
 		sil = append(sil, NewImageTag(svi.Original(), *il.items[svi.Original()].TagDate, il.items[svi.Original()].TagDigest))
 	}

--- a/pkg/tag/tag_test.go
+++ b/pkg/tag/tag_test.go
@@ -106,7 +106,7 @@ func Test_SortableImageTagList(t *testing.T) {
 	})
 
 	t.Run("Sort by semver", func(t *testing.T) {
-		names := []string{"v2.0.2", "v1.0", "v1.0.1", "v2.0.3", "v2.0"}
+		names := []string{"v2.0.2", "v1.0", "v2.0.0", "v1.0.1", "v2.0.3", "v2.0"}
 		il := NewImageTagList()
 		for _, name := range names {
 			tag := NewImageTag(name, time.Now(), "")
@@ -117,8 +117,9 @@ func Test_SortableImageTagList(t *testing.T) {
 		assert.Equal(t, "v1.0", sil[0].TagName)
 		assert.Equal(t, "v1.0.1", sil[1].TagName)
 		assert.Equal(t, "v2.0", sil[2].TagName)
-		assert.Equal(t, "v2.0.2", sil[3].TagName)
-		assert.Equal(t, "v2.0.3", sil[4].TagName)
+		assert.Equal(t, "v2.0.0", sil[3].TagName)
+		assert.Equal(t, "v2.0.2", sil[4].TagName)
+		assert.Equal(t, "v2.0.3", sil[5].TagName)
 	})
 
 	t.Run("Sort by date", func(t *testing.T) {


### PR DESCRIPTION
Fixes #375

The heart of the issue is that https://github.com/masterminds/semver does not yield deterministic results when sorting versions. That package (rightfully) considers `1.24` and `1.24.0`, for example, to be equal. This is fine in nearly all circumstances, but when sorting a list of versions containing both of these, these two can appear in either order, making the results of the sort non-deterministic. If one's goal were to select the latest `1.24.x`, you'd sometimes end up with `list[len(list) - 1]` being `1.24` and other times being `1.24.0`.

This PR furnishes a drop-in replacement for the `semver.Collection` type that breaks comparison ties with a lexical comparison of the origin strings from which both `Version` objects were created.

fwiw, I do plan to offer this improvement upstream to https://github.com/masterminds/semver, but am also offering it here because the `semver` package has moved on to a `v3` which is API-compatible, but has breaking changes in its _functionality_. I am reluctant to suggest that the solution is the get this merged upstream and _then_ upgrade to v3, as that upgrade would surely affect things in other, unanticipated ways.

