### PR TITLE
Dj/moarshit

### DIFF
--- a/pkg/image/options.go
+++ b/pkg/image/options.go
@@ -98,6 +98,8 @@ func (img *ContainerImage) GetParameterUpdateStrategy(annotations map[string]str
 func (img *ContainerImage) ParseUpdateStrategy(val string) UpdateStrategy {
 	logCtx := img.LogContext()
 	switch strings.ToLower(val) {
+	case "modified_semver":
+		return StrategyModifiedSemVer
 	case "semver":
 		return StrategySemVer
 	case "latest":

--- a/pkg/image/version.go
+++ b/pkg/image/version.go
@@ -14,18 +14,22 @@ import (
 type UpdateStrategy int
 
 const (
+	// VersionModifiedSemVer does custom sorting based on prizeicks tags
+	StrategyModifiedSemVer UpdateStrategy = 0
 	// VersionSortSemVer sorts tags using semver sorting (the default)
-	StrategySemVer UpdateStrategy = 0
+	StrategySemVer UpdateStrategy = 1
 	// VersionSortLatest sorts tags after their creation date
-	StrategyNewestBuild UpdateStrategy = 1
+	StrategyNewestBuild UpdateStrategy = 2
 	// VersionSortName sorts tags alphabetically by name
-	StrategyAlphabetical UpdateStrategy = 2
+	StrategyAlphabetical UpdateStrategy = 3
 	// VersionSortDigest uses latest digest of an image
-	StrategyDigest UpdateStrategy = 3
+	StrategyDigest UpdateStrategy = 4
 )
 
 func (us UpdateStrategy) String() string {
 	switch us {
+	case StrategyModifiedSemVer:
+		return "modified_semver"
 	case StrategySemVer:
 		return "semver"
 	case StrategyNewestBuild:
@@ -85,6 +89,8 @@ func (img *ContainerImage) GetNewestVersionFromTags(vc *VersionConstraint, tagLi
 
 	var availableTags tag.SortableImageTagList
 	switch vc.Strategy {
+	case StrategyModifiedSemVer:
+		availableTags = tagList.SortByModifiedSemVer()
 	case StrategySemVer:
 		availableTags = tagList.SortBySemVer()
 	case StrategyAlphabetical:

--- a/pkg/tag/modified_semver.go
+++ b/pkg/tag/modified_semver.go
@@ -1,0 +1,66 @@
+package tag
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+// semverCollection is a replacement for semver.Collection that breaks version
+// comparison ties through a lexical comparison of the original version strings.
+// Using this, instead of semver.Collection, when sorting will yield
+// deterministic results that semver.Collection will not yield.
+type modifiedSemverCollection []*semver.Version
+
+// Len returns the length of a collection. The number of Version instances
+// on the slice.
+func (s modifiedSemverCollection) Len() int {
+	return len(s)
+}
+
+// Less is needed for the sort interface to compare two Version objects on the
+// slice. If checks if one is less than the other.
+func (s modifiedSemverCollection) Less(i, j int) bool {
+	baseI, suffixNumI := extractBaseAndSuffix(s[i].Original())
+	baseJ, suffixNumJ := extractBaseAndSuffix(s[j].Original())
+
+	// Compare base versions without suffixes
+	baseVersionI, _ := semver.NewVersion(baseI)
+	baseVersionJ, _ := semver.NewVersion(baseJ)
+	comp := baseVersionI.Compare(baseVersionJ)
+	if comp != 0 {
+		return comp < 0
+	}
+
+	return suffixNumI < suffixNumJ
+}
+
+// Swap is needed for the sort interface to replace the Version objects
+// at two different positions in the slice.
+func (s modifiedSemverCollection) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func extractBaseAndSuffix(version string) (string, int) {
+	// Regex to match a base version and an optional suffix with .n
+	re := regexp.MustCompile(`^([^-]+)(?:-(.*))?`)
+	matches := re.FindStringSubmatch(version)
+
+	baseVersion := matches[1]
+	suffixNum := 0
+
+	if len(matches) > 2 && matches[2] != "" {
+		// Check for a trailing .n in the suffix, and extract the number if present
+		suffixParts := strings.Split(matches[2], ".")
+		if len(suffixParts) > 1 {
+			num, err := strconv.Atoi(suffixParts[len(suffixParts)-1])
+			if err == nil {
+				suffixNum = num
+			}
+		}
+	}
+
+	return baseVersion, suffixNum
+}


### PR DESCRIPTION
intent of this PR is to extend the modified semver sorting algorithm to support `release-candidate` tags. Tests were added to account for all cases 