### PR TITLE
fix: fixed path for ssh signing key, error mounting in another volume

### DIFF
--- a/docs/basics/update-methods.md
+++ b/docs/basics/update-methods.md
@@ -275,7 +275,7 @@ Set `git.commit-signing-key` `argocd-image-updater-config` ConfigMap to the path
 ```yaml
 data:
   git.commit-sign-off: "true"
-  git.commit-signing-key: /app/.ssh/id_rsa
+  git.commit-signing-key: /app/ssh-keys/id_rsa
   git.commit-signing-method: "ssh"
 ```
 

--- a/manifests/base/deployment/argocd-image-updater-deployment.yaml
+++ b/manifests/base/deployment/argocd-image-updater-deployment.yaml
@@ -135,7 +135,7 @@ spec:
         - mountPath: /tmp
           name: tmp
         - name: ssh-signing-key
-          mountPath: /app/.ssh/id_rsa
+          mountPath: /app/ssh-keys/id_rsa
           readOnly: true
           subPath: sshPrivateKey
       serviceAccountName: argocd-image-updater

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -217,7 +217,7 @@ spec:
           name: ssh-config
         - mountPath: /tmp
           name: tmp
-        - mountPath: /app/.ssh/id_rsa
+        - mountPath: /app/ssh-keys/id_rsa
           name: ssh-signing-key
           readOnly: true
           subPath: sshPrivateKey


### PR DESCRIPTION
Moved ssh key mount for signing key into a new `ssh-keys` directory. This is to avoid trying to mount in an existing .ssh directory. 