### PR TITLE
feat: Allow ACR authentication using Azure CLI

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -1,3 +1,5 @@
+acr
+ACR
 aic
 amd
 anyfield
@@ -14,6 +16,7 @@ argoprojlabs
 args
 auths
 aws
+azurecr
 babayaga
 baralias
 baz
@@ -217,6 +220,7 @@ TODO
 toolchain
 Torvalds
 Tracef
+tsv
 uber
 unmarshal
 unmarshals

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,10 @@ RUN apk update && \
     apk add ca-certificates git openssh-client aws-cli tini gpg gpg-agent && \
     rm -rf /var/cache/apk/*
 
+RUN apk add gcc musl-dev python3-dev libffi-dev openssl-dev cargo make py3-pip && \
+    pip3 install --break-system-packages azure-cli && \
+    rm -rf /var/cache/apk/*
+
 RUN mkdir -p /usr/local/bin
 RUN mkdir -p /app/config
 RUN adduser --home "/app" --disabled-password --uid 1000 argocd

--- a/docs/configuration/registries.md
+++ b/docs/configuration/registries.md
@@ -15,6 +15,7 @@ It has been successfully tested against the following popular registries:
 * GitHub Packages Registry (`docker.pkg.github.com`)
 * GitLab Container Registry (`registry.gitlab.com`)
 * Google Container Registry (`gcr.io`)
+* Azure Container Registry (`azurecr.io`)
 
 Chances are, that it will work out of the box for other registries as well.
 
@@ -326,3 +327,29 @@ two strategies to overcome this:
   i.e. for getting EKS credentials from the aws CLI. For example, if the
   token has a lifetime of 12 hours, you can set `credsexpire: 12h` and Argo
   CD Image Updater will get a new token after 12 hours.
+
+### <a name="external-script-azure"></a>Configuring a script to authenticate against an Azure Container Registry
+
+You can authenticate against an Azure Container Registry using Azure Managed Identities with an external script:
+
+```yaml
+registries:
+- name: ACR example with external script
+  api_url: https://acr-example.azurecr.io/
+  prefix: acr-example.azurecr.io
+  credentials: ext:/app/scripts/acr-login.sh
+  credsexpire: 10h
+```
+
+The script should contain the name of the registry:
+
+```bash
+  acr-login.sh: |
+    #!/bin/sh
+    LOGIN=$(az login --identity)
+    REGISTRY="acr-example"
+    TOKEN=$(az acr login --name $REGISTRY --expose-token --output tsv --query accessToken)
+    echo "00000000-0000-0000-0000-000000000000:$TOKEN"
+```
+
+And the image used for `argocd-image-updater` should contain the Azure CLI.

--- a/registry-scanner/pkg/image/credentials.go
+++ b/registry-scanner/pkg/image/credentials.go
@@ -146,7 +146,7 @@ func (src *CredentialSource) FetchCredentials(registryURL string, kubeclient *ku
 			return nil, fmt.Errorf("could not stat %s: %v", src.ScriptPath, err)
 		}
 		cmd := exec.Command(src.ScriptPath)
-		out, err := argoexec.RunCommandExt(cmd, argoexec.CmdOpts{Timeout: 10 * time.Second})
+		out, err := argoexec.RunCommandExt(cmd, argoexec.CmdOpts{Timeout: 30 * time.Second})
 		if err != nil {
 			return nil, fmt.Errorf("error executing %s: %v", src.ScriptPath, err)
 		}


### PR DESCRIPTION
Install azure-cli in Docker image in order to use the `az acr login` command.

Can be used with Azure Managed Identities with the following script:

```yaml
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: argocd-image-updater-config
  namespace: argocd
data:
  log.level: debug
  registries.conf: |
    registries:
    - name: acrexample
      api_url: https://acrexample.azurecr.io/
      prefix: acrexample.azurecr.io
      ping: yes
      insecure: no
      credentials: ext:/app/scripts/acr-login.sh
      credsexpire: 10h
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: argocd-image-updater-config-acr
  namespace: argocd
data:
  acr-login.sh: |
    #!/bin/sh
    LOGIN=$(az login --identity)
    REGISTRY="acrexample"
    TOKEN=$(az acr login --name $REGISTRY --expose-token --output tsv --query accessToken)
    echo "00000000-0000-0000-0000-000000000000:$TOKEN"
```

Closes #550 and #473