### PR TITLE
Multiple secrets for the same registry

### DIFF
--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -141,6 +141,10 @@ func UpdateApplication(updateConf *UpdateConfiguration, state *SyncIterationStat
 	result := ImageUpdaterResult{}
 	app := updateConf.UpdateApp.Application.GetName()
 	changeList := make([]ChangeEntry, 0)
+	prefix := updateConf.UpdateApp.Application.ObjectMeta.Annotations[fmt.Sprintf(common.RegistryPrefixAnnotation, app)]
+	if prefix != "" {
+		prefix = "/" + prefix
+	}
 
 	// Get all images that are deployed with the current application
 	applicationImages := GetImagesFromApplication(&updateConf.UpdateApp.Application)
@@ -183,7 +187,7 @@ func UpdateApplication(updateConf *UpdateConfiguration, state *SyncIterationStat
 
 		imgCtx.Debugf("Considering this image for update")
 
-		rep, err := registry.GetRegistryEndpoint(applicationImage.RegistryURL)
+		rep, err := registry.GetRegistryEndpoint(applicationImage.RegistryURL + prefix)
 		if err != nil {
 			imgCtx.Errorf("Could not get registry endpoint from configuration: %v", err)
 			result.NumErrors += 1

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -35,6 +35,7 @@ const (
 	UpdateStrategyAnnotation    = ImageUpdaterAnnotationPrefix + "/%s.update-strategy"
 	PullSecretAnnotation        = ImageUpdaterAnnotationPrefix + "/%s.pull-secret"
 	PlatformsAnnotation         = ImageUpdaterAnnotationPrefix + "/%s.platforms"
+	RegistryPrefixAnnotation    = ImageUpdaterAnnotationPrefix + "/%s.registry-prefix"
 )
 
 // Application-wide update strategy related annotations


### PR DESCRIPTION
This is a pull request based on the following issue: https://github.com/argoproj-labs/argocd-image-updater/issues/639

If you have multiple credentials for the same registry maybe because you want to pull private images from two different authors, the image updater currently can't pick the correct credentials for the job. My code checks if the argo application has a `registry-prefix` annotation. If it has one it picks the correct registry via the prefix configured in your registry configuration.

### Example registry configuration
```
- name: GHCR author1
  api_url: https://ghcr.io
  prefix: ghcr.io/author1
  credentials: ext:/some/script
  credsexpire: 5h
- name: GHCR author2
  api_url: https://ghcr.io
  prefix: ghcr.io/author2
  credentials: ext:/some/script
  credsexpire: 5h

```

### Example application configuration
```
argocd-image-updater.argoproj.io/app-author1.helm.image-name: app-author1.image.repository
argocd-image-updater.argoproj.io/app-author1.helm.image-tag: app-author1.image.tag
argocd-image-updater.argoproj.io/app-author1.registry-prefix: author1
argocd-image-updater.argoproj.io/app-author1.update-strategy: digest

argocd-image-updater.argoproj.io/app-author2.helm.image-name: app-author2.image.repository
argocd-image-updater.argoproj.io/app-author2.helm.image-tag: app-author2.image.tag
argocd-image-updater.argoproj.io/app-author2.registry-prefix: author2
argocd-image-updater.argoproj.io/app-author2.update-strategy: digest
```

I hope it helps someone.