### PR TITLE
Keep yaml sequence indentation when writing back to Git to a kustomize file

### DIFF
--- a/pkg/argocd/git.go
+++ b/pkg/argocd/git.go
@@ -382,7 +382,7 @@ func updateKustomizeFile(filter kyaml.Filter, path string) (error, bool) {
 		PreserveSeqIndent: true,
 	}
 
-	// Read input file
+	// Read from input buffer
 	newYSlice, err := rw.Read()
 	if err != nil {
 		return err, false
@@ -405,7 +405,7 @@ func updateKustomizeFile(filter kyaml.Filter, path string) (error, bool) {
 		return err, false
 	}
 
-	// yCpy contains metadata used by kio to preserve sequence indentation,
+	// newY contains metadata used by kio to preserve sequence indentation,
 	// hence we need to parse the output buffer instead
 	newParsedY, err := kyaml.Parse(out.String())
 	if err != nil {
@@ -416,12 +416,13 @@ func updateKustomizeFile(filter kyaml.Filter, path string) (error, bool) {
 		return err, false
 	}
 
-	// Diff the updated document with the original
+	// Compare the updated document with the original document
 	if originalData == newData {
 		log.Debugf("target parameter file and marshaled data are the same, skipping commit.")
 		return nil, true
 	}
 
+	// Write to file the changes
 	if err := os.WriteFile(path, out.Bytes(), 0600); err != nil {
 		return err, false
 	}

--- a/pkg/argocd/git.go
+++ b/pkg/argocd/git.go
@@ -350,72 +350,74 @@ func writeKustomization(app *v1alpha1.Application, wbc *WriteBackConfig, gitC gi
 // to the file. This is the same behavior as kyaml.UpdateFile, but it preserves the original order of YAML fields
 // and indentation of YAML sequences to minimize git diffs.
 func updateKustomizeFile(filter kyaml.Filter, path string) (error, bool) {
-	// Read the yaml
-	y, err := kyaml.ReadFile(path)
-	if err != nil {
-		return err, false
-	}
-
-	originalData, err := y.String()
-	if err != nil {
-		return err, false
-	}
-
 	// Open the input file for read
-	in, err := os.Open(path)
+	yRaw, err := os.ReadFile(path)
 	if err != nil {
 		return err, false
 	}
-	defer in.Close()
+
+	// Read the yaml document from bytes
+	originalYSlice, err := kio.FromBytes(yRaw)
+	if err != nil {
+		return err, false
+	}
+
+	// Check that we are dealing with a single document
+	if len(originalYSlice) != 1 {
+		return errors.New("target parameter file should contain a single YAML document"), false
+	}
+	originalY := originalYSlice[0]
+
+	// Get the (parsed) original document
+	originalData, err := originalY.String()
+	if err != nil {
+		return err, false
+	}
 
 	// Create a reader, preserving indentation of sequences
 	var out bytes.Buffer
 	rw := &kio.ByteReadWriter{
-		Reader:            in,
+		Reader:            bytes.NewBuffer(yRaw),
 		Writer:            &out,
 		PreserveSeqIndent: true,
 	}
 
 	// Read input file
-	yCpySlice, err := rw.Read()
+	newYSlice, err := rw.Read()
 	if err != nil {
 		return err, false
 	}
-
-	// We expect a single yaml
-	if len(yCpySlice) != 1 {
-		return errors.New("target parameter file should contain a single YAML document"), false
-	}
-	yCpy := yCpySlice[0]
+	// We can safely assume we have a single document from the previous check
+	newY := newYSlice[0]
 
 	// Update the yaml
-	if err := yCpy.PipeE(filter); err != nil {
+	if err := newY.PipeE(filter); err != nil {
 		return err, false
 	}
 
 	// Preserve the original order of fields
-	if err := order.SyncOrder(y, yCpy); err != nil {
+	if err := order.SyncOrder(originalY, newY); err != nil {
 		return err, false
 	}
 
 	// Write the yaml document to the output buffer
-	if err = rw.Write([]*kyaml.RNode{yCpy}); err != nil {
+	if err = rw.Write([]*kyaml.RNode{newY}); err != nil {
 		return err, false
 	}
 
 	// yCpy contains metadata used by kio to preserve sequence indentation,
 	// hence we need to parse the output buffer instead
-	parsed, err := kyaml.Parse(out.String())
+	newParsedY, err := kyaml.Parse(out.String())
 	if err != nil {
 		return err, false
 	}
-	override, err := parsed.String()
+	newData, err := newParsedY.String()
 	if err != nil {
 		return err, false
 	}
 
 	// Diff the updated document with the original
-	if originalData == override {
+	if originalData == newData {
 		log.Debugf("target parameter file and marshaled data are the same, skipping commit.")
 		return nil, true
 	}

--- a/pkg/argocd/git_test.go
+++ b/pkg/argocd/git_test.go
@@ -271,6 +271,18 @@ func Test_updateKustomizeFile(t *testing.T) {
 			filter: filter,
 		},
 		{
+			name: "indented",
+			content: `images:
+  - name: foo
+    digest: sha12345
+`,
+			wantContent: `images:
+  - name: foo
+    digest: sha23456
+`,
+			filter: filter,
+		},
+		{
 			name: "no-change",
 			content: `images:
 - name: foo


### PR DESCRIPTION
Hi,

I've created a PR that should solve #501. First time I (really) contribute to an open-source project, so feel free to criticize anything I may have done wrong!

I have based this PR on the v0.15.2 branch instead of master as master was failing for me (throwing panics at runtime in my cluster). Let me know whether this is fine.

I've basically changed the way the `updateKustomizeFile` function in `pkg/argocd/git.go` works. It now uses `kio.ByteReadWriter`, which allows to preserve sequence indentation. 
I also had to slightly modify how the comparison is done: `kio` adds some `metadata.annotations` to the yaml document, hence my approach was to get the output from the writer (which clears those annotations), and then parse it again with `kyaml`, hence ensuring that indentation is the same across the two files.

I'm also planning of sending a PR to `kyaml` to add a boolean that optionally retains the initial triple dashes of a document, if present (though I have yet to dig on `kyaml` code). To me, that would be a very nice achievement, as git diffs would become truly the smallest they can be!

I hope that my explanation (and code) make sense!

EDIT: added a test case for the change