### PR TITLE
chore(ci): use files parameter in codecov-action instead of file, which was deprecated and removed

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -90,7 +90,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: coverage.out
+          files: coverage.out
 
   test-manifests:
     name: Ensure kubernetes manifests conform to their schema


### PR DESCRIPTION
see https://github.com/codecov/codecov-action/tree/main?tab=readme-ov-file#arguments for codecov-action parameters.