### PR TITLE
Fix issue regarding volume added in #710

### DIFF
--- a/manifests/base/deployment/argocd-image-updater-deployment.yaml
+++ b/manifests/base/deployment/argocd-image-updater-deployment.yaml
@@ -160,6 +160,6 @@ spec:
       - name: ssh-signing-key
         secret:
           secretName: ssh-git-creds
-        optional: true
+          optional: true
       - emptyDir: {}
         name: tmp

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -241,8 +241,8 @@ spec:
           optional: true
         name: ssh-config
       - name: ssh-signing-key
-        optional: true
         secret:
+          optional: true
           secretName: ssh-git-creds
       - emptyDir: {}
         name: tmp


### PR DESCRIPTION
Fix issue with volume `ssh-git-creds` (introduced in #710) that prevents to install `master` branch

`optional: true` was missing an indent