### PR TITLE
fix: log level for library from argocd

### DIFF
--- a/manifests/base/deployment/argocd-image-updater-deployment.yaml
+++ b/manifests/base/deployment/argocd-image-updater-deployment.yaml
@@ -101,6 +101,12 @@ spec:
               name: argocd-image-updater-config
               key: kube.events
               optional: true
+        - name: ARGOCD_LOGLEVEL
+          valueFrom:
+            configMapKeyRef:
+              name: argocd-image-updater-config
+              key: log.level
+              optional: true
         livenessProbe:
           httpGet:
             path: /healthz

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -209,6 +209,12 @@ spec:
               key: kube.events
               name: argocd-image-updater-config
               optional: true
+        - name: ARGOCD_LOGLEVEL
+          valueFrom:
+            configMapKeyRef:
+              key: log.level
+              name: argocd-image-updater-config
+              optional: true
         image: quay.io/argoprojlabs/argocd-image-updater:latest
         imagePullPolicy: Always
         livenessProbe:


### PR DESCRIPTION
This is a follow-up PR of https://github.com/argoproj-labs/argocd-image-updater/pull/904

This environment variable can control the logs like below
```
time="2024-10-31T08:51:43Z" level=info msg=Trace args="[git config user.name argocd]" dir=/tmp/git-rainmaker3532605552 operation_name="exec git" time_ms=1.117718
```