### PR TITLE
update k8s.io/client-go from v1.5.2 to v0.31.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.31.0
 	k8s.io/apimachinery v0.31.0
-	k8s.io/client-go v1.5.2
+	k8s.io/client-go v0.31.0
 	sigs.k8s.io/kustomize/api v0.17.2
 	sigs.k8s.io/kustomize/kyaml v0.17.1
 )

--- a/registry-scanner/go.mod
+++ b/registry-scanner/go.mod
@@ -17,7 +17,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.31.0
 	k8s.io/apimachinery v0.31.0
-	k8s.io/client-go v1.5.2
+	k8s.io/client-go v0.31.0
 )
 
 require (


### PR DESCRIPTION
https://pkg.go.dev/k8s.io/client-go#section-readme
<details><summary>Details</summary>
<p>

![image](https://github.com/user-attachments/assets/4934d476-f18e-44e5-bcf0-13c932f3b1ac)


</p>
</details> 

migrates to newer scheme to match kubernetes releases. 