### PR TITLE
remove docker/distribution replace from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -175,7 +175,6 @@ require (
 replace (
 	// Uncomment for local testing
 	// github.com/argoproj-labs/argocd-image-updater/registry-scanner => ./registry-scanner/
-	github.com/docker/distribution => github.com/docker/distribution v2.8.1+incompatible
 	github.com/golang/protobuf => github.com/golang/protobuf v1.5.4
 
 	k8s.io/api => k8s.io/api v0.31.0


### PR DESCRIPTION
```bash
🔎 Scanning "packages/x86_64/argocd-image-updater-0.15.1-r0.apk"
└── 📄 /usr/bin/argocd-image-updater
        📦 github.com/docker/distribution v2.8.1+incompatible (go-module)
            High CVE-2023-2253 GHSA-hqxw-f8mx-cpmw fixed in 2.8.2-beta.1
```
context: I'm packaging it [here](https://github.com/wolfi-dev/os/pull/37040) and this is being flagged out as a CVE by the scanner. 
