### PR TITLE
fix: delay setting git.username and git.email config till commit time

### DIFF
--- a/pkg/argocd/git.go
+++ b/pkg/argocd/git.go
@@ -158,14 +158,6 @@ func commitChangesGit(app *v1alpha1.Application, wbc *WriteBackConfig, changeLis
 		return err
 	}
 
-	// Set username and e-mail address used to identify the commiter
-	if wbc.GitCommitUser != "" && wbc.GitCommitEmail != "" {
-		err = gitC.Config(wbc.GitCommitUser, wbc.GitCommitEmail)
-		if err != nil {
-			return err
-		}
-	}
-
 	// The branch to checkout is either a configured branch in the write-back
 	// config, or taken from the application spec's targetRevision. If the
 	// target revision is set to the special value HEAD, or is the empty
@@ -245,6 +237,14 @@ func commitChangesGit(app *v1alpha1.Application, wbc *WriteBackConfig, changeLis
 		commitOpts.CommitMessagePath = cm.Name()
 		_ = cm.Close()
 		defer os.Remove(cm.Name())
+	}
+
+	// Set username and e-mail address used to identify the commiter
+	if wbc.GitCommitUser != "" && wbc.GitCommitEmail != "" {
+		err = gitC.Config(wbc.GitCommitUser, wbc.GitCommitEmail)
+		if err != nil {
+			return err
+		}
 	}
 
 	if wbc.GitCommitSigningKey != "" {

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -3363,6 +3363,7 @@ replacements: []
 		app := app.DeepCopy()
 		gitMock := &gitmock.Client{}
 		gitMock.On("Init").Return(nil)
+		gitMock.On("Root").Return(t.TempDir())
 		gitMock.On("ShallowFetch", mock.Anything, mock.Anything).Return(nil)
 		gitMock.On("Checkout", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 			args.Assert(t, "mydefaultbranch", false)


### PR DESCRIPTION
In https://github.com/argoproj-labs/argocd-image-updater/blob/master/pkg/argocd/git.go#L161-L167, it sets git.username and git.email config to the git client. These 2 configs are used by commit operation later. In some cases, the commit operation will not be needed, either because there are errors before the commit, or because the commit should be skipped due to absence of real changes.

This PR delays setting these 2 configs, which involves calling git command twice, till before the commit operation. In addition to the savings from skipping the 2 command calls, the logs will also be cleaner.