### PR TITLE
chore(deps): Upgrade the version of semver package from v1 to v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/argoproj-labs/argocd-image-updater
 go 1.20
 
 require (
-	github.com/Masterminds/semver v1.5.0
+	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/argoproj/argo-cd/v2 v2.7.9
 	github.com/argoproj/gitops-engine v0.7.1-0.20230607163028-425d65e07695
 	github.com/argoproj/pkg v0.13.7-0.20230627120311-a4dd357b057e
@@ -42,7 +42,6 @@ require (
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 	github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd // indirect
-	github.com/Masterminds/semver/v3 v3.2.0 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20230717121422-5aa5874ade95 // indirect
 	github.com/acomagu/bufpipe v1.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -420,10 +420,8 @@ github.com/GoogleCloudPlatform/k8s-cloud-provider v1.16.1-0.20210702024009-ea616
 github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab/go.mod h1:3VYc5hodBMJ5+l/7J4xAyMeuM2PNuepvHlGs8yilUCA=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd h1:sjQovDkwrZp8u+gxLtPgKGjk5hCxuy2hrRejBTA9xFU=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
-github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
-github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
-github.com/Masterminds/semver/v3 v3.2.0 h1:3MEsd0SM6jqZojhjLWWeBY+Kcjy9i6MQAeY7YgDP83g=
-github.com/Masterminds/semver/v3 v3.2.0/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
+github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
+github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/Microsoft/go-winio v0.4.15/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=
 github.com/Microsoft/go-winio v0.4.17/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -1739,7 +1739,7 @@ func Test_GetGitCreds(t *testing.T) {
 				},
 			},
 			Spec: v1alpha1.ApplicationSpec{
-				Source: v1alpha1.ApplicationSource{
+				Source: &v1alpha1.ApplicationSource{
 					RepoURL:        "https://example-helm-repo.com/example",
 					TargetRevision: "main",
 				},

--- a/pkg/image/version.go
+++ b/pkg/image/version.go
@@ -7,7 +7,7 @@ import (
 	"github.com/argoproj-labs/argocd-image-updater/pkg/options"
 	"github.com/argoproj-labs/argocd-image-updater/pkg/tag"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 )
 
 // VersionSortMode defines the method to sort a list of tags

--- a/pkg/tag/semver.go
+++ b/pkg/tag/semver.go
@@ -1,6 +1,6 @@
 package tag
 
-import "github.com/Masterminds/semver"
+import "github.com/Masterminds/semver/v3"
 
 // semverCollection is a replacement for semver.Collection that breaks version
 // comparison ties through a lexical comparison of the original version strings.

--- a/pkg/tag/tag.go
+++ b/pkg/tag/tag.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/argoproj-labs/argocd-image-updater/pkg/log"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 )
 
 // ImageTag is a representation of an image tag with metadata


### PR DESCRIPTION
## Reason for the upgrade

I attempted to use the `semver` update strategy with the `x-0` constraint.

- `x-0` signifies any tags that adhere to semantic versioning,  whether or not they have prerelease tags.

However, the constraint wasn't considering tags with prerelease versions as valid tags.

There was a fix[^1] in `Masterminds/semver` package, which `argocd-image-updater` uses for semver checks. This fix was included in the v3.2.0 release[^2] of `Masterminds/semver` and the lastest release is `v3.2.1`.

Therefore I have upgraded the version of `Masterminds/semver` package from v1 .5.0to v3.2.1.

## Testing

I have verified that the `x-0` constraint correctly handles prerelease tags by the following test code.
The test code includes multiple test cases to cover various scenarios.

<details><summary>Details</summary>
<p>

```go
package tag

import (
	"fmt"
	"github.com/Masterminds/semver/v3"
	"github.com/stretchr/testify/assert"
	"strconv"
	"testing"
	"time"
)

func Test_Semver(t *testing.T) {
	for i, tt := range []struct {
		imageList  []string
		expected   string
		constraint string
	}{
		{
			imageList: []string{"v1.2.3", "v1.2.3-rc1"},
			expected:  "v1.2.3",
		},
		{
			imageList: []string{"v1.2", "v1.2.3"},
			expected:  "v1.2.3",
		},
		{
			imageList: []string{"v1.2.3-rc1", "v1.2.3"},
			expected:  "v1.2.3",
		},
		{
			imageList: []string{"v1.2.3-rc1", "v1.2.3-rc2"},
			expected:  "v1.2.3-rc2",
		},
		{
			imageList: []string{"v1.2.3-rc2", "v1.2.3-rc12"},
			// This is because if prelease tags are string,
			// they are sorted by the order of strings.
			expected: "v1.2.3-rc2",
		},
		{
			imageList:  []string{"v1.2.3-1", "v1.2.3"},
			expected:   "v1.2.3",
			constraint: "x-0",
		},
		{
			imageList:  []string{"v1.2.3-rc1", "v1.2.3-1"},
			expected:   "v1.2.3-rc1",
			constraint: "x-0",
		},
		{
			imageList:  []string{"v1.2.3-1", "v1.2.3-rc1"},
			expected:   "v1.2.3-rc1",
			constraint: "x-0",
		},
	} {
		t.Run("tt "+strconv.Itoa(i), func(t *testing.T) {
			var (
				v   *semver.Constraints
				err error
			)
			if tt.constraint != "" {
				v, err = semver.NewConstraint(tt.constraint)
				assert.NoError(t, err)
			}

			il := NewImageTagList()
			for _, tag := range tt.imageList {
				version, err := semver.NewVersion(tag)
				assert.NoError(t, err)
				if v != nil && !v.Check(version) {
					t.Logf("Constraint failed. constraint=%s, version=%s", tt.constraint, tag)
					continue
				}
				t.Logf("Constraint qualified. constraint=%s, version=%s", tt.constraint, tag)
				il.Add(NewImageTag(tag, time.Now(), ""))
			}
			sorted := il.SortBySemVer()
			answer := sorted[len(sorted)-1].TagName
			assert.Equal(t, tt.expected, answer, fmt.Sprintf("expected %s, but %s returned. sorted version: %+v", tt.expected, answer, sorted))
		})
	}
}
```

</p>
</details> 

[^1]: https://github.com/Masterminds/semver/pull/176
[^2]: https://github.com/Masterminds/semver/releases/tag/v3.2.0