### PR TITLE
fix: invalid memory address due to store is nil in gitcreds.go

### DIFF
--- a/pkg/argocd/gitcreds.go
+++ b/pkg/argocd/gitcreds.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/util/db"
+	argoGit "github.com/argoproj/argo-cd/v2/util/git"
 	"github.com/argoproj/argo-cd/v2/util/settings"
 
 	"github.com/argoproj-labs/argocd-image-updater/ext/git"
@@ -43,7 +44,7 @@ func getCredsFromArgoCD(wbc *WriteBackConfig, kubeClient *kube.KubernetesClient)
 	if !repo.HasCredentials() {
 		return nil, fmt.Errorf("credentials for '%s' are not configured in Argo CD settings", wbc.GitRepo)
 	}
-	return repo.GetGitCreds(nil), nil
+	return repo.GetGitCreds(argoGit.NoopCredsStore{}), nil
 }
 
 // getCredsFromSecret loads repository credentials from secret


### PR DESCRIPTION
Closes: https://github.com/argoproj-labs/argocd-image-updater/issues/621