### PR TITLE
fix: Multiple aliases for the same image only 1 parameter is updated

### DIFF
--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -465,10 +465,22 @@ func GetImagesAndAliasesFromApplication(app *v1alpha1.Application) image.Contain
 	// We update the ImageAlias field of the Images found in the app.Status.Summary.Images list.
 	for _, img := range *parseImageList(app.Annotations) {
 		if image := images.ContainsImage(img, false); image != nil {
-			if img.ImageAlias == "" {
-				image.ImageAlias = img.ImageName
+			if image.ImageAlias != "" {
+				// this image has already been matched to an alias, so create a copy
+				// and assign this alias to the image copy to avoid overwriting the existing alias association
+				imageCopy := *image
+				if img.ImageAlias == "" {
+					imageCopy.ImageAlias = img.ImageName
+				} else {
+					imageCopy.ImageAlias = img.ImageAlias
+				}
+				images = append(images, &imageCopy)
 			} else {
-				image.ImageAlias = img.ImageAlias
+				if img.ImageAlias == "" {
+					image.ImageAlias = img.ImageName
+				} else {
+					image.ImageAlias = img.ImageAlias
+				}
 			}
 		}
 	}

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -1471,6 +1471,109 @@ replicas: 1
 		assert.Equal(t, strings.TrimSpace(strings.ReplaceAll(expected, "\t", "  ")), strings.TrimSpace(string(yaml)))
 	})
 
+	t.Run("Valid Helm source with Helm values file with multiple aliases", func(t *testing.T) {
+		expected := `
+foo.image.name: nginx
+foo.image.tag: v1.0.0
+bar.image.name: nginx
+bar.image.tag: v1.0.0
+bbb.image.name: nginx
+bbb.image.tag: v1.0.0
+replicas: 1
+`
+		app := v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "testapp",
+				Annotations: map[string]string{
+					"argocd-image-updater.argoproj.io/image-list":          "foo=nginx, bar=nginx, bbb=nginx",
+					"argocd-image-updater.argoproj.io/write-back-method":   "git",
+					"argocd-image-updater.argoproj.io/write-back-target":   "helmvalues:./test-values.yaml",
+					"argocd-image-updater.argoproj.io/foo.helm.image-name": "foo.image.name",
+					"argocd-image-updater.argoproj.io/foo.helm.image-tag":  "foo.image.tag",
+					"argocd-image-updater.argoproj.io/bar.helm.image-name": "bar.image.name",
+					"argocd-image-updater.argoproj.io/bar.helm.image-tag":  "bar.image.tag",
+					"argocd-image-updater.argoproj.io/bbb.helm.image-name": "bbb.image.name",
+					"argocd-image-updater.argoproj.io/bbb.helm.image-tag":  "bbb.image.tag",
+				},
+			},
+			Spec: v1alpha1.ApplicationSpec{
+				Sources: []v1alpha1.ApplicationSource{
+					{
+						Chart: "my-app",
+						Helm: &v1alpha1.ApplicationSourceHelm{
+							ReleaseName: "my-app",
+							ValueFiles:  []string{"$values/some/dir/values.yaml"},
+							Parameters: []v1alpha1.HelmParameter{
+								{
+									Name:        "foo.image.name",
+									Value:       "nginx",
+									ForceString: true,
+								},
+								{
+									Name:        "foo.image.tag",
+									Value:       "v1.0.0",
+									ForceString: true,
+								},
+								{
+									Name:        "bar.image.name",
+									Value:       "nginx",
+									ForceString: true,
+								},
+								{
+									Name:        "bar.image.tag",
+									Value:       "v1.0.0",
+									ForceString: true,
+								},
+								{
+									Name:        "bbb.image.name",
+									Value:       "nginx",
+									ForceString: true,
+								},
+								{
+									Name:        "bbb.image.tag",
+									Value:       "v1.0.0",
+									ForceString: true,
+								},
+							},
+						},
+						RepoURL:        "https://example.com/example",
+						TargetRevision: "main",
+					},
+					{
+						Ref:            "values",
+						RepoURL:        "https://example.com/example2",
+						TargetRevision: "main",
+					},
+				},
+			},
+			Status: v1alpha1.ApplicationStatus{
+				SourceTypes: []v1alpha1.ApplicationSourceType{
+					v1alpha1.ApplicationSourceTypeHelm,
+					"",
+				},
+				Summary: v1alpha1.ApplicationSummary{
+					Images: []string{
+						"nginx:v0.0.0",
+					},
+				},
+			},
+		}
+
+		originalData := []byte(`
+foo.image.name: nginx
+foo.image.tag: v0.0.0
+bar.image.name: nginx
+bar.image.tag: v0.0.0
+bbb.image.name: nginx
+bbb.image.tag: v0.0.0
+replicas: 1
+`)
+		yaml, err := marshalParamsOverride(&app, originalData)
+		require.NoError(t, err)
+		assert.NotEmpty(t, yaml)
+		assert.Equal(t, strings.TrimSpace(strings.ReplaceAll(expected, "\t", "  ")), strings.TrimSpace(string(yaml)))
+	})
+
 	t.Run("Failed to setValue image parameter name", func(t *testing.T) {
 		expected := `
 image:


### PR DESCRIPTION
Fixes https://github.com/argoproj-labs/argocd-image-updater/issues/809

For multiple aliases pointing to the same image, parameters for each alias should be updated according to the application annotations. The test is contributed by dshmelev.