### PR TITLE
feat!: Filter labels on the server instead of client to allow more label filtering options

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -236,7 +236,7 @@ func newRunCommand() *cobra.Command {
 	runCmd.Flags().IntVar(&cfg.MaxConcurrency, "max-concurrency", 10, "maximum number of update threads to run concurrently")
 	runCmd.Flags().StringVar(&cfg.ArgocdNamespace, "argocd-namespace", "", "namespace where ArgoCD runs in (current namespace by default)")
 	runCmd.Flags().StringSliceVar(&cfg.AppNamePatterns, "match-application-name", nil, "patterns to match application name against")
-	runCmd.Flags().StringVar(&cfg.AppLabel, "match-application-label", "", "label to match application labels against")
+	runCmd.Flags().StringVar(&cfg.AppLabel, "match-application-label", "", "label selector to match application labels against")
 	runCmd.Flags().BoolVar(&warmUpCache, "warmup-cache", true, "whether to perform a cache warm-up on startup")
 	runCmd.Flags().StringVar(&cfg.GitCommitUser, "git-commit-user", env.GetStringVal("GIT_COMMIT_USER", "argocd-image-updater"), "Username to use for Git commits")
 	runCmd.Flags().StringVar(&cfg.GitCommitMail, "git-commit-email", env.GetStringVal("GIT_COMMIT_EMAIL", "noreply@argoproj.io"), "E-Mail address to use for Git commits")
@@ -267,7 +267,7 @@ func runImageUpdater(cfg *ImageUpdaterConfig, warmUp bool) (argocd.ImageUpdaterR
 	}
 	cfg.ArgoClient = argoClient
 
-	apps, err := cfg.ArgoClient.ListApplications()
+	apps, err := cfg.ArgoClient.ListApplications(cfg.AppLabel)
 	if err != nil {
 		log.WithContext().
 			AddField("argocd_server", cfg.ClientOpts.ServerAddr).
@@ -281,7 +281,7 @@ func runImageUpdater(cfg *ImageUpdaterConfig, warmUp bool) (argocd.ImageUpdaterR
 
 	// Get the list of applications that are allowed for updates, that is, those
 	// applications which have correct annotation.
-	appList, err := argocd.FilterApplicationsForUpdate(apps, cfg.AppNamePatterns, cfg.AppLabel)
+	appList, err := argocd.FilterApplicationsForUpdate(apps, cfg.AppNamePatterns)
 	if err != nil {
 		return result, err
 	}

--- a/docs/install/reference.md
+++ b/docs/install/reference.md
@@ -116,15 +116,16 @@ style wildcards, i.e. `*-staging` would match any application name with a
 suffix of `-staging`. Can be specified multiple times to define more than
 one pattern, from which at least one has to match.
 
-**--match-application-label *label* **
+**--match-application-label *selector* **
 
 Only process applications that have a valid annotation and match the given
-*label*. The *label* is a string that matches the standard kubernetes label 
-syntax of `key=value`. For e.g, `custom.label/name=xyz` would be a valid label
-that can be supplied through this parameter. Any applications carrying this 
+*label* selector. The *selector* is a string that matches the standard kubernetes label
+[label selector syntax][]. For e.g, `custom.label/name=xyz` would be a valid label
+that can be supplied through this parameter. Any applications carrying this
 exact label will be considered as candidates for image updates. This parameter
-currently does not support pattern matching on label values (e.g `customer.label/name=*-staging`)
-and only accepts a single label to match applications against. 
+currently does not support pattern matching on label values (e.g `customer.label/name=*-staging`).
+You can specify equality, inequality, or set based requirements or a combination.
+For e.g., `app,app!=foo,custom.label/name=xyz,customer in (a,b,c)`
 
 **--max-concurrency *number* **
 
@@ -142,3 +143,5 @@ Load the registry configuration from file at *path*. Defaults to the path
 `/app/config/registries.conf`. If no configuration should be loaded, and the
 default configuration should be used instead, specify the empty string, i.e.
 `--registries-conf-path=""`.
+
+[label selector syntax]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors

--- a/pkg/argocd/argocd_test.go
+++ b/pkg/argocd/argocd_test.go
@@ -491,7 +491,7 @@ func Test_FilterApplicationsForUpdate(t *testing.T) {
 				},
 			},
 		}
-		filtered, err := FilterApplicationsForUpdate(applicationList, []string{}, "")
+		filtered, err := FilterApplicationsForUpdate(applicationList, []string{})
 		require.NoError(t, err)
 		require.Len(t, filtered, 1)
 		require.Contains(t, filtered, "argocd/app1")
@@ -543,55 +543,13 @@ func Test_FilterApplicationsForUpdate(t *testing.T) {
 				},
 			},
 		}
-		filtered, err := FilterApplicationsForUpdate(applicationList, []string{"app*"}, "")
+		filtered, err := FilterApplicationsForUpdate(applicationList, []string{"app*"})
 		require.NoError(t, err)
 		require.Len(t, filtered, 2)
 		require.Contains(t, filtered, "argocd/app1")
 		require.Contains(t, filtered, "argocd/app2")
 		assert.Len(t, filtered["argocd/app1"].Images, 2)
 	})
-
-	t.Run("Filter for applications with label", func(t *testing.T) {
-		applicationList := []v1alpha1.Application{
-			// Annotated and carries required label
-			{
-				ObjectMeta: v1.ObjectMeta{
-					Name:      "app1",
-					Namespace: "argocd",
-					Annotations: map[string]string{
-						common.ImageUpdaterAnnotation: "nginx, quay.io/dexidp/dex:v1.23.0",
-					},
-					Labels: map[string]string{
-						"custom.label/name": "xyz",
-					},
-				},
-				Spec: v1alpha1.ApplicationSpec{},
-				Status: v1alpha1.ApplicationStatus{
-					SourceType: v1alpha1.ApplicationSourceTypeKustomize,
-				},
-			},
-			// Annotated but does not carry required label
-			{
-				ObjectMeta: v1.ObjectMeta{
-					Name:      "app2",
-					Namespace: "argocd",
-					Annotations: map[string]string{
-						common.ImageUpdaterAnnotation: "nginx, quay.io/dexidp/dex:v1.23.0",
-					},
-				},
-				Spec: v1alpha1.ApplicationSpec{},
-				Status: v1alpha1.ApplicationStatus{
-					SourceType: v1alpha1.ApplicationSourceTypeHelm,
-				},
-			},
-		}
-		filtered, err := FilterApplicationsForUpdate(applicationList, []string{}, "custom.label/name=xyz")
-		require.NoError(t, err)
-		require.Len(t, filtered, 1)
-		require.Contains(t, filtered, "argocd/app1")
-		assert.Len(t, filtered["argocd/app1"].Images, 2)
-	})
-
 }
 
 func Test_GetHelmParamAnnotations(t *testing.T) {
@@ -1064,7 +1022,7 @@ func TestKubernetesClient(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("List applications", func(t *testing.T) {
-		apps, err := client.ListApplications()
+		apps, err := client.ListApplications("")
 		require.NoError(t, err)
 		require.Len(t, apps, 1)
 

--- a/pkg/argocd/mocks/ArgoCD.go
+++ b/pkg/argocd/mocks/ArgoCD.go
@@ -48,7 +48,7 @@ func (_m *ArgoCD) GetApplication(ctx context.Context, appName string) (*v1alpha1
 }
 
 // ListApplications provides a mock function with given fields:
-func (_m *ArgoCD) ListApplications() ([]v1alpha1.Application, error) {
+func (_m *ArgoCD) ListApplications(labelSelector string) ([]v1alpha1.Application, error) {
 	ret := _m.Called()
 
 	if len(ret) == 0 {


### PR DESCRIPTION
Filter labels on the server instead of client
* This will allow supporting filtering by more label options
  * Multiple labels
  * Negative matching
  * Label exists regardless of value
* This should reduce cpu, memory, and networking resources needed
* Updated docs to reflect new capabilities