### PR TITLE
Added support for ssh signed commits and completed gpg signed commit work

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -2,6 +2,9 @@
 aeece
 Artifactory
 applicationid
+atlassian
+Bitbucket
+bitbucketserver
 bacd
 CVE
 credref
@@ -11,7 +14,9 @@ eec
 fbd
 ffb
 gitlab
+GPG
 helmvalues
+html
 installationid
 jfrog
 mep

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -21,6 +21,7 @@ installationid
 jfrog
 mep
 myregistry
+openpgp
 PRIVATEKEYDATA
 repocreds
 rollbacked

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -28,27 +28,28 @@ const applicationsAPIKindArgoCD = "argocd"
 
 // ImageUpdaterConfig contains global configuration and required runtime data
 type ImageUpdaterConfig struct {
-	ApplicationsAPIKind string
-	ClientOpts          argocd.ClientOptions
-	ArgocdNamespace     string
-	DryRun              bool
-	CheckInterval       time.Duration
-	ArgoClient          argocd.ArgoCD
-	LogLevel            string
-	KubeClient          *kube.KubernetesClient
-	MaxConcurrency      int
-	HealthPort          int
-	MetricsPort         int
-	RegistriesConf      string
-	AppNamePatterns     []string
-	AppLabel            string
-	GitCommitUser       string
-	GitCommitMail       string
-	GitCommitMessage    *template.Template
-	GitCommitSigningKey string
-	GitCommitSignOff    bool
-	DisableKubeEvents   bool
-	GitCreds            git.CredsStore
+	ApplicationsAPIKind    string
+	ClientOpts             argocd.ClientOptions
+	ArgocdNamespace        string
+	DryRun                 bool
+	CheckInterval          time.Duration
+	ArgoClient             argocd.ArgoCD
+	LogLevel               string
+	KubeClient             *kube.KubernetesClient
+	MaxConcurrency         int
+	HealthPort             int
+	MetricsPort            int
+	RegistriesConf         string
+	AppNamePatterns        []string
+	AppLabel               string
+	GitCommitUser          string
+	GitCommitMail          string
+	GitCommitMessage       *template.Template
+	GitCommitSigningKey    string
+	GitCommitSigningMethod string
+	GitCommitSignOff       bool
+	DisableKubeEvents      bool
+	GitCreds               git.CredsStore
 }
 
 // newRootCommand implements the root command of argocd-image-updater

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -45,6 +45,8 @@ type ImageUpdaterConfig struct {
 	GitCommitUser       string
 	GitCommitMail       string
 	GitCommitMessage    *template.Template
+	GitCommitSigningKey string
+	GitCommitSignOff    bool
 	DisableKubeEvents   bool
 	GitCreds            git.CredsStore
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -240,7 +240,8 @@ func newRunCommand() *cobra.Command {
 	runCmd.Flags().BoolVar(&warmUpCache, "warmup-cache", true, "whether to perform a cache warm-up on startup")
 	runCmd.Flags().StringVar(&cfg.GitCommitUser, "git-commit-user", env.GetStringVal("GIT_COMMIT_USER", "argocd-image-updater"), "Username to use for Git commits")
 	runCmd.Flags().StringVar(&cfg.GitCommitMail, "git-commit-email", env.GetStringVal("GIT_COMMIT_EMAIL", "noreply@argoproj.io"), "E-Mail address to use for Git commits")
-	runCmd.Flags().StringVar(&cfg.GitCommitSigningKey, "git-commit-signing-key", env.GetStringVal("GIT_COMMIT_SIGNING_KEY", ""), "GnuPG key ID or path to Public SSH Key used to sign the commits")
+	runCmd.Flags().StringVar(&cfg.GitCommitSigningKey, "git-commit-signing-key", env.GetStringVal("GIT_COMMIT_SIGNING_KEY", ""), "GnuPG key ID or path to Private SSH Key used to sign the commits")
+	runCmd.Flags().StringVar(&cfg.GitCommitSigningMethod, "git-commit-signing-method", env.GetStringVal("GIT_COMMIT_SIGNING_METHOD", "openpgp"), "Method used to sign Git commits ('openpgp' or 'ssh')")
 	runCmd.Flags().BoolVar(&cfg.GitCommitSignOff, "git-commit-sign-off", env.GetBoolVal("GIT_COMMIT_SIGN_OFF", false), "Whether to sign-off git commits")
 	runCmd.Flags().StringVar(&commitMessagePath, "git-commit-message-path", defaultCommitTemplatePath, "Path to a template to use for Git commit messages")
 	runCmd.Flags().BoolVar(&cfg.DisableKubeEvents, "disable-kube-events", env.GetBoolVal("IMAGE_UPDATER_KUBE_EVENTS", false), "Disable kubernetes events")
@@ -321,18 +322,19 @@ func runImageUpdater(cfg *ImageUpdaterConfig, warmUp bool) (argocd.ImageUpdaterR
 			defer sem.Release(1)
 			log.Debugf("Processing application %s", app)
 			upconf := &argocd.UpdateConfiguration{
-				NewRegFN:          registry.NewClient,
-				ArgoClient:        cfg.ArgoClient,
-				KubeClient:        cfg.KubeClient,
-				UpdateApp:         &curApplication,
-				DryRun:            dryRun,
-				GitCommitUser:     cfg.GitCommitUser,
-				GitCommitEmail:    cfg.GitCommitMail,
-				GitCommitMessage:  cfg.GitCommitMessage,
-				GitCommitSigningKey: cfg.GitCommitSigningKey,
-				GitCommitSignOff:    cfg.GitCommitSignOff,
-				DisableKubeEvents: cfg.DisableKubeEvents,
-				GitCreds:          cfg.GitCreds,
+				NewRegFN:               registry.NewClient,
+				ArgoClient:             cfg.ArgoClient,
+				KubeClient:             cfg.KubeClient,
+				UpdateApp:              &curApplication,
+				DryRun:                 dryRun,
+				GitCommitUser:          cfg.GitCommitUser,
+				GitCommitEmail:         cfg.GitCommitMail,
+				GitCommitMessage:       cfg.GitCommitMessage,
+				GitCommitSigningKey:    cfg.GitCommitSigningKey,
+				GitCommitSigningMethod: cfg.GitCommitSigningMethod,
+				GitCommitSignOff:       cfg.GitCommitSignOff,
+				DisableKubeEvents:      cfg.DisableKubeEvents,
+				GitCreds:               cfg.GitCreds,
 			}
 			res := argocd.UpdateApplication(upconf, syncState)
 			result.NumApplicationsProcessed += 1

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -240,6 +240,8 @@ func newRunCommand() *cobra.Command {
 	runCmd.Flags().BoolVar(&warmUpCache, "warmup-cache", true, "whether to perform a cache warm-up on startup")
 	runCmd.Flags().StringVar(&cfg.GitCommitUser, "git-commit-user", env.GetStringVal("GIT_COMMIT_USER", "argocd-image-updater"), "Username to use for Git commits")
 	runCmd.Flags().StringVar(&cfg.GitCommitMail, "git-commit-email", env.GetStringVal("GIT_COMMIT_EMAIL", "noreply@argoproj.io"), "E-Mail address to use for Git commits")
+	runCmd.Flags().StringVar(&cfg.GitCommitSigningKey, "git-commit-signing-key", env.GetStringVal("GIT_COMMIT_SIGNING_KEY", ""), "GnuPG key ID or path to Public SSH Key used to sign the commits")
+	runCmd.Flags().BoolVar(&cfg.GitCommitSignOff, "git-commit-sign-off", env.GetBoolVal("GIT_COMMIT_SIGN_OFF", false), "Whether to sign-off git commits")
 	runCmd.Flags().StringVar(&commitMessagePath, "git-commit-message-path", defaultCommitTemplatePath, "Path to a template to use for Git commit messages")
 	runCmd.Flags().BoolVar(&cfg.DisableKubeEvents, "disable-kube-events", env.GetBoolVal("IMAGE_UPDATER_KUBE_EVENTS", false), "Disable kubernetes events")
 
@@ -327,6 +329,8 @@ func runImageUpdater(cfg *ImageUpdaterConfig, warmUp bool) (argocd.ImageUpdaterR
 				GitCommitUser:     cfg.GitCommitUser,
 				GitCommitEmail:    cfg.GitCommitMail,
 				GitCommitMessage:  cfg.GitCommitMessage,
+				GitCommitSigningKey: cfg.GitCommitSigningKey,
+				GitCommitSignOff:    cfg.GitCommitSignOff,
 				DisableKubeEvents: cfg.DisableKubeEvents,
 				GitCreds:          cfg.GitCreds,
 			}

--- a/docs/basics/update-methods.md
+++ b/docs/basics/update-methods.md
@@ -153,8 +153,7 @@ format. To create such a secret from an existing private key, you can use
 
 ```bash
 kubectl -n argocd-image-updater create secret generic git-creds \
-  --from-file=sshPrivateKey=~/.ssh/id_rsa \
-  --from-file=sshPublicKey=~/.ssh/id_rsa.pub \
+  --from-file=sshPrivateKey=~/.ssh/id_rsa
 ```
 
 ### <a name="method-git-repository"></a>Specifying a repository when using a Helm repository in repoURL
@@ -248,44 +247,48 @@ as the author. You can override the author using the
 `git.user` and `git.email`
 in the `argocd-image-updater-config` ConfigMap.
 
-### <a name="method-git-commit-signing"></a>Enabling commit signature verification using an SSH or GPG key
-Commit signing requires the repository be accessed using HTTPS or SSH with a user account.
+## <a name="method-git-commit-signing"></a>Enabling commit signature signing using an SSH or GPG key
+
+### 1. SCM branch protection rules require signed commits
+Commit signing for SCM branch protection rules require the repository be accessed using HTTPS or SSH with a user account.
 Repositories accessed using a GitHub App can not be verified when using the git command line at this time.
 
-Each Git commit associated with an author's name and email address can be signed via a public SSH key or GPG key.
+Each Git commit associated with an author's name and email address can be signed via a private SSH key or GPG key.
+
 Commit signing requires a bot account with a GPG or SSH key and the username and email address configured to match the bot account.
 
-Your preferred signing key must be associated with your bot account. See provider documentation for further details:
+Your preferred signing key must be associated with your bot account. See SCM provider documentation for further details:
 * [GitHub](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)
 * [GitLab](https://docs.gitlab.com/ee/user/project/repository/signed_commits/)
 * [Bitbucket](https://confluence.atlassian.com/bitbucketserver/controlling-access-to-code-776639770.html)
 
-Commit Sign Off can be enabled by setting `git.commit-sign-off: "true"`
+### 2. Signing commits for future use with ArgoCD Source Verification Policies
+Commits can also be signed for use with source verification.
+In this case signing keys do not need to be associated with an SCM user account.
 
 **SSH:**
 
-Both private and public keys must be mounted and accessible on the `argocd-image-updater` pod.
+The private key must be mounted and accessible on the `argocd-image-updater` pod.
 
-Set `git.commit-signing-key` `argocd-image-updater-config` ConfigMap to the path of your public key:
+Set `git.commit-signing-key` `argocd-image-updater-config` ConfigMap to the path of your private key:
 
 ```yaml
 data:
   git.commit-sign-off: "true"
-  git.commit-signing-key: /app/.ssh/id_rsa.pub
+  git.commit-signing-key: /app/.ssh/id_rsa
+  git.commit-signing-method: "ssh"
 ```
 
-The matching private key must be available in the same location.
-
-Create a new SSH secret or add the public key to your existing SSH secret:
+Create a new SSH secret or use your existing SSH secret:
 ```bash
 kubectl -n argocd-image-updater create secret generic ssh-git-creds \
-  --from-file=sshPrivateKey=~/.ssh/id_rsa \
-  --from-file=sshPublicKey=~/.ssh/id_rsa.pub
+  --from-file=sshPrivateKey=~/.ssh/id_rsa
 ```
 
 **GPG:**
 
 The GPG private key must be installed and available in the `argocd-image-updater` pod.
+The `git.commit-signing-method` defaults to `openpgp`.
 Set `git.commit-signing-key` in the `argocd-image-updater-config` ConfigMap to the GPG key ID you want to use:
 
 ```yaml
@@ -293,6 +296,8 @@ data:
   git.commit-sign-off: "true"
   git.commit-signing-key: 3AA5C34371567BD2
 ```
+
+#### Commit Sign Off can be enabled by setting `git.commit-sign-off: "true"`
 
 ### <a name="method-git-commit-message"></a>Changing the Git commit message
 

--- a/ext/git/client.go
+++ b/ext/git/client.go
@@ -82,6 +82,7 @@ type Client interface {
 	Add(path string) error
 	SymRefToBranch(symRef string) (string, error)
 	Config(username string, email string) error
+	SigningConfig(signingkey string) error
 }
 
 type EventHandlers struct {

--- a/ext/git/client.go
+++ b/ext/git/client.go
@@ -82,7 +82,6 @@ type Client interface {
 	Add(path string) error
 	SymRefToBranch(symRef string) (string, error)
 	Config(username string, email string) error
-	SigningConfig(signingkey string) error
 }
 
 type EventHandlers struct {

--- a/ext/git/mocks/Client.go
+++ b/ext/git/mocks/Client.go
@@ -160,6 +160,20 @@ func (_m *Client) Config(username string, email string) error {
 	return r0
 }
 
+// SigningConfig provides a mock function with given fields: signingkey
+func (_m *Client) SigningConfig(signingkey string) error {
+	ret := _m.Called(signingkey)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(signingkey)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Fetch provides a mock function with given fields: revision
 func (_m *Client) Fetch(revision string) error {
 	ret := _m.Called(revision)

--- a/ext/git/writer.go
+++ b/ext/git/writer.go
@@ -3,7 +3,6 @@ package git
 import (
 	"fmt"
 	"os/exec"
-	"regexp"
 	"strings"
 
 	"github.com/argoproj-labs/argocd-image-updater/pkg/log"
@@ -15,8 +14,10 @@ type CommitOptions struct {
 	CommitMessageText string
 	// CommitMessagePath holds the path to a file to be used for the commit message (-F option)
 	CommitMessagePath string
-	// SigningKey holds a GnuPG key ID or path to Public SSH Key used to sign the commit with (-S option)
+	// SigningKey holds a GnuPG key ID or path to a Private SSH Key used to sign the commit with (-S option)
 	SigningKey string
+	// SigningMethod holds the signing method used to sign commits. (git -c gpg.format=ssh option)
+	SigningMethod string
 	// SignOff specifies whether to sign-off a commit (-s option)
 	SignOff bool
 }
@@ -26,25 +27,18 @@ type CommitOptions struct {
 // changes will be commited. If message is not the empty string, it will be
 // used as the commit message, otherwise a default commit message will be used.
 // If signingKey is not the empty string, commit will be signed with the given
-// GPG key.
+// GPG or SSH key.
 func (m *nativeGitClient) Commit(pathSpec string, opts *CommitOptions) error {
 	defaultCommitMsg := "Update parameters"
-	args := []string{"commit"}
+	// Git configuration
+	config := "gpg.format=" + opts.SigningMethod
+	args := []string{"-c", config, "commit"}
 	if pathSpec == "" || pathSpec == "*" {
 		args = append(args, "-a")
 	}
-	if opts.SigningKey != "" {
-		// Check if SiginingKey is a GPG key or Public SSH Key
-		keyCheck, err := regexp.MatchString(".*pub$", opts.SigningKey)
-		if err != nil {
-			return fmt.Errorf("could not validate Signing Key as GPG or Public SSH Key: %v", err)
-		}
-		if keyCheck {
-			args = append(args, "-S")
-		} else {
-			args = append(args, "-S", opts.SigningKey)
-		}
-	}
+	// Commit fails with a space between -S flag and path to SSH key
+	// -S/user/test/.ssh/signingKey or -SAAAAAAAA...
+	args = append(args, fmt.Sprintf("-S%s", opts.SigningKey))
 	if opts.SignOff {
 		args = append(args, "-s")
 	}
@@ -156,29 +150,4 @@ func (m *nativeGitClient) runCredentialedCmdWithOutput(args ...string) (string, 
 	cmd := exec.Command("git", args...)
 	cmd.Env = append(cmd.Env, environ...)
 	return m.runCmdOutput(cmd, runOpts{})
-}
-
-// SigningConfig configures commit signing for the repository
-func (m *nativeGitClient) SigningConfig(signingkey string) error {
-	// Check if SiginingKey is a GPG key or Public SSH Key
-	keyCheck, err := regexp.MatchString(".*pub$", signingkey)
-	if err != nil {
-		return fmt.Errorf("could not validate Signing Key as GPG or Public SSH Key: %v", err)
-	}
-	if keyCheck {
-		// Setting the GPG format to ssh
-		log.Warnf("Setting GPG Format to SSH")
-		_, err = m.runCmd("config", "gpg.format", "ssh")
-		if err != nil {
-			return fmt.Errorf("could not set gpg format to ssh: %v", err)
-		}
-		// Setting Public SSH Key as our signing key
-		// SSH Keys can not currently be set via cli flag
-		_, err = m.runCmd("config", "user.signingkey", signingkey)
-		if err != nil {
-			return fmt.Errorf("could not set git signing key: %v", err)
-		}
-	}
-
-	return nil
 }

--- a/ext/git/writer.go
+++ b/ext/git/writer.go
@@ -3,6 +3,7 @@ package git
 import (
 	"fmt"
 	"os/exec"
+	"regexp"
 	"strings"
 
 	"github.com/argoproj-labs/argocd-image-updater/pkg/log"
@@ -14,7 +15,7 @@ type CommitOptions struct {
 	CommitMessageText string
 	// CommitMessagePath holds the path to a file to be used for the commit message (-F option)
 	CommitMessagePath string
-	// SigningKey holds a GnuPG key ID used to sign the commit with (-S option)
+	// SigningKey holds a GnuPG key ID or path to Public SSH Key used to sign the commit with (-S option)
 	SigningKey string
 	// SignOff specifies whether to sign-off a commit (-s option)
 	SignOff bool
@@ -33,7 +34,16 @@ func (m *nativeGitClient) Commit(pathSpec string, opts *CommitOptions) error {
 		args = append(args, "-a")
 	}
 	if opts.SigningKey != "" {
-		args = append(args, "-S", opts.SigningKey)
+		// Check if SiginingKey is a GPG key or Public SSH Key
+		keyCheck, err := regexp.MatchString(".*pub$", opts.SigningKey)
+		if err != nil {
+			return fmt.Errorf("could not validate Signing Key as GPG or Public SSH Key: %v", err)
+		}
+		if keyCheck {
+			args = append(args, "-S")
+		} else {
+			args = append(args, "-S", opts.SigningKey)
+		}
 	}
 	if opts.SignOff {
 		args = append(args, "-s")
@@ -146,4 +156,29 @@ func (m *nativeGitClient) runCredentialedCmdWithOutput(args ...string) (string, 
 	cmd := exec.Command("git", args...)
 	cmd.Env = append(cmd.Env, environ...)
 	return m.runCmdOutput(cmd, runOpts{})
+}
+
+// SigningConfig configures commit signing for the repository
+func (m *nativeGitClient) SigningConfig(signingkey string) error {
+	// Check if SiginingKey is a GPG key or Public SSH Key
+	keyCheck, err := regexp.MatchString(".*pub$", signingkey)
+	if err != nil {
+		return fmt.Errorf("could not validate Signing Key as GPG or Public SSH Key: %v", err)
+	}
+	if keyCheck {
+		// Setting the GPG format to ssh
+		log.Warnf("Setting GPG Format to SSH")
+		_, err = m.runCmd("config", "gpg.format", "ssh")
+		if err != nil {
+			return fmt.Errorf("could not set gpg format to ssh: %v", err)
+		}
+		// Setting Public SSH Key as our signing key
+		// SSH Keys can not currently be set via cli flag
+		_, err = m.runCmd("config", "user.signingkey", signingkey)
+		if err != nil {
+			return fmt.Errorf("could not set git signing key: %v", err)
+		}
+	}
+
+	return nil
 }

--- a/manifests/base/deployment/argocd-image-updater-deployment.yaml
+++ b/manifests/base/deployment/argocd-image-updater-deployment.yaml
@@ -83,6 +83,12 @@ spec:
               key: git.commit-signing-key
               name: argocd-image-updater-config
               optional: true
+        - name: GIT_COMMIT_SIGNING_METHOD
+          valueFrom:
+            configMapKeyRef:
+              key: git.commit-signing-key
+              name: argocd-image-updater-config
+              optional: true
         - name: GIT_COMMIT_SIGN_OFF
           valueFrom:
             configMapKeyRef:
@@ -132,10 +138,6 @@ spec:
           mountPath: /app/.ssh/id_rsa
           readOnly: true
           subPath: sshPrivateKey
-        - name: ssh-signing-key
-          mountPath: /app/.ssh/id_rsa.pub
-          readOnly: true
-          subPath: sshPublicKey
       serviceAccountName: argocd-image-updater
       volumes:
       - configMap:

--- a/manifests/base/deployment/argocd-image-updater-deployment.yaml
+++ b/manifests/base/deployment/argocd-image-updater-deployment.yaml
@@ -77,6 +77,18 @@ spec:
               name: argocd-image-updater-config
               key: git.email
               optional: true
+        - name: GIT_COMMIT_SIGNING_KEY
+          valueFrom:
+            configMapKeyRef:
+              key: git.commit-signing-key
+              name: argocd-image-updater-config
+              optional: true
+        - name: GIT_COMMIT_SIGN_OFF
+          valueFrom:
+            configMapKeyRef:
+              key: git.commit-sign-off
+              name: argocd-image-updater-config
+              optional: true
         - name: IMAGE_UPDATER_KUBE_EVENTS
           valueFrom:
             configMapKeyRef:
@@ -116,6 +128,14 @@ spec:
           name: ssh-config
         - mountPath: /tmp
           name: tmp
+        - name: ssh-signing-key
+          mountPath: /app/.ssh/id_rsa
+          readOnly: true
+          subPath: sshPrivateKey
+        - name: ssh-signing-key
+          mountPath: /app/.ssh/id_rsa.pub
+          readOnly: true
+          subPath: sshPublicKey
       serviceAccountName: argocd-image-updater
       volumes:
       - configMap:
@@ -135,5 +155,9 @@ spec:
           name: argocd-image-updater-ssh-config
           optional: true
         name: ssh-config
+      - name: ssh-signing-key
+        secret:
+          secretName: ssh-git-creds
+        optional: true
       - emptyDir: {}
         name: tmp

--- a/manifests/base/deployment/argocd-image-updater-deployment.yaml
+++ b/manifests/base/deployment/argocd-image-updater-deployment.yaml
@@ -86,7 +86,7 @@ spec:
         - name: GIT_COMMIT_SIGNING_METHOD
           valueFrom:
             configMapKeyRef:
-              key: git.commit-signing-key
+              key: git.commit-signing-method
               name: argocd-image-updater-config
               optional: true
         - name: GIT_COMMIT_SIGN_OFF

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -158,6 +158,18 @@ spec:
               key: git.email
               name: argocd-image-updater-config
               optional: true
+        - name: GIT_COMMIT_SIGNING_KEY
+          valueFrom:
+            configMapKeyRef:
+              key: git.commit-signing-key
+              name: argocd-image-updater-config
+              optional: true
+        - name: GIT_COMMIT_SIGN_OFF
+          valueFrom:
+            configMapKeyRef:
+              key: git.commit-sign-off
+              name: argocd-image-updater-config
+              optional: true
         - name: IMAGE_UPDATER_KUBE_EVENTS
           valueFrom:
             configMapKeyRef:
@@ -199,6 +211,14 @@ spec:
           name: ssh-config
         - mountPath: /tmp
           name: tmp
+        - mountPath: /app/.ssh/id_rsa
+          name: ssh-signing-key
+          readOnly: true
+          subPath: sshPrivateKey
+        - mountPath: /app/.ssh/id_rsa.pub
+          name: ssh-signing-key
+          readOnly: true
+          subPath: sshPublicKey
       serviceAccountName: argocd-image-updater
       volumes:
       - configMap:
@@ -218,5 +238,9 @@ spec:
           name: argocd-image-updater-ssh-config
           optional: true
         name: ssh-config
+      - name: ssh-signing-key
+        optional: true
+        secret:
+          secretName: ssh-git-creds
       - emptyDir: {}
         name: tmp

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -164,6 +164,12 @@ spec:
               key: git.commit-signing-key
               name: argocd-image-updater-config
               optional: true
+        - name: GIT_COMMIT_SIGNING_METHOD
+          valueFrom:
+            configMapKeyRef:
+              key: git.commit-signing-key
+              name: argocd-image-updater-config
+              optional: true
         - name: GIT_COMMIT_SIGN_OFF
           valueFrom:
             configMapKeyRef:
@@ -215,10 +221,6 @@ spec:
           name: ssh-signing-key
           readOnly: true
           subPath: sshPrivateKey
-        - mountPath: /app/.ssh/id_rsa.pub
-          name: ssh-signing-key
-          readOnly: true
-          subPath: sshPublicKey
       serviceAccountName: argocd-image-updater
       volumes:
       - configMap:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -167,7 +167,7 @@ spec:
         - name: GIT_COMMIT_SIGNING_METHOD
           valueFrom:
             configMapKeyRef:
-              key: git.commit-signing-key
+              key: git.commit-signing-method
               name: argocd-image-updater-config
               optional: true
         - name: GIT_COMMIT_SIGN_OFF

--- a/pkg/argocd/git.go
+++ b/pkg/argocd/git.go
@@ -169,14 +169,6 @@ func commitChangesGit(app *v1alpha1.Application, wbc *WriteBackConfig, changeLis
 		}
 	}
 
-	// Set commit signing configuration
-	if wbc.GitCommitSigningKey != "" {
-		err = gitC.SigningConfig(wbc.GitCommitSigningKey)
-		if err != nil {
-			return err
-		}
-	}
-
 	// The branch to checkout is either a configured branch in the write-back
 	// config, or taken from the application spec's targetRevision. If the
 	// target revision is set to the special value HEAD, or is the empty
@@ -246,6 +238,7 @@ func commitChangesGit(app *v1alpha1.Application, wbc *WriteBackConfig, changeLis
 		commitOpts.SigningKey = wbc.GitCommitSigningKey
 	}
 
+	commitOpts.SigningMethod = wbc.GitCommitSigningMethod
 	commitOpts.SignOff = wbc.GitCommitSignOff
 
 	err = gitC.Commit("", commitOpts)

--- a/pkg/argocd/git.go
+++ b/pkg/argocd/git.go
@@ -169,6 +169,14 @@ func commitChangesGit(app *v1alpha1.Application, wbc *WriteBackConfig, changeLis
 		}
 	}
 
+	// Set commit signing configuration
+	if wbc.GitCommitSigningKey != "" {
+		err = gitC.SigningConfig(wbc.GitCommitSigningKey)
+		if err != nil {
+			return err
+		}
+	}
+
 	// The branch to checkout is either a configured branch in the write-back
 	// config, or taken from the application spec's targetRevision. If the
 	// target revision is set to the special value HEAD, or is the empty
@@ -233,6 +241,12 @@ func commitChangesGit(app *v1alpha1.Application, wbc *WriteBackConfig, changeLis
 		_ = cm.Close()
 		defer os.Remove(cm.Name())
 	}
+
+	if wbc.GitCommitSigningKey != "" {
+		commitOpts.SigningKey = wbc.GitCommitSigningKey
+	}
+
+	commitOpts.SignOff = wbc.GitCommitSignOff
 
 	err = gitC.Commit("", commitOpts)
 	if err != nil {

--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -44,6 +44,8 @@ type UpdateConfiguration struct {
 	GitCommitUser     string
 	GitCommitEmail    string
 	GitCommitMessage  *template.Template
+	GitCommitSigningKey string
+	GitCommitSignOff    bool
 	DisableKubeEvents bool
 	IgnorePlatforms   bool
 	GitCreds          git.CredsStore
@@ -70,6 +72,8 @@ type WriteBackConfig struct {
 	GitCommitUser    string
 	GitCommitEmail   string
 	GitCommitMessage string
+	GitCommitSigningKey string
+	GitCommitSignOff    bool
 	KustomizeBase    string
 	Target           string
 	GitRepo          string
@@ -330,6 +334,10 @@ func UpdateApplication(updateConf *UpdateConfiguration, state *SyncIterationStat
 		if len(changeList) > 0 && updateConf.GitCommitMessage != nil {
 			wbc.GitCommitMessage = TemplateCommitMessage(updateConf.GitCommitMessage, updateConf.UpdateApp.Application.Name, changeList)
 		}
+		if updateConf.GitCommitSigningKey != "" {
+			wbc.GitCommitSigningKey = updateConf.GitCommitSigningKey
+		}
+		wbc.GitCommitSignOff = updateConf.GitCommitSignOff
 	}
 
 	if needUpdate {

--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -36,19 +36,20 @@ type ImageUpdaterResult struct {
 }
 
 type UpdateConfiguration struct {
-	NewRegFN          registry.NewRegistryClient
-	ArgoClient        ArgoCD
-	KubeClient        *kube.KubernetesClient
-	UpdateApp         *ApplicationImages
-	DryRun            bool
-	GitCommitUser     string
-	GitCommitEmail    string
-	GitCommitMessage  *template.Template
-	GitCommitSigningKey string
-	GitCommitSignOff    bool
-	DisableKubeEvents bool
-	IgnorePlatforms   bool
-	GitCreds          git.CredsStore
+	NewRegFN               registry.NewRegistryClient
+	ArgoClient             ArgoCD
+	KubeClient             *kube.KubernetesClient
+	UpdateApp              *ApplicationImages
+	DryRun                 bool
+	GitCommitUser          string
+	GitCommitEmail         string
+	GitCommitMessage       *template.Template
+	GitCommitSigningKey    string
+	GitCommitSigningMethod string
+	GitCommitSignOff       bool
+	DisableKubeEvents      bool
+	IgnorePlatforms        bool
+	GitCreds               git.CredsStore
 }
 
 type GitCredsSource func(app *v1alpha1.Application) (git.Creds, error)
@@ -65,19 +66,20 @@ type WriteBackConfig struct {
 	Method     WriteBackMethod
 	ArgoClient ArgoCD
 	// If GitClient is not nil, the client will be used for updates. Otherwise, a new client will be created.
-	GitClient        git.Client
-	GetCreds         GitCredsSource
-	GitBranch        string
-	GitWriteBranch   string
-	GitCommitUser    string
-	GitCommitEmail   string
-	GitCommitMessage string
-	GitCommitSigningKey string
-	GitCommitSignOff    bool
-	KustomizeBase    string
-	Target           string
-	GitRepo          string
-	GitCreds         git.CredsStore
+	GitClient              git.Client
+	GetCreds               GitCredsSource
+	GitBranch              string
+	GitWriteBranch         string
+	GitCommitUser          string
+	GitCommitEmail         string
+	GitCommitMessage       string
+	GitCommitSigningKey    string
+	GitCommitSigningMethod string
+	GitCommitSignOff       bool
+	KustomizeBase          string
+	Target                 string
+	GitRepo                string
+	GitCreds               git.CredsStore
 }
 
 // The following are helper structs to only marshal the fields we require
@@ -337,6 +339,7 @@ func UpdateApplication(updateConf *UpdateConfiguration, state *SyncIterationStat
 		if updateConf.GitCommitSigningKey != "" {
 			wbc.GitCommitSigningKey = updateConf.GitCommitSigningKey
 		}
+		wbc.GitCommitSigningMethod = updateConf.GitCommitSigningMethod
 		wbc.GitCommitSignOff = updateConf.GitCommitSignOff
 	}
 


### PR DESCRIPTION
Building upon the work done in [PR 428](https://github.com/argoproj-labs/argocd-image-updater/pull/428) to add support for SSH signed commits. 

Updated Documentation to include instructions and examples for adding an SSH signing key along with links to repository provider documentation for setting up commit verification.  

Updated deployment to include volumes for SSH key secrets and the respective volume mounts. 