### PR TITLE
create github actions workflow init-release.yaml for preparing release

### DIFF
--- a/.github/workflows/init-release.yaml
+++ b/.github/workflows/init-release.yaml
@@ -1,0 +1,119 @@
+name: Init Argo CD Image Updater Release
+on:
+  workflow_dispatch:
+    inputs:
+      TARGET_BRANCH:
+        description: 'TARGET_BRANCH to checkout (e.g. release-0.14)'
+        required: true
+        type: string
+
+      TARGET_VERSION:
+        description: 'TARGET_VERSION to build manifests (e.g. 0.14.0-rc1) Note: the `v` prefix is not used'
+        required: true
+        type: string
+
+permissions: {}
+
+env:
+  TARGET_REMOTE: upstream
+  TARGET_TAG: "v${{ inputs.TARGET_VERSION }}"
+
+jobs:
+  prepare-release:
+    permissions:
+      contents: write  # for peter-evans/create-pull-request to create branch
+      pull-requests: write  # for peter-evans/create-pull-request to create a PR
+    name: Automatically generate version and manifests on ${{ inputs.TARGET_BRANCH }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8410ad0602e1e429cee44a835ae9f77f654a6694  # v4.0.0
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ inputs.TARGET_BRANCH }}
+
+      - name: Check if TARGET_VERSION is well formed.
+        run: |
+          set -ue
+          # Target version must not contain 'v' prefix
+          if echo "${{ inputs.TARGET_VERSION }}" | grep -e '^v'; then
+            echo "::error::Target version '${{ inputs.TARGET_VERSION }}' should not begin with a 'v' prefix, refusing to continue." >&2
+            exit 1
+          fi
+          if ! echo "${{ inputs.TARGET_VERSION }}" | egrep -q '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Error: Target version '${{ inputs.TARGET_VERSION }}' is not well-formed. Must be X.Y.Z" >&2
+            exit 1
+          fi
+
+      - name: Checking for current git branch
+        run: |
+          set -ue
+          RELEASE_BRANCH=$(git rev-parse --abbrev-ref HEAD || true)
+          if [[ $RELEASE_BRANCH = release-* ]]; then
+            echo "***   branch is $RELEASE_BRANCH"
+          else
+            echo "Error: Branch $RELEASE_BRANCH is not release branch" >&2
+            exit 1
+          fi
+
+      - name: Checking for existence of git tag
+        run: |
+          set -ue
+          if git show-ref --tags "${{ env.TARGET_TAG }}" --quiet; then
+            echo "Error: Tag with version ${{ env.TARGET_TAG }} already exists." >&2
+            exit 1
+          fi
+
+      - name: Create VERSION information
+        run: |
+          set -ue
+          if ! test -f VERSION; then
+            echo "Error: You should be in repository root." >&2
+            exit 1
+          fi
+          echo "Bumping version from $(cat VERSION) to ${{ inputs.TARGET_VERSION }}"
+          echo "${{ inputs.TARGET_VERSION }}" > VERSION
+
+      - name: Install Kustomize
+        uses: imranismail/setup-kustomize@v2
+        with:
+          kustomize-version: '5.2.1'
+
+      - name: Generate new set of manifests
+        run: |
+          set -ue
+          echo kustomize version $(kustomize version)
+          make manifests IMAGE_TAG="${{ env.TARGET_TAG }}"
+          git diff
+
+      - name: Create pull request
+        id: create-pull-request
+        uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e  # v6.0.5
+        with:
+          commit-message: "Bump version to ${{ inputs.TARGET_VERSION }}"
+          title: "Bump version to ${{ inputs.TARGET_VERSION }} on ${{ inputs.TARGET_BRANCH }} branch"
+          body: Updating VERSION and manifests to ${{ inputs.TARGET_VERSION }}
+          branch: update-version
+          branch-suffix: random
+          signoff: true
+          labels: release
+
+      - name: Next steps
+        run: |
+          echo "Created release PR: ${{ steps.create-pull-request.outputs.pull-request-url }}"
+          echo "Once this PR is merged, pull from ${{ env.TARGET_REMOTE }} ${{ inputs.TARGET_BRANCH }}, tag the release, and build release artifacts."
+          echo "If everything is fine, push changes to GitHub and container registry:"
+          echo "   git fetch ${{ env.TARGET_REMOTE }} ${{ inputs.TARGET_BRANCH }}"
+          echo "   git switch ${{ inputs.TARGET_BRANCH }}"
+          echo "   git pull ${{ env.TARGET_REMOTE }} ${{ inputs.TARGET_BRANCH }}"
+          echo "   git tag ${{ env.TARGET_TAG }}"
+          echo "   make multiarch-image"
+          echo "   make release-binaries"
+          echo "   git push ${{ env.TARGET_REMOTE }} ${{ inputs.TARGET_BRANCH }} ${{ env.TARGET_TAG }}"
+          echo "   make IMAGE_TAG='${{ env.TARGET_TAG }}' multiarch-image-push"
+          echo
+          echo "Then, create release tag and execute upload-multiarch-release-assets.sh"
+
+


### PR DESCRIPTION
Fixes #734 

This PR adds a github actions on-demand workflow that contains necessary steps to prepare a release. This workflow is modelled after the script https://github.com/argoproj-labs/argocd-image-updater/blob/master/hack/release.sh, minus the last few steps in the end.

Note that this workflow only prepares the release, and the responsible release engineer is still responsible for verifying the output, and continue with further manual steps in order to finish the releasing.

A screenshot of the workflow input fields:
https://gist.github.com/chengfang/32f8c6f31fb0736476677abe1b8cc451

After a successful test run of the workflow in my fork, the following test PR in my fork was created:
https://github.com/chengfang/argocd-image-updater/pull/7