### PR TITLE
Fix: kustomize write target starts failing after indeterminate period at time

### DIFF
--- a/pkg/argocd/git.go
+++ b/pkg/argocd/git.go
@@ -294,18 +294,8 @@ var _ changeWriter = writeOverrides
 // writeKustomization writes any changes required for updating one or more images to a kustomization.yml
 func writeKustomization(app *v1alpha1.Application, wbc *WriteBackConfig, gitC git.Client) (err error, skip bool) {
 	logCtx := log.WithContext().AddField("application", app.GetName())
-	if oldDir, err := os.Getwd(); err != nil {
-		return err, false
-	} else {
-		defer func() {
-			_ = os.Chdir(oldDir)
-		}()
-	}
 
 	base := filepath.Join(gitC.Root(), wbc.KustomizeBase)
-	if err := os.Chdir(base); err != nil {
-		return err, false
-	}
 
 	logCtx.Infof("updating base %s", base)
 


### PR DESCRIPTION
Fixes at least one of the causes of the image kustomize write back with git failing as documented in this issue: https://github.com/argoproj-labs/argocd-image-updater/issues/240

Our Argo CD Image Updater deployment started having the same issue after switching to use Kustomize from Helm. After troubleshooting the issue with our setup, the process chdir that is happening in the write kustomization func didn't always chdir back to the original dir. Then subsequent `os.Getwd()` calls would fail with `getwd: no such file or directory` because the process working directory was still set to a previous temp dir that no longer exists. After reviewing the implementation details and testing, the chdir code doesn't appear to be needed anyway so it has been removed in the PR fixing the issue.

Note: `make test`, `make test-race` and `make lint`  targets are all still passing after the changes.

Also during testing, I noticed that _zombie_ git processes are building up in the running container after each periodic image updater run. The Argo CD project had a similar issue: https://github.com/argoproj/argo-cd/issues/3611. I will be opening another PR with a similar fix as well