### PR TITLE
feat: Sync namespace for Event to the Application namespace (#847)

### DIFF
--- a/manifests/base/rbac/argocd-image-updater-clusterrole.yaml
+++ b/manifests/base/rbac/argocd-image-updater-clusterrole.yaml
@@ -1,5 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: argocd-image-updater
@@ -8,20 +8,8 @@ metadata:
   name: argocd-image-updater
 rules:
   - apiGroups:
-      - ''
+      - ""
     resources:
-      - secrets
-      - configmaps
+      - events
     verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - argoproj.io
-    resources:
-      - applications
-    verbs:
-      - get
-      - list
-      - update
-      - patch
+      - create

--- a/manifests/base/rbac/argocd-image-updater-clusterrolebinding.yaml
+++ b/manifests/base/rbac/argocd-image-updater-clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: argocd-image-updater
+    app.kubernetes.io/part-of: argocd-image-updater
+    app.kubernetes.io/component: controller
+  name: argocd-image-updater
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argocd-image-updater
+subjects:
+  - kind: ServiceAccount
+    name: argocd-image-updater

--- a/manifests/base/rbac/kustomization.yaml
+++ b/manifests/base/rbac/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - argocd-image-updater-clusterrole.yaml
+  - argocd-image-updater-clusterrolebinding.yaml
   - argocd-image-updater-role.yaml
   - argocd-image-updater-rolebinding.yaml
   - argocd-image-updater-sa.yaml

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -34,6 +34,16 @@ rules:
   - list
   - update
   - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: argocd-image-updater
+    app.kubernetes.io/part-of: argocd-image-updater
+  name: argocd-image-updater
+rules:
 - apiGroups:
   - ""
   resources:
@@ -52,6 +62,22 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
+  name: argocd-image-updater
+subjects:
+- kind: ServiceAccount
+  name: argocd-image-updater
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: argocd-image-updater
+    app.kubernetes.io/part-of: argocd-image-updater
+  name: argocd-image-updater
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
   name: argocd-image-updater
 subjects:
 - kind: ServiceAccount

--- a/pkg/kube/kubernetes.go
+++ b/pkg/kube/kubernetes.go
@@ -96,14 +96,14 @@ func (client *KubernetesClient) GetSecretField(namespace string, secretName stri
 	}
 }
 
-// CreateApplicationevent creates a kubernetes event with a custom reason and message for an application.
+// CreateApplicationEvent creates a kubernetes event with a custom reason and message for an application.
 func (client *KubernetesClient) CreateApplicationEvent(app *appv1alpha1.Application, reason string, message string, annotations map[string]string) (*v1.Event, error) {
 	t := metav1.Time{Time: time.Now()}
 
 	event := v1.Event{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        fmt.Sprintf("%v.%x", app.ObjectMeta.Name, t.UnixNano()),
-			Namespace:   client.Namespace,
+			Namespace:   app.ObjectMeta.Namespace,
 			Annotations: annotations,
 		},
 		Source: v1.EventSource{
@@ -125,7 +125,7 @@ func (client *KubernetesClient) CreateApplicationEvent(app *appv1alpha1.Applicat
 		Reason:         reason,
 	}
 
-	result, err := client.Clientset.CoreV1().Events(client.Namespace).Create(client.Context, &event, metav1.CreateOptions{})
+	result, err := client.Clientset.CoreV1().Events(app.ObjectMeta.Namespace).Create(client.Context, &event, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kube/kubernetes_test.go
+++ b/pkg/kube/kubernetes_test.go
@@ -93,6 +93,6 @@ func Test_CreateApplicationEvent(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, event)
 		assert.Equal(t, "ArgocdImageUpdater", event.Source.Component)
-		assert.Equal(t, "default", client.Namespace)
+		assert.Equal(t, "argocd", event.Namespace)
 	})
 }


### PR DESCRIPTION
Sync namespace for Event to the Application namespace (#847)

Note that this does assume that the kubernetes client has permissions to create Events on the particular namespace (this typically depends on cluster RBAC)