### PR TITLE
fix: allow the specific image platform os/arch/variant to meet the requirement for a broader image platform os/arch

### DIFF
--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -32,7 +32,7 @@ func PlatformKey(os string, arch string, variant string) string {
 	return key
 }
 
-// MatchesPlatform returns true if given OS name matches the OS set in options
+// WantsPlatform returns true if given platform matches the platform set in options
 func (o *ManifestOptions) WantsPlatform(os string, arch string, variant string) bool {
 	o.mutex.RLock()
 	defer o.mutex.RUnlock()
@@ -40,7 +40,17 @@ func (o *ManifestOptions) WantsPlatform(os string, arch string, variant string) 
 		return true
 	}
 	_, ok := o.platforms[PlatformKey(os, arch, variant)]
-	return ok
+	if ok {
+		return true
+	}
+
+	// if no exact match, and the passed platform has variant, it may be a more
+	// specific variant of the platform specified in options. So compare os/arch only
+	if variant != "" {
+		_, ok = o.platforms[PlatformKey(os, arch, "")]
+		return ok
+	}
+	return false
 }
 
 // WithPlatform sets a platform filter for options o

--- a/pkg/options/options_test.go
+++ b/pkg/options/options_test.go
@@ -26,10 +26,28 @@ func Test_WantsPlatform(t *testing.T) {
 		opts = opts.WithPlatform("linux", "arm", "v7")
 		assert.True(t, opts.WantsPlatform("linux", "arm", "v7"))
 	})
-	t.Run("Platform appended", func(t *testing.T) {
+	t.Run("Platform appended and non-match", func(t *testing.T) {
 		opts = opts.WithPlatform("linux", "arm", "v8")
 		assert.True(t, opts.WantsPlatform("linux", "arm", "v7"))
 		assert.True(t, opts.WantsPlatform("linux", "arm", "v8"))
+
+		assert.False(t, opts.WantsPlatform("linux", "arm", "v6"))
+		assert.False(t, opts.WantsPlatform("linux", "arm", ""))
+		assert.False(t, opts.WantsPlatform("linux", "", ""))
+
+		assert.False(t, opts.WantsPlatform("linux", "amd64", "v7"))
+		assert.False(t, opts.WantsPlatform("linux", "amd64", ""))
+
+		assert.False(t, opts.WantsPlatform("darwin", "arm", "v7"))
+		assert.False(t, opts.WantsPlatform("darwin", "arm", ""))
+	})
+	t.Run("Platform lenient match", func(t *testing.T) {
+		opts := &ManifestOptions{}
+		opts = opts.WithPlatform("linux", "arm", "")
+		opts = opts.WithPlatform("linux", "arm", "v7")
+		assert.True(t, opts.WantsPlatform("linux", "arm", "v8"))
+		assert.True(t, opts.WantsPlatform("linux", "arm", "v7"))
+		assert.True(t, opts.WantsPlatform("linux", "arm", ""))
 	})
 	t.Run("Uninitialized options", func(t *testing.T) {
 		opts := &ManifestOptions{}

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -64,7 +64,7 @@ type registryClient struct {
 }
 
 // credentials is an implementation of distribution/V3/session struct
-// to mangage registry credentials and token
+// to manage registry credentials and token
 type credentials struct {
 	username      string
 	password      string
@@ -306,8 +306,8 @@ func (client *registryClient) TagMetadata(manifest distribution.Manifest, opts *
 		}
 
 		if !opts.WantsPlatform(info.OS, info.Arch, info.Variant) {
-			logCtx.Debugf("ignoring v2 manifest %v. Manifest platform: %s/%s, requested: %s",
-				ti.EncodedDigest(), info.OS, info.Arch, strings.Join(opts.Platforms(), ","))
+			logCtx.Debugf("ignoring v2 manifest %v. Manifest platform: %s, requested: %s",
+				ti.EncodedDigest(), options.PlatformKey(info.OS, info.Arch, info.Variant), strings.Join(opts.Platforms(), ","))
 			return nil, nil
 		}
 
@@ -338,8 +338,8 @@ func (client *registryClient) TagMetadata(manifest distribution.Manifest, opts *
 		}
 
 		if !opts.WantsPlatform(info.OS, info.Arch, info.Variant) {
-			logCtx.Debugf("ignoring OCI manifest %v. Manifest platform: %s/%s, requested: %s",
-				ti.EncodedDigest(), info.OS, info.Arch, strings.Join(opts.Platforms(), ","))
+			logCtx.Debugf("ignoring OCI manifest %v. Manifest platform: %s, requested: %s",
+				ti.EncodedDigest(), options.PlatformKey(info.OS, info.Arch, info.Variant), strings.Join(opts.Platforms(), ","))
 			return nil, nil
 		}
 
@@ -367,19 +367,20 @@ func TagInfoFromReferences(client *registryClient, opts *options.ManifestOptions
 			refArch = ref.Platform.Architecture
 			refVariant = ref.Platform.Variant
 		}
-		platforms = append(platforms, refOS+"/"+refArch)
-		logCtx.Tracef("Found %s", options.PlatformKey(refOS, refArch, refVariant))
+		platform1 := options.PlatformKey(refOS, refArch, refVariant)
+		platforms = append(platforms, platform1)
+		logCtx.Tracef("Found %s", platform1)
 		if !opts.WantsPlatform(refOS, refArch, refVariant) {
 			logCtx.Tracef("Ignoring referenced manifest %v because platform %s does not match any of: %s",
 				ref.Digest,
-				options.PlatformKey(refOS, refArch, refVariant),
+				platform1,
 				strings.Join(opts.Platforms(), ","))
 			continue
 		}
 		ml = append(ml, ref)
 	}
 
-	// We need at least one reference that matches requested plaforms
+	// We need at least one reference that matches requested platforms
 	if len(ml) == 0 {
 		logCtx.Debugf("Manifest list did not contain any usable reference. Platforms requested: (%s), platforms included: (%s)",
 			strings.Join(opts.Platforms(), ","), strings.Join(platforms, ","))


### PR DESCRIPTION
Fixes https://github.com/argoproj-labs/argocd-image-updater/issues/711

* change `WantsPlatform()` method to allow match of broader platform
* add unit tests for the above change
* improve logs to include platform variant so it's clear why certain match is false
* this fix causes some change of behavior in comparing options platforms vs platforms of available images, as shown in the changes to `pkg/image/options_test.go`