### PR TITLE
fix: respect log level settings

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -40,20 +40,23 @@ func NewContext() *LogContext {
 
 // SetLogLevel sets the log level to use for the logger
 func SetLogLevel(logLevel string) error {
+	var level logrus.Level
 	switch strings.ToLower(logLevel) {
 	case "trace":
-		logger.SetLevel(logrus.TraceLevel)
+		level = logrus.TraceLevel
 	case "debug":
-		logger.SetLevel(logrus.DebugLevel)
+		level = logrus.DebugLevel
 	case "info":
-		logger.SetLevel(logrus.InfoLevel)
+		level = logrus.InfoLevel
 	case "warn":
-		logger.SetLevel(logrus.WarnLevel)
+		level = logrus.WarnLevel
 	case "error":
-		logger.SetLevel(logrus.ErrorLevel)
+		level = logrus.ErrorLevel
 	default:
 		return fmt.Errorf("invalid loglevel: %s", logLevel)
 	}
+	logger.SetLevel(level)
+	logrus.SetLevel(level) // set loglevel for the default logrus.logger
 	return nil
 }
 


### PR DESCRIPTION
This is an approach to fix https://github.com/argoproj-labs/argocd-image-updater/issues/903

However, there are still some info level logs printed. 

```
time="2024-10-31T08:51:43Z" level=info msg=Trace args="[git config user.name argocd]" dir=/tmp/git-rainmaker3532605552 operation_name="exec git" time_ms=1.117718
```

These logs are generated by codes listed below
1. https://github.com/argoproj-labs/argocd-image-updater/blob/master/ext/git/client.go#L814
2.  https://github.com/argoproj/argo-cd/blob/master/util/exec/exec.go#L54
3. https://github.com/argoproj/gitops-engine/blob/master/pkg/utils/tracing/logging.go#L43

They provided a way to set the log level, which is here https://github.com/argoproj/argo-cd/blob/master/util/log/logrus.go#L55. We can use the environment variable `ARGOCD_LOG_LEVEL` to set the log level. This can be done through the helm chart. 

Update:
I test with set below for the helm chart, and it works. 
```
extraEnv:
  - name: ARGOCD_LOG_LEVEL
    value: "warn"
```