### PR TITLE
Create directory automatically

### DIFF
--- a/pkg/argocd/git.go
+++ b/pkg/argocd/git.go
@@ -291,6 +291,12 @@ func writeOverrides(app *v1alpha1.Application, wbc *WriteBackConfig, gitC git.Cl
 		}
 	}
 
+	dir := filepath.Dir(targetFile)
+	err = os.MkdirAll(dir, 0700)
+	if err != nil {
+		return
+	}
+
 	err = os.WriteFile(targetFile, override, 0600)
 	if err != nil {
 		return


### PR DESCRIPTION
* When writing to a new file, create the directory for the file if it does not already exist
* This is useful if writing `helmvalues` to a new directory that is solely used for updating the image version. The ArgoCD Application can add a second source and reference the file with the `ignoreMissingValueFiles` flag turned on as an additional values file
* If the directory already exists, this command does nothing.

This will be most beneficial once https://github.com/argoproj-labs/argocd-image-updater/pull/663 is also merged.