### PR TITLE
feat: Use shallow clone to speed up performance

### DIFF
--- a/ext/git/client.go
+++ b/ext/git/client.go
@@ -65,6 +65,7 @@ type Client interface {
 	Root() string
 	Init() error
 	Fetch(revision string) error
+	ShallowFetch(revision string, depth int) error
 	Submodule() error
 	Checkout(revision string, submoduleEnabled bool) error
 	LsRefs() (*Refs, error)

--- a/ext/git/git_test.go
+++ b/ext/git/git_test.go
@@ -322,6 +322,25 @@ func TestVerifyCommitSignature(t *testing.T) {
 	}
 }
 
+func TestVerifyShallowFetchCheckout(t *testing.T) {
+	p := t.TempDir()
+
+	client, err := NewClientExt("https://github.com/argoproj/argo-cd.git", p, NopCreds{}, false, false, "")
+	assert.NoError(t, err)
+
+	err = client.Init()
+	assert.NoError(t, err)
+
+	err = client.ShallowFetch("HEAD", 1)
+	assert.NoError(t, err)
+
+	commitSHA, err := client.LsRemote("HEAD")
+	assert.NoError(t, err)
+
+	err = client.Checkout(commitSHA, true)
+	assert.NoError(t, err)
+}
+
 func TestNewFactory(t *testing.T) {
 	addBinDirToPath := path.NewBinDirToPath()
 	defer addBinDirToPath.Close()

--- a/ext/git/mocks/Client.go
+++ b/ext/git/mocks/Client.go
@@ -192,6 +192,24 @@ func (_m *Client) Fetch(revision string) error {
 	return r0
 }
 
+// Fetch provides a mock function with given fields: revision
+func (_m *Client) ShallowFetch(revision string, depth int) error {
+	ret := _m.Called(revision)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Fetch")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, int) error); ok {
+		r0 = rf(revision, depth)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Init provides a mock function with given fields:
 func (_m *Client) Init() error {
 	ret := _m.Called()

--- a/pkg/argocd/git.go
+++ b/pkg/argocd/git.go
@@ -157,10 +157,6 @@ func commitChangesGit(app *v1alpha1.Application, wbc *WriteBackConfig, changeLis
 	if err != nil {
 		return err
 	}
-	err = gitC.Fetch("")
-	if err != nil {
-		return err
-	}
 
 	// Set username and e-mail address used to identify the commiter
 	if wbc.GitCommitUser != "" && wbc.GitCommitEmail != "" {
@@ -185,6 +181,10 @@ func commitChangesGit(app *v1alpha1.Application, wbc *WriteBackConfig, changeLis
 		if err != nil {
 			return err
 		}
+	}
+	err = gitC.ShallowFetch(checkOutBranch, 1)
+	if err != nil {
+		return err
 	}
 
 	// The push branch is by default the same as the checkout branch, unless

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -3009,7 +3009,7 @@ replacements: []
 		app := app.DeepCopy()
 		gitMock := &gitmock.Client{}
 		gitMock.On("Init").Return(nil)
-		gitMock.On("Fetch", mock.Anything).Return(nil)
+		gitMock.On("ShallowFetch", mock.Anything, mock.Anything).Return(nil)
 		gitMock.On("Checkout", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 			args.Assert(t, "mydefaultbranch", false)
 		}).Return(nil)
@@ -3035,7 +3035,7 @@ replacements: []
 	t.Run("Cannot init", func(t *testing.T) {
 		gitMock := &gitmock.Client{}
 		gitMock.On("Init").Return(fmt.Errorf("cannot init"))
-		gitMock.On("Fetch", mock.Anything).Return(nil)
+		gitMock.On("ShallowFetch", mock.Anything, mock.Anything).Return(nil)
 		gitMock.On("Checkout", mock.Anything, mock.Anything).Return(nil)
 		gitMock.On("Commit", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		gitMock.On("Push", mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -3050,7 +3050,7 @@ replacements: []
 	t.Run("Cannot fetch", func(t *testing.T) {
 		gitMock := &gitmock.Client{}
 		gitMock.On("Init").Return(nil)
-		gitMock.On("Fetch", mock.Anything).Return(fmt.Errorf("cannot fetch"))
+		gitMock.On("ShallowFetch", mock.Anything, mock.Anything).Return(fmt.Errorf("cannot fetch"))
 		gitMock.On("Checkout", mock.Anything, mock.Anything).Return(nil)
 		gitMock.On("Commit", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		gitMock.On("Push", mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -3064,7 +3064,7 @@ replacements: []
 	t.Run("Cannot checkout", func(t *testing.T) {
 		gitMock := &gitmock.Client{}
 		gitMock.On("Init").Return(nil)
-		gitMock.On("Fetch", mock.Anything).Return(nil)
+		gitMock.On("ShallowFetch", mock.Anything, mock.Anything).Return(nil)
 		gitMock.On("Checkout", mock.Anything, mock.Anything).Return(fmt.Errorf("cannot checkout"))
 		gitMock.On("Commit", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		gitMock.On("Push", mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -3180,7 +3180,7 @@ func mockGit(t *testing.T) (gitMock *gitmock.Client, dir string, cleanup func())
 	gitMock = &gitmock.Client{}
 	gitMock.On("Root").Return(dir)
 	gitMock.On("Init").Return(nil)
-	gitMock.On("Fetch", mock.Anything).Return(nil)
+	gitMock.On("ShallowFetch", mock.Anything, mock.Anything).Return(nil)
 	return gitMock, dir, func() {
 		_ = os.RemoveAll(dir)
 	}


### PR DESCRIPTION
* Only git fetch the one target revision that we need
* This does not utilize the history so there is no reason to clone it
* For large repos, this will speed up performance significantly