### PR TITLE
feat: Respect original parameter overrides with git write-back

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	go.uber.org/ratelimit v0.1.1-0.20201110185707-e86515f0dda9
 	golang.org/x/crypto v0.1.0
+	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v1.22.4
@@ -128,7 +129,6 @@ require (
 	github.com/xanzy/ssh-agent v0.2.1 // indirect
 	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
-	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect
 	golang.org/x/sys v0.5.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/btree v1.0.1 // indirect
-	github.com/google/go-cmp v0.5.6 // indirect
+	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/google/go-github/v29 v29.0.2 // indirect
 	github.com/google/go-github/v38 v38.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
@@ -128,7 +128,7 @@ require (
 	github.com/xanzy/ssh-agent v0.2.1 // indirect
 	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
-	golang.org/x/exp v0.0.0-20210901193431-a062eea981d2 // indirect
+	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect
 	golang.org/x/sys v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -415,7 +415,6 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
@@ -966,7 +965,6 @@ golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20210220032938-85be41e4509f/go.mod h1:I6l2HNBLBZEcrOoCpyKLdY2lHoRZ8lI4x60KMCQDft4=
-golang.org/x/exp v0.0.0-20210901193431-a062eea981d2 h1:Or4Ra3AAlhUlNn8WmIzw2Yq2vUHSkrP6E2e/FIESpF8=
 golang.org/x/exp v0.0.0-20210901193431-a062eea981d2/go.mod h1:a3o/VtDNHN+dCVLEpzjjUHOzR+Ln3DHX056ZPzoZGGA=
 golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
 golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=

--- a/go.sum
+++ b/go.sum
@@ -417,6 +417,8 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-github/v29 v29.0.2 h1:opYN6Wc7DOz7Ku3Oh4l7prmkOMwEcQxpFtxdU8N8Pts=
 github.com/google/go-github/v29 v29.0.2/go.mod h1:CHKiKKPHJ0REzfwc14QMklvtHwCveD0PxlMjLlzAM5E=
 github.com/google/go-github/v38 v38.0.0 h1:l/BalRp6dmFh/SFbl32RrlaVvbByhxpy+/LY0sv9isM=
@@ -966,6 +968,8 @@ golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMk
 golang.org/x/exp v0.0.0-20210220032938-85be41e4509f/go.mod h1:I6l2HNBLBZEcrOoCpyKLdY2lHoRZ8lI4x60KMCQDft4=
 golang.org/x/exp v0.0.0-20210901193431-a062eea981d2 h1:Or4Ra3AAlhUlNn8WmIzw2Yq2vUHSkrP6E2e/FIESpF8=
 golang.org/x/exp v0.0.0-20210901193431-a062eea981d2/go.mod h1:a3o/VtDNHN+dCVLEpzjjUHOzR+Ln3DHX056ZPzoZGGA=
+golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
+golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=

--- a/pkg/argocd/git.go
+++ b/pkg/argocd/git.go
@@ -259,22 +259,28 @@ func writeOverrides(app *v1alpha1.Application, wbc *WriteBackConfig, gitC git.Cl
 		}
 	}
 
-	override, err := marshalParamsOverride(app)
-	if err != nil {
-		return
-	}
-
 	// If the target file already exist in the repository, we will check whether
 	// our generated new file is the same as the existing one, and if yes, we
 	// don't proceed further for commit.
+	var override []byte
+	var originalData []byte
 	if targetExists {
-		data, err := os.ReadFile(targetFile)
+		originalData, err = os.ReadFile(targetFile)
 		if err != nil {
 			return err, false
 		}
-		if string(data) == string(override) {
+		override, err = marshalParamsOverride(app, originalData)
+		if err != nil {
+			return
+		}
+		if string(originalData) == string(override) {
 			logCtx.Debugf("target parameter file and marshaled data are the same, skipping commit.")
 			return nil, true
+		}
+	} else {
+		override, err = marshalParamsOverride(app, nil)
+		if err != nil {
+			return
 		}
 	}
 

--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -9,6 +9,8 @@ import (
 	"text/template"
 	"time"
 
+	"golang.org/x/exp/slices"
+
 	"github.com/argoproj-labs/argocd-image-updater/ext/git"
 	"github.com/argoproj-labs/argocd-image-updater/pkg/common"
 	"github.com/argoproj-labs/argocd-image-updater/pkg/image"
@@ -16,7 +18,6 @@ import (
 	"github.com/argoproj-labs/argocd-image-updater/pkg/log"
 	"github.com/argoproj-labs/argocd-image-updater/pkg/registry"
 	"github.com/argoproj-labs/argocd-image-updater/pkg/tag"
-	"golang.org/x/exp/slices"
 
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
@@ -420,7 +421,7 @@ func marshalParamsOverride(app *v1alpha1.Application, originalData []byte) ([]by
 			override, err = yaml.Marshal(newParams)
 			break
 		}
-		err := yaml.Unmarshal(originalData, &params)
+		err = yaml.Unmarshal(originalData, &params)
 		if err != nil {
 			override, err = yaml.Marshal(newParams)
 			break

--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -3,7 +3,6 @@ package argocd
 import (
 	"context"
 	"fmt"
-	"golang.org/x/exp/slices"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -17,6 +16,7 @@ import (
 	"github.com/argoproj-labs/argocd-image-updater/pkg/log"
 	"github.com/argoproj-labs/argocd-image-updater/pkg/registry"
 	"github.com/argoproj-labs/argocd-image-updater/pkg/tag"
+	"golang.org/x/exp/slices"
 
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
@@ -398,7 +398,7 @@ func marshalParamsOverride(app *v1alpha1.Application, originalData []byte) ([]by
 			override, err = yaml.Marshal(newParams)
 			break
 		}
-		err := yaml.Unmarshal(originalData, &params)
+		err = yaml.Unmarshal(originalData, &params)
 		if err != nil {
 			override, err = yaml.Marshal(newParams)
 			break

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -1823,6 +1823,56 @@ func Test_CommitUpdates(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("Good commit to helm override", func(t *testing.T) {
+		app := app.DeepCopy()
+		app.Status.SourceType = "Helm"
+		app.Spec.Source.Helm = &v1alpha1.ApplicationSourceHelm{Parameters: []v1alpha1.HelmParameter{
+			{Name: "bar", Value: "bar", ForceString: true},
+			{Name: "baz", Value: "baz", ForceString: true},
+		}}
+		gitMock, dir, cleanup := mockGit(t)
+		defer cleanup()
+		of := filepath.Join(dir, ".argocd-source-testapp.yaml")
+		assert.NoError(t, os.WriteFile(of, []byte(`
+helm:
+  parameters:
+  - name: foo
+    value: foo
+    forcestring: true
+`), os.ModePerm))
+
+		gitMock.On("Checkout", mock.Anything).Run(func(args mock.Arguments) {
+			args.Assert(t, "mydefaultbranch")
+		}).Return(nil)
+		gitMock.On("Add", mock.Anything).Return(nil)
+		gitMock.On("Commit", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		gitMock.On("Push", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		gitMock.On("SymRefToBranch", mock.Anything).Return("mydefaultbranch", nil)
+		wbc, err := getWriteBackConfig(app, &kubeClient, &argoClient)
+		require.NoError(t, err)
+		wbc.GitClient = gitMock
+		app.Spec.Source.TargetRevision = "HEAD"
+		wbc.GitBranch = ""
+
+		err = commitChanges(app, wbc, nil)
+		assert.NoError(t, err)
+		override, err := os.ReadFile(of)
+		assert.NoError(t, err)
+		assert.YAMLEq(t, `
+helm:
+  parameters:
+  - name: foo
+    value: foo
+    forcestring: true
+  - name: bar
+    value: bar
+    forcestring: true
+  - name: baz
+    value: baz
+    forcestring: true
+`, string(override))
+	})
+
 	t.Run("Good commit to kustomization", func(t *testing.T) {
 		app := app.DeepCopy()
 		app.Annotations[common.WriteBackTargetAnnotation] = "kustomization"

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -1094,7 +1094,7 @@ kustomize:
 			},
 		}
 
-		yaml, err := marshalParamsOverride(&app)
+		yaml, err := marshalParamsOverride(&app, nil)
 		require.NoError(t, err)
 		assert.NotEmpty(t, yaml)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(yaml)))
@@ -1120,7 +1120,7 @@ kustomize:
 			},
 		}
 
-		yaml, err := marshalParamsOverride(&app)
+		yaml, err := marshalParamsOverride(&app, nil)
 		require.NoError(t, err)
 		assert.Empty(t, yaml)
 		assert.Equal(t, "", strings.TrimSpace(string(yaml)))
@@ -1170,7 +1170,7 @@ helm:
 			},
 		}
 
-		yaml, err := marshalParamsOverride(&app)
+		yaml, err := marshalParamsOverride(&app, nil)
 		require.NoError(t, err)
 		assert.NotEmpty(t, yaml)
 		assert.Equal(t, strings.TrimSpace(strings.ReplaceAll(expected, "\t", "  ")), strings.TrimSpace(string(yaml)))
@@ -1196,7 +1196,7 @@ helm:
 			},
 		}
 
-		yaml, err := marshalParamsOverride(&app)
+		yaml, err := marshalParamsOverride(&app, nil)
 		require.NoError(t, err)
 		assert.Empty(t, yaml)
 	})
@@ -1227,7 +1227,7 @@ helm:
 			},
 		}
 
-		_, err := marshalParamsOverride(&app)
+		_, err := marshalParamsOverride(&app, nil)
 		assert.Error(t, err)
 	})
 }

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -1066,6 +1066,7 @@ func Test_MarshalParamsOverride(t *testing.T) {
 		expected := `
 kustomize:
   images:
+  - baz
   - foo
   - bar
 `
@@ -1093,8 +1094,12 @@ kustomize:
 				SourceType: v1alpha1.ApplicationSourceTypeKustomize,
 			},
 		}
-
-		yaml, err := marshalParamsOverride(&app, nil)
+		originalData := []byte(`
+kustomize:
+  images:
+  - baz
+`)
+		yaml, err := marshalParamsOverride(&app, originalData)
 		require.NoError(t, err)
 		assert.NotEmpty(t, yaml)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(yaml)))
@@ -1130,6 +1135,9 @@ kustomize:
 		expected := `
 helm:
   parameters:
+	- name: baz
+		value: baz
+		forcestring: false
 	- name: foo
 		value: bar
 		forcestring: true
@@ -1170,7 +1178,14 @@ helm:
 			},
 		}
 
-		yaml, err := marshalParamsOverride(&app, nil)
+		originalData := []byte(`
+helm:
+  parameters:
+    - name: baz
+      value: baz
+      forcestring: false
+`)
+		yaml, err := marshalParamsOverride(&app, originalData)
 		require.NoError(t, err)
 		assert.NotEmpty(t, yaml)
 		assert.Equal(t, strings.TrimSpace(strings.ReplaceAll(expected, "\t", "  ")), strings.TrimSpace(string(yaml)))


### PR DESCRIPTION
Modification:

Make image-updater respect the original parameter overrides written in `.argocd-source-<appName>.yaml`.

Motivation:

Currently, the original overridden parameters stored in `.argocd-source-<appName>.yaml`
are not respected when image-updater writes back its change to git.

Imagine that a user has originally defined `.argocd-source-<appName>.yaml` like below
```yaml
helm:
  parameters:
  - name: some.prop
    value: some-value
    forcestring: true
```
...and image-updater wants to write back the additional overrides below
- `foo.image.repository: foo`
- `foo.image.tag: 2.0.0`

The user may want the edited file to be like...
```yaml
helm:
  parameters:
  - name: some.prop
    value: some-value
    focestring: true
  - name: foo.image.repository
    value: foo
    forcestring: true
  - name: foo.image.tag
    value: 2.0.0
    forcestring: true
```
... but what's actually committed to git is the following and it deletes the original user-defined parameter overrides.
```yaml
helm:
  parameters:
  - name: foo.image.repository
    value: foo
    forcestring: true
  - name: foo.image.tag
    value: 2.0.0
    forcestring: true
```

And this image-updater behavior is a suspected cause of #562 and the likes
as image-updater ignores the tags for an image that it failed to fetch when
there are multiple updatable images defined in an `Application` and generate 
the parameter overrides without the ignored image. 
If only a part of image tags were successfully fetched from the image registry
due to unstable network, image-updater may write a broken parameter override
file to git.