### PR TITLE
Allow setting new value in Helm values file

### DIFF
--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -465,11 +465,11 @@ func marshalParamsOverride(app *v1alpha1.Application, originalData []byte) ([]by
 					return nil, fmt.Errorf("%s parameter not found", helmAnnotationParamVersion)
 				}
 
-				err = setHelmValue(helmNewValues, helmAnnotationParamName, helmParamName.Value)
+				err = setHelmValue(&helmNewValues, helmAnnotationParamName, helmParamName.Value)
 				if err != nil {
 					return nil, fmt.Errorf("failed to set image parameter name value: %v", err)
 				}
-				err = setHelmValue(helmNewValues, helmAnnotationParamVersion, helmParamVersion.Value)
+				err = setHelmValue(&helmNewValues, helmAnnotationParamVersion, helmParamVersion.Value)
 				if err != nil {
 					return nil, fmt.Errorf("failed to set image parameter version value: %v", err)
 				}
@@ -542,34 +542,53 @@ func findHelmValuesKey(m yaml.MapSlice, key string) (int, bool) {
 }
 
 // set value of the parameter passed from the annotations.
-func setHelmValue(m yaml.MapSlice, key string, value interface{}) error {
+func setHelmValue(currentValues *yaml.MapSlice, key string, value interface{}) error {
 	// Check if the full key exists
-	if idx, found := findHelmValuesKey(m, key); found {
-		m[idx].Value = value
+	if idx, found := findHelmValuesKey(*currentValues, key); found {
+		(*currentValues)[idx].Value = value
 		return nil
 	}
 
 	var err error
 	keys := strings.Split(key, ".")
-	current := m
+	current := currentValues
+	var parent *yaml.MapSlice
+	var parentIdx int
 
 	for i, k := range keys {
-		if idx, found := findHelmValuesKey(current, k); found {
+		if idx, found := findHelmValuesKey(*current, k); found {
 			if i == len(keys)-1 {
 				// If we're at the final key, set the value and return
-				current[idx].Value = value
+				(*current)[idx].Value = value
 				return nil
 			} else {
 				// Navigate deeper into the map
-				if nestedMap, ok := current[idx].Value.(yaml.MapSlice); ok {
-					current = nestedMap
+				if nestedMap, ok := (*current)[idx].Value.(yaml.MapSlice); ok {
+					parent = current
+					parentIdx = idx
+					current = &nestedMap
 				} else {
-					return fmt.Errorf("unexpected type %T for key %s", current[idx].Value, k)
+					return fmt.Errorf("unexpected type %T for key %s", (*current)[idx].Value, k)
 				}
 			}
 		} else {
-			err = fmt.Errorf("key %s not found in the map", k)
-			break
+			newCurrent := yaml.MapSlice{}
+			var newParent yaml.MapSlice
+
+			if i == len(keys)-1 {
+				newParent = append(*current, yaml.MapItem{Key: k, Value: value})
+			} else {
+				newParent = append(*current, yaml.MapItem{Key: k, Value: newCurrent})
+			}
+
+			if parent == nil {
+				*currentValues = newParent
+			} else {
+				(*parent)[parentIdx].Value = newParent
+			}
+
+			parent = &newParent
+			current = &newCurrent
 		}
 	}
 


### PR DESCRIPTION
* This was previously supported, but broke when the function was refactored to preserve order of yaml file (#748)
* Behavior does not change if overriding an existing value
* If the values file is empty or does not have a previous value, add the value instead of erroring