### PR TITLE
Fix: git zombie processes left behind after periodic image updater runs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ FROM alpine:latest
 
 RUN apk update && \
     apk upgrade && \
-    apk add ca-certificates git openssh-client python3 py3-pip && \
+    apk add ca-certificates git openssh-client python3 py3-pip tini && \
     pip3 install --upgrade pip && \
     pip3 install awscli && \
     rm -rf /var/cache/apk/*
@@ -28,4 +28,4 @@ COPY hack/git-ask-pass.sh /usr/local/bin/git-ask-pass.sh
 
 USER 1000
 
-ENTRYPOINT ["/usr/local/bin/argocd-image-updater"]
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/argocd-image-updater"]

--- a/manifests/base/deployment/argocd-image-updater-deployment.yaml
+++ b/manifests/base/deployment/argocd-image-updater-deployment.yaml
@@ -18,8 +18,7 @@ spec:
         app.kubernetes.io/name: argocd-image-updater
     spec:
       containers:
-      - command:
-        - /usr/local/bin/argocd-image-updater
+      - args:
         - run
         image: quay.io/argoprojlabs/argocd-image-updater:latest
         imagePullPolicy: Always


### PR DESCRIPTION
As mentioned in https://github.com/argoproj-labs/argocd-image-updater/pull/583, during troubleshooting and testing for that issue, I noticed that zombie git processes were building up in the running container after each periodic image updater run. The Argo CD project had a similar issue: https://github.com/argoproj/argo-cd/issues/3611 and my fix uses the same solution