### PR TITLE
fix(git): write back to custom git branch failed by rejected push: tip of your current branch is behind

### DIFF
--- a/pkg/argocd/git.go
+++ b/pkg/argocd/git.go
@@ -246,7 +246,7 @@ func commitChangesGit(app *v1alpha1.Application, wbc *WriteBackConfig, changeLis
 	if err != nil {
 		return err
 	}
-	err = gitC.Push("origin", pushBranch, false)
+	err = gitC.Push("origin", pushBranch, pushBranch != checkOutBranch)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes https://github.com/argoproj-labs/argocd-image-updater/issues/673 https://github.com/argoproj-labs/argocd-image-updater/issues/879