### PR TITLE
feat: Allow applications in any namespace

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -45,6 +45,7 @@ type ImageUpdaterConfig struct {
 	GitCommitMail       string
 	GitCommitMessage    *template.Template
 	DisableKubeEvents   bool
+	Namespaced          bool
 }
 
 // newRootCommand implements the root command of argocd-image-updater

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -68,7 +68,7 @@ argocd-image-updater test nginx --allow-tags '^1.19.\d+(\-.*)*$' --update-strate
 			var err error
 			if !disableKubernetes {
 				ctx := context.Background()
-				kubeClient, err = getKubeConfig(ctx, "", kubeConfig)
+				kubeClient, err = getKubeConfig(ctx, "", true, kubeConfig)
 				if err != nil {
 					log.Fatalf("could not create K8s client: %v", err)
 				}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -26,7 +26,7 @@ func getPrintableHealthPort(port int) string {
 	}
 }
 
-func getKubeConfig(ctx context.Context, namespace string, kubeConfig string) (*kube.KubernetesClient, error) {
+func getKubeConfig(ctx context.Context, namespace string, namespaced bool, kubeConfig string) (*kube.KubernetesClient, error) {
 	var fullKubeConfigPath string
 	var kubeClient *kube.KubernetesClient
 	var err error
@@ -39,12 +39,12 @@ func getKubeConfig(ctx context.Context, namespace string, kubeConfig string) (*k
 	}
 
 	if fullKubeConfigPath != "" {
-		log.Debugf("Creating Kubernetes client from %s", fullKubeConfigPath)
+		log.Debugf("Creating Kubernetes client from %s for namespace '%s'", fullKubeConfigPath, namespace)
 	} else {
-		log.Debugf("Creating in-cluster Kubernetes client")
+		log.Debugf("Creating in-cluster Kubernetes client for namespace '%s'", namespace)
 	}
 
-	kubeClient, err = kube.NewKubernetesClientFromConfig(ctx, namespace, fullKubeConfigPath)
+	kubeClient, err = kube.NewKubernetesClientFromConfig(ctx, namespace, namespaced, fullKubeConfigPath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/argocd/argocd_test.go
+++ b/pkg/argocd/argocd_test.go
@@ -206,8 +206,8 @@ func Test_FilterApplicationsForUpdate(t *testing.T) {
 		filtered, err := FilterApplicationsForUpdate(applicationList, []string{}, "")
 		require.NoError(t, err)
 		require.Len(t, filtered, 1)
-		require.Contains(t, filtered, "app1")
-		assert.Len(t, filtered["app1"].Images, 2)
+		require.Contains(t, filtered, "argocd/app1")
+		assert.Len(t, filtered["argocd/app1"].Images, 2)
 	})
 
 	t.Run("Filter for applications with patterns", func(t *testing.T) {
@@ -258,9 +258,9 @@ func Test_FilterApplicationsForUpdate(t *testing.T) {
 		filtered, err := FilterApplicationsForUpdate(applicationList, []string{"app*"}, "")
 		require.NoError(t, err)
 		require.Len(t, filtered, 2)
-		require.Contains(t, filtered, "app1")
-		require.Contains(t, filtered, "app2")
-		assert.Len(t, filtered["app1"].Images, 2)
+		require.Contains(t, filtered, "argocd/app1")
+		require.Contains(t, filtered, "argocd/app2")
+		assert.Len(t, filtered["argocd/app1"].Images, 2)
 	})
 
 	t.Run("Filter for applications with label", func(t *testing.T) {
@@ -300,8 +300,8 @@ func Test_FilterApplicationsForUpdate(t *testing.T) {
 		filtered, err := FilterApplicationsForUpdate(applicationList, []string{}, "custom.label/name=xyz")
 		require.NoError(t, err)
 		require.Len(t, filtered, 1)
-		require.Contains(t, filtered, "app1")
-		assert.Len(t, filtered["app1"].Images, 2)
+		require.Contains(t, filtered, "argocd/app1")
+		assert.Len(t, filtered["argocd/app1"].Images, 2)
 	})
 
 }

--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -140,6 +140,7 @@ func UpdateApplication(updateConf *UpdateConfiguration, state *SyncIterationStat
 
 	result := ImageUpdaterResult{}
 	app := updateConf.UpdateApp.Application.GetName()
+	namespace := updateConf.UpdateApp.Application.GetNamespace()
 	changeList := make([]ChangeEntry, 0)
 
 	// Get all images that are deployed with the current application
@@ -156,7 +157,10 @@ func UpdateApplication(updateConf *UpdateConfiguration, state *SyncIterationStat
 	for _, applicationImage := range updateConf.UpdateApp.Images {
 		updateableImage := applicationImages.ContainsImage(applicationImage, false)
 		if updateableImage == nil {
-			log.WithContext().AddField("application", app).Debugf("Image '%s' seems not to be live in this application, skipping", applicationImage.ImageName)
+			log.WithContext().
+				AddField("application", app).
+				AddField("namespace", namespace).
+				Debugf("Image '%s' seems not to be live in this application, skipping", applicationImage.ImageName)
 			result.NumSkipped += 1
 			continue
 		}
@@ -172,6 +176,7 @@ func UpdateApplication(updateConf *UpdateConfiguration, state *SyncIterationStat
 
 		imgCtx := log.WithContext().
 			AddField("application", app).
+			AddField("namespace", namespace).
 			AddField("registry", updateableImage.RegistryURL).
 			AddField("image_name", updateableImage.ImageName).
 			AddField("image_tag", updateableImage.ImageTag).

--- a/pkg/kube/kubernetes.go
+++ b/pkg/kube/kubernetes.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/argoproj-labs/argocd-image-updater/pkg/log"
 	"github.com/argoproj-labs/argocd-image-updater/pkg/metrics"
 
 	appv1alpha1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
@@ -38,7 +39,7 @@ func NewKubernetesClient(ctx context.Context, client kubernetes.Interface, appli
 // NewKubernetesClient creates a new Kubernetes client object from given
 // configuration file. If configuration file is the empty string, in-cluster
 // client will be created.
-func NewKubernetesClientFromConfig(ctx context.Context, namespace string, kubeconfig string) (*KubernetesClient, error) {
+func NewKubernetesClientFromConfig(ctx context.Context, namespace string, namespaced bool, kubeconfig string) (*KubernetesClient, error) {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
 	loadingRules.ExplicitPath = kubeconfig
@@ -50,7 +51,7 @@ func NewKubernetesClientFromConfig(ctx context.Context, namespace string, kubeco
 		return nil, err
 	}
 
-	if namespace == "" {
+	if namespace == "" && namespaced {
 		namespace, _, err = clientConfig.Namespace()
 		if err != nil {
 			return nil, err
@@ -67,6 +68,7 @@ func NewKubernetesClientFromConfig(ctx context.Context, namespace string, kubeco
 		return nil, err
 	}
 
+	log.Debugf("Creating kubernetes client for ns '%s'", namespace)
 	return NewKubernetesClient(ctx, clientset, applicationsClientset, namespace), nil
 }
 

--- a/pkg/kube/kubernetes_test.go
+++ b/pkg/kube/kubernetes_test.go
@@ -16,14 +16,14 @@ import (
 
 func Test_NewKubernetesClient(t *testing.T) {
 	t.Run("Get new K8s client for remote cluster instance", func(t *testing.T) {
-		client, err := NewKubernetesClientFromConfig(context.TODO(), "", "../../test/testdata/kubernetes/config")
+		client, err := NewKubernetesClientFromConfig(context.TODO(), "", true, "../../test/testdata/kubernetes/config")
 		require.NoError(t, err)
 		assert.NotNil(t, client)
 		assert.Equal(t, "default", client.Namespace)
 	})
 
 	t.Run("Get new K8s client for remote cluster instance specified namespace", func(t *testing.T) {
-		client, err := NewKubernetesClientFromConfig(context.TODO(), "argocd", "../../test/testdata/kubernetes/config")
+		client, err := NewKubernetesClientFromConfig(context.TODO(), "argocd", true, "../../test/testdata/kubernetes/config")
 		require.NoError(t, err)
 		assert.NotNil(t, client)
 		assert.Equal(t, "argocd", client.Namespace)


### PR DESCRIPTION
Add `--namespaced` flag, that when true will only monitor the configured namespace for applications. If it is false, then monitor all namespaces for applications.

By default this is set to `true` to preserve the current behavior.

fixes #601