### PR TITLE
chore(deps): upgrade golangci-lint from v1.57.2 to v1.59.1; change golangci-lint vet to govet

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.57.2
+          version: v1.59.1
           args: --timeout 5m
   test:
     name: Ensure unit tests are passing

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,7 @@ run:
 linters:
   enable:
     - gofmt
-    - vet
+    - govet
     - goimports
     - ineffassign
     - misspell


### PR DESCRIPTION
To fix the warning with recent golangci-lint versions: `WARN [lintersdb] The name "vet" is deprecated. The linter has been renamed to: govet.`

golangci-lint v1.59.1:
https://github.com/golangci/golangci-lint/releases/tag/v1.59.1