### PR TITLE
fix: pass through git store to git creds

### DIFF
--- a/pkg/argocd/gitcreds.go
+++ b/pkg/argocd/gitcreds.go
@@ -130,7 +130,7 @@ func getCredsFromSecret(wbc *WriteBackConfig, credentialsSecret string, kubeClie
 		if sshPrivateKey, ok = credentials["sshPrivateKey"]; !ok {
 			return nil, fmt.Errorf("invalid secret %s: does not contain field sshPrivateKey", credentialsSecret)
 		}
-		return git.NewSSHCreds(string(sshPrivateKey), "", true, git.NoopCredsStore{}, ""), nil
+		return git.NewSSHCreds(string(sshPrivateKey), "", true, wbc.GitCreds, ""), nil
 	} else if git.IsHTTPSURL(wbc.GitRepo) {
 		var username, password, githubAppID, githubAppInstallationID, githubAppPrivateKey []byte
 		if githubAppID, ok = credentials["githubAppID"]; ok {
@@ -149,12 +149,12 @@ func getCredsFromSecret(wbc *WriteBackConfig, credentialsSecret string, kubeClie
 			if err != nil {
 				return nil, fmt.Errorf("invalid value in field githubAppInstallationID: %w", err)
 			}
-			return git.NewGitHubAppCreds(intGithubAppID, intGithubAppInstallationID, string(githubAppPrivateKey), "", "", "", "", true, "", git.NoopCredsStore{}), nil
+			return git.NewGitHubAppCreds(intGithubAppID, intGithubAppInstallationID, string(githubAppPrivateKey), "", "", "", "", true, "", wbc.GitCreds), nil
 		} else if username, ok = credentials["username"]; ok {
 			if password, ok = credentials["password"]; !ok {
 				return nil, fmt.Errorf("invalid secret %s: does not contain field password", credentialsSecret)
 			}
-			return git.NewHTTPSCreds(string(username), string(password), "", "", true, "", git.NoopCredsStore{}, false), nil
+			return git.NewHTTPSCreds(string(username), string(password), "", "", true, "", wbc.GitCreds, false), nil
 		}
 		return nil, fmt.Errorf("invalid repository credentials in secret %s: does not contain githubAppID or username", credentialsSecret)
 	}


### PR DESCRIPTION
Pass the git store from the write back config to the git credential functions.

Fixes:
- https://github.com/argoproj-labs/argocd-image-updater/issues/728
- https://github.com/argoproj-labs/argocd-image-updater/issues/754