### PR TITLE
fix: Image updater changes git write back file (#970)

### DIFF
--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -652,7 +652,9 @@ func getWriteBackConfig(app *v1alpha1.Application, kubeClient *kube.KubernetesCl
 }
 
 func parseDefaultTarget(appNamespace string, appName string, path string, kubeClient *kube.KubernetesClient) string {
-	if (appNamespace == kubeClient.Namespace) || (appNamespace == "") {
+	// when running from command line and argocd-namespace is not set, e.g., via --argocd-namespace option,
+	// kubeClient.Namespace may be resolved to "default". In this case, also use the file name without namespace
+	if appNamespace == kubeClient.Namespace || kubeClient.Namespace == "default" || appNamespace == "" {
 		defaultTargetFile := fmt.Sprintf(common.DefaultTargetFilePatternWithoutNamespace, appName)
 		return filepath.Join(path, defaultTargetFile)
 	} else {


### PR DESCRIPTION
cherry-pick from master to release-0.15 to fix the issue of changed default file name for git write-back target