### PR TITLE
chore: fix checking for the existence of TARGET_TAG

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -36,8 +36,8 @@ fi
 
 echo "${TARGET_VERSION}" > VERSION
 
-echo "*** checking for existance of git tag ${TARGET_TAG}"
-if git tag -l "${TARGET_VERSION}" | grep -q "${TARGET_TAG}"; then
+echo "*** checking for existence of git tag ${TARGET_TAG}"
+if git tag -l "${TARGET_TAG}" | grep -q "${TARGET_TAG}"; then
 	echo "Error: Tag with version ${TARGET_TAG} already exists." >&2
 	exit 1
 fi


### PR DESCRIPTION
This PR fixes the logic to check for the existence of a tag.

With the current logic, `tag -l "${TARGET_VERSION}"` produces no output since the TARGET_VERSION is something like `0.13.1`, while tags are in the form of `v0.13.1`, so the whole condition always evals to false, even with an existing tag.