### PR TITLE
dockerfile house keeping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,7 @@ FROM alpine:latest
 
 RUN apk update && \
     apk upgrade && \
-    apk add ca-certificates git openssh-client python3 py3-pip tini && \
-    pip3 install --upgrade pip && \
-    pip3 install awscli && \
+    apk add ca-certificates git openssh-client python3 py3-pip tini aws-cli && \
     rm -rf /var/cache/apk/*
 
 RUN mkdir -p /usr/local/bin


### PR DESCRIPTION
resolving this error 
The system-wide python installation should be maintained using the system
92.69     package manager (apk) only.
92.69
92.69     If the package in question is not packaged already (and hence installable via
92.69     "apk add py3-somepackage"), please consider installing it inside a virtual
92.69     environment, e.g.:

![Screenshot 2024-01-22 at 15 16 27](https://github.com/argoproj-labs/argocd-image-updater/assets/20438586/1753272a-d183-4626-b84a-2e5b09a971f6)
