### PR TITLE
Improve Application updates when write-back method is ArgoCD

### DIFF
--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -288,6 +288,18 @@ func UpdateApplication(updateConf *UpdateConfiguration, state *SyncIterationStat
 		if needsUpdate(updateableImage, applicationImage, latest) {
 
 			imgCtx.Infof("Setting new image to %s", applicationImage.WithTag(latest).GetFullNameWithTag())
+
+			// Check if new image is alredy set in Application Spec when write back is set to argocd
+			// and compare with new image
+			appImage, err := getAppImage(&updateConf.UpdateApp.Application, applicationImage.WithTag(latest))
+			if err != nil {
+				continue
+			}
+			if appImage == applicationImage.WithTag(latest).GetFullNameWithTag() {
+				imgCtx.Infof("New image %s already set in spec", applicationImage.WithTag(latest).GetFullNameWithTag())
+				continue
+			}
+
 			needUpdate = true
 
 			err = setAppImage(&updateConf.UpdateApp.Application, applicationImage.WithTag(latest))
@@ -380,6 +392,18 @@ func UpdateApplication(updateConf *UpdateConfiguration, state *SyncIterationStat
 func needsUpdate(updateableImage *image.ContainerImage, applicationImage *image.ContainerImage, latest *tag.ImageTag) bool {
 	// If the latest tag does not match image's current tag or the kustomize image is different, it means we have an update candidate.
 	return !updateableImage.ImageTag.Equals(latest) || applicationImage.KustomizeImage != nil && applicationImage.DiffersFrom(updateableImage, false)
+}
+
+func getAppImage(app *v1alpha1.Application, img *image.ContainerImage) (string, error) {
+	var err error
+	if appType := GetApplicationType(app); appType == ApplicationTypeKustomize {
+		return GetKustomizeImage(app, img)
+	} else if appType == ApplicationTypeHelm {
+		return GetHelmImage(app, img)
+	} else {
+		err = fmt.Errorf("could not update application %s - neither Helm nor Kustomize application", app)
+		return "", err
+	}
 }
 
 func setAppImage(app *v1alpha1.Application, img *image.ContainerImage) error {

--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -287,7 +287,7 @@ func UpdateApplication(updateConf *UpdateConfiguration, state *SyncIterationStat
 
 		if needsUpdate(updateableImage, applicationImage, latest) {
 			appImageWithTag := applicationImage.WithTag(latest)
-			appImageWithTagFull := appImageWithTag.GetFullNameWithTag()
+			appImageFullNameWithTag := appImageWithTag.GetFullNameWithTag()
 
 			// Check if new image is already set in Application Spec when write back is set to argocd
 			// and compare with new image
@@ -295,13 +295,13 @@ func UpdateApplication(updateConf *UpdateConfiguration, state *SyncIterationStat
 			if err != nil {
 				continue
 			}
-			if appImageSpec == appImageWithTagFull {
-				imgCtx.Infof("New image %s already set in spec", appImageWithTagFull)
+			if appImageSpec == appImageFullNameWithTag {
+				imgCtx.Infof("New image %s already set in spec", appImageFullNameWithTag)
 				continue
 			}
 
 			needUpdate = true
-			imgCtx.Infof("Setting new image to %s", appImageWithTagFull)
+			imgCtx.Infof("Setting new image to %s", appImageFullNameWithTag)
 
 			err = setAppImage(&updateConf.UpdateApp.Application, appImageWithTag)
 
@@ -310,7 +310,7 @@ func UpdateApplication(updateConf *UpdateConfiguration, state *SyncIterationStat
 				result.NumErrors += 1
 				continue
 			} else {
-				imgCtx.Infof("Successfully updated image '%s' to '%s', but pending spec update (dry run=%v)", updateableImage.GetFullNameWithTag(), appImageWithTag.GetFullNameWithTag(), updateConf.DryRun)
+				imgCtx.Infof("Successfully updated image '%s' to '%s', but pending spec update (dry run=%v)", updateableImage.GetFullNameWithTag(), appImageFullNameWithTag, updateConf.DryRun)
 				changeList = append(changeList, ChangeEntry{appImageWithTag, updateableImage.ImageTag, appImageWithTag.ImageTag})
 				result.NumImagesUpdated += 1
 			}


### PR DESCRIPTION
When the write-back method is ArgoCD, the Image Updater sends an update to the ArgoCD Application on each iteration. No matter whether the new image has already been set or not, it always sends the update. In a situation where autoSync is disabled, this means that it continuously sends updates until somebody syncs the Application.

To reduce updates and improve resource usage, this pull request slightly changes the behavior. The Image Updater will check if the new image is already set in the Application source to apply the update or ignore it.

We have tested the changes in our ArgoCD instance to check the feature and you can see the results in the image below. Updates have been reduced. Once they are applied, updates disappear. CPU and memory usage have been improved.

![Captura de pantalla 2024-12-09 a las 10 22 03](https://github.com/user-attachments/assets/e69d2eac-19a0-413a-aa7a-634b88cf85f0)
