### PR TITLE
chore: add cherry-pick-bot

### DIFF
--- a/.github/cherry-pick-bot.yml
+++ b/.github/cherry-pick-bot.yml
@@ -1,0 +1,3 @@
+enabled: true
+preservePullRequestTitle: true
+


### PR DESCRIPTION
This PR enables a [cherry-pick-bot](https://github.com/googleapis/repo-automation-bots/tree/main/packages/cherry-pick-bot) that will automate cherry picks into a PR.