### PR TITLE
fix: missing namespace on clusterrolebinding in install manifests

### DIFF
--- a/docs/install/installation.md
+++ b/docs/install/installation.md
@@ -28,6 +28,10 @@ Argo CD is running. Don't worry, without any configuration, it will not start me
 kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj-labs/argocd-image-updater/stable/manifests/install.yaml
 ```
 
+!!! warning
+The installation manifests include `ClusterRoleBinding` resources that reference `argocd` namespace. If you are installing Argo CD into a different
+namespace then make sure to update the namespace reference.
+
 !!!note "A word on high availability"
     It is not advised to run multiple replicas of the same Argo CD Image Updater
     instance. Just leave the number of replicas at 1, otherwise weird side
@@ -69,6 +73,10 @@ First, create a namespace and apply the manifests to your cluster
 kubectl create namespace argocd-image-updater
 kubectl apply -n argocd-image-updater -f https://raw.githubusercontent.com/argoproj-labs/argocd-image-updater/stable/manifests/install.yaml
 ```
+
+!!! warning
+The installation manifests include `ClusterRoleBinding` resources that reference `argocd` namespace. If you are installing Argo CD into a different
+namespace then make sure to update the namespace reference.
 
 !!!note "A word on high availability"
     It is not advised to run multiple replicas of the same Argo CD Image Updater

--- a/manifests/base/rbac/argocd-image-updater-clusterrolebinding.yaml
+++ b/manifests/base/rbac/argocd-image-updater-clusterrolebinding.yaml
@@ -13,3 +13,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: argocd-image-updater
+    namespace: argocd

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -82,6 +82,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: argocd-image-updater
+  namespace: argocd
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
Fixes https://github.com/argoproj-labs/argocd-image-updater/issues/859

PR https://github.com/argoproj-labs/argocd-image-updater/pull/848 added a clusterrolebinding without specifying SA namespace to the install manifests, causing the installation to fail. This PR fixes the problem by adding a default SA namespace `argocd` to the clusterrolebinding, and also updates the docs with a reminder/warning for the need to change the namespace if necessary. Tested with installing both plain manifest and kustomization.