### PR TITLE
docs: correct formatting issues

### DIFF
--- a/docs/basics/update-strategies.md
+++ b/docs/basics/update-strategies.md
@@ -19,7 +19,7 @@ The following update strategies are currently supported:
 * [digest](#strategy-digest) - Update to the latest version of a given version (tag), using the tag's SHA digest
 * [name/alphabetical](#strategy-name) - Sorts tags alphabetically and update to the one with the highest cardinality
 
-!!!warning "Renamed image update strategies
+!!!warning "Renamed image update strategies"
     The `latest` strategy has been renamed to `newest-build`, and `name` strategy has been renamed to `alphabetical`. 
     Please switch to the new convention as support for the old naming convention will be removed in future releases.
 

--- a/docs/install/installation.md
+++ b/docs/install/installation.md
@@ -29,8 +29,8 @@ kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj-labs/argoc
 ```
 
 !!! warning
-     The installation manifests include `ClusterRoleBinding` resources that reference `argocd` namespace. If you are installing Argo CD into a different
-namespace then make sure to update the namespace reference.
+    The installation manifests include `ClusterRoleBinding` resources that reference `argocd` namespace. If you are installing Argo CD into a different
+    namespace then make sure to update the namespace reference.
 
 !!!note "A word on high availability"
     It is not advised to run multiple replicas of the same Argo CD Image Updater
@@ -75,8 +75,8 @@ kubectl apply -n argocd-image-updater -f https://raw.githubusercontent.com/argop
 ```
 
 !!! warning
-     The installation manifests include `ClusterRoleBinding` resources that reference `argocd` namespace. If you are installing Argo CD into a different
-namespace then make sure to update the namespace reference.
+    The installation manifests include `ClusterRoleBinding` resources that reference `argocd` namespace. If you are installing Argo CD into a different
+    namespace then make sure to update the namespace reference.
 
 !!!note "A word on high availability"
     It is not advised to run multiple replicas of the same Argo CD Image Updater


### PR DESCRIPTION
I'm not entirely sure of the correct syntax or the process for testing these docs locally (just doing a drive-by commit on GitHub). I noticed that some of the Warning blocks in the docs had broken formatting. This PR should fix that. 

# Before
![image](https://github.com/user-attachments/assets/cba2f050-faae-4d41-8e62-d727cb485d05)

![image](https://github.com/user-attachments/assets/87ffae26-3069-4986-8398-3a391c65f633)

![image](https://github.com/user-attachments/assets/5aecd8af-1c9b-4769-a876-a92466204902)
