### PR TITLE
fix: downgrade alpine version, while aws cli is not available in 3.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY . .
 RUN mkdir -p dist && \
 	make controller
 
-FROM alpine:latest
+FROM alpine:3.19
 
 RUN apk update && \
     apk upgrade && \


### PR DESCRIPTION
Related to: https://github.com/alpinelinux/docker-alpine/issues/396