### PR TITLE
fix: add build steps to create binary checksum and signature files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,10 @@ release-binaries:
 	BINNAME=argocd-image-updater-darwin_amd64 OUTDIR=dist/release OS=darwin ARCH=amd64 make controller
 	BINNAME=argocd-image-updater-darwin_arm64 OUTDIR=dist/release OS=darwin ARCH=arm64 make controller
 	BINNAME=argocd-image-updater-win64.exe OUTDIR=dist/release OS=windows ARCH=amd64 make controller
+	rm -f dist/release/release-v${VERSION}.sha256 dist/release/release-v${VERSION}.sha256.asc
+	for bin in dist/release/argocd-image-updater-*; do sha256sum "$$bin" >> dist/release/release-v${VERSION}.sha256; done
+	gpg -a --detach-sign dist/release/release-v${VERSION}.sha256
+	gpg -a --verify dist/release/release-v${VERSION}.sha256.asc
 
 .PHONY: extract-binary
 extract-binary:


### PR DESCRIPTION
Fixes https://github.com/argoproj-labs/argocd-image-updater/issues/898
