### PR TITLE
fix: Add gpg-agent to container image (#978)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ FROM alpine:3.20
 
 RUN apk update && \
     apk upgrade && \
-    apk add ca-certificates git openssh-client aws-cli tini gpg && \
+    apk add ca-certificates git openssh-client aws-cli tini gpg gpg-agent && \
     rm -rf /var/cache/apk/*
 
 RUN mkdir -p /usr/local/bin


### PR DESCRIPTION
cherry-pick from master to release-0.15 branch to fix the issue of missing gpg-agent package 