### PR TITLE
Replace common constant references

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/argoproj/pkg v0.13.7-0.20230627120311-a4dd357b057e
 	github.com/bmatcuk/doublestar/v4 v4.7.1
 	github.com/bradleyfalzon/ghinstallation/v2 v2.12.0
+	github.com/distribution/distribution/v3 v3.0.0-20230722181636-7b502560cad4
 	github.com/go-git/go-git/v5 v5.13.0
 	github.com/google/uuid v1.6.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
@@ -52,7 +53,6 @@ require (
 	github.com/cyphar/filepath-securejoin v0.3.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
-	github.com/distribution/distribution/v3 v3.0.0-20230722181636-7b502560cad4 // indirect
 	github.com/distribution/reference v0.5.0 // indirect
 	github.com/dlclark/regexp2 v1.11.4 // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect
@@ -174,7 +174,7 @@ require (
 
 replace (
 	// Uncomment for local testing
-	github.com/argoproj-labs/argocd-image-updater/registry-scanner => ./registry-scanner/
+	// github.com/argoproj-labs/argocd-image-updater/registry-scanner => ./registry-scanner/
 	github.com/golang/protobuf => github.com/golang/protobuf v1.5.4
 
 	k8s.io/api => k8s.io/api v0.31.0

--- a/go.mod
+++ b/go.mod
@@ -174,7 +174,7 @@ require (
 
 replace (
 	// Uncomment for local testing
-	// github.com/argoproj-labs/argocd-image-updater/registry-scanner => ./registry-scanner/
+	github.com/argoproj-labs/argocd-image-updater/registry-scanner => ./registry-scanner/
 	github.com/golang/protobuf => github.com/golang/protobuf v1.5.4
 
 	k8s.io/api => k8s.io/api v0.31.0

--- a/go.mod
+++ b/go.mod
@@ -5,13 +5,12 @@ go 1.22.0
 toolchain go1.23.0
 
 require (
-	github.com/argoproj-labs/argocd-image-updater/registry-scanner v0.0.0-20250110211602-b1555062f8fc
+	github.com/argoproj-labs/argocd-image-updater/registry-scanner v0.0.0-20250114144021-10a01f381aa7
 	github.com/argoproj/argo-cd/v2 v2.13.2
 	github.com/argoproj/gitops-engine v0.7.1-0.20240905010810-bd7681ae3f8b
 	github.com/argoproj/pkg v0.13.7-0.20230627120311-a4dd357b057e
 	github.com/bmatcuk/doublestar/v4 v4.7.1
 	github.com/bradleyfalzon/ghinstallation/v2 v2.12.0
-	github.com/distribution/distribution/v3 v3.0.0-20230722181636-7b502560cad4
 	github.com/go-git/go-git/v5 v5.13.0
 	github.com/google/uuid v1.6.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
@@ -53,6 +52,7 @@ require (
 	github.com/cyphar/filepath-securejoin v0.3.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/distribution/distribution/v3 v3.0.0-20230722181636-7b502560cad4 // indirect
 	github.com/distribution/reference v0.5.0 // indirect
 	github.com/dlclark/regexp2 v1.11.4 // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/alicebob/miniredis/v2 v2.33.0/go.mod h1:MhP4a3EU7aENRi9aO+tHfTBZicLqQ
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/argoproj-labs/argocd-image-updater/registry-scanner v0.0.0-20250110211602-b1555062f8fc h1:c5AQRytI+RfOIgkes7WAUKywY2A5s00HU7++SsjaIew=
-github.com/argoproj-labs/argocd-image-updater/registry-scanner v0.0.0-20250110211602-b1555062f8fc/go.mod h1:gTR08JBkPgrrEJ06a5J6H97EWllbgCNs2nbDSPMKHDo=
+github.com/argoproj-labs/argocd-image-updater/registry-scanner v0.0.0-20250114144021-10a01f381aa7 h1:5sujDhwNOHW3X3WMzfamC4e9H52z2LboabQ+WLvDQ14=
+github.com/argoproj-labs/argocd-image-updater/registry-scanner v0.0.0-20250114144021-10a01f381aa7/go.mod h1:gTR08JBkPgrrEJ06a5J6H97EWllbgCNs2nbDSPMKHDo=
 github.com/argoproj/argo-cd/v2 v2.13.2 h1:eLar0aAqz7AgJiYncRzkPkqEbIxiXl+pUzOuSi47tA0=
 github.com/argoproj/argo-cd/v2 v2.13.2/go.mod h1:RC23V2744nhZstZVpLCWTQLT2gR0+IXGC3GTBCI6M+I=
 github.com/argoproj/gitops-engine v0.7.1-0.20240905010810-bd7681ae3f8b h1:wOPWJ5MBScQO767WpU55oUJDXObfvPL0EfAYWxogbSw=

--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -11,6 +11,7 @@ import (
 	"github.com/argoproj-labs/argocd-image-updater/pkg/common"
 	"github.com/argoproj-labs/argocd-image-updater/pkg/kube"
 	"github.com/argoproj-labs/argocd-image-updater/pkg/metrics"
+	registryCommon "github.com/argoproj-labs/argocd-image-updater/registry-scanner/pkg/common"
 	"github.com/argoproj-labs/argocd-image-updater/registry-scanner/pkg/env"
 	"github.com/argoproj-labs/argocd-image-updater/registry-scanner/pkg/image"
 	"github.com/argoproj-labs/argocd-image-updater/registry-scanner/pkg/log"
@@ -232,7 +233,7 @@ func parseImageList(annotations map[string]string) *image.ContainerImageList {
 		splits := strings.Split(updateImage, ",")
 		for _, s := range splits {
 			img := image.NewFromIdentifier(strings.TrimSpace(s))
-			if kustomizeImage := img.GetParameterKustomizeImageName(annotations); kustomizeImage != "" {
+			if kustomizeImage := img.GetParameterKustomizeImageName(annotations, common.ImageUpdaterAnnotationPrefix); kustomizeImage != "" {
 				img.KustomizeImage = image.NewFromIdentifier(kustomizeImage)
 			}
 			results = append(results, img)
@@ -314,17 +315,17 @@ func getHelmParamNamesFromAnnotation(annotations map[string]string, img *image.C
 	var annotationName, helmParamName, helmParamVersion string
 
 	// Image spec is a full-qualified specifier, if we have it, we return early
-	if param := img.GetParameterHelmImageSpec(annotations); param != "" {
+	if param := img.GetParameterHelmImageSpec(annotations, common.ImageUpdaterAnnotationPrefix); param != "" {
 		log.Tracef("found annotation %s", annotationName)
 		return strings.TrimSpace(param), ""
 	}
 
-	if param := img.GetParameterHelmImageName(annotations); param != "" {
+	if param := img.GetParameterHelmImageName(annotations, common.ImageUpdaterAnnotationPrefix); param != "" {
 		log.Tracef("found annotation %s", annotationName)
 		helmParamName = param
 	}
 
-	if param := img.GetParameterHelmImageTag(annotations); param != "" {
+	if param := img.GetParameterHelmImageTag(annotations, common.ImageUpdaterAnnotationPrefix); param != "" {
 		log.Tracef("found annotation %s", annotationName)
 		helmParamVersion = param
 	}
@@ -384,16 +385,16 @@ func GetHelmImage(app *v1alpha1.Application, newImage *image.ContainerImage) (st
 
 	var hpImageName, hpImageTag, hpImageSpec string
 
-	hpImageSpec = newImage.GetParameterHelmImageSpec(app.Annotations)
-	hpImageName = newImage.GetParameterHelmImageName(app.Annotations)
-	hpImageTag = newImage.GetParameterHelmImageTag(app.Annotations)
+	hpImageSpec = newImage.GetParameterHelmImageSpec(app.Annotations, common.ImageUpdaterAnnotationPrefix)
+	hpImageName = newImage.GetParameterHelmImageName(app.Annotations, common.ImageUpdaterAnnotationPrefix)
+	hpImageTag = newImage.GetParameterHelmImageTag(app.Annotations, common.ImageUpdaterAnnotationPrefix)
 
 	if hpImageSpec == "" {
 		if hpImageName == "" {
-			hpImageName = common.DefaultHelmImageName
+			hpImageName = registryCommon.DefaultHelmImageName
 		}
 		if hpImageTag == "" {
-			hpImageTag = common.DefaultHelmImageTag
+			hpImageTag = registryCommon.DefaultHelmImageTag
 		}
 	}
 
@@ -434,16 +435,16 @@ func SetHelmImage(app *v1alpha1.Application, newImage *image.ContainerImage) err
 
 	var hpImageName, hpImageTag, hpImageSpec string
 
-	hpImageSpec = newImage.GetParameterHelmImageSpec(app.Annotations)
-	hpImageName = newImage.GetParameterHelmImageName(app.Annotations)
-	hpImageTag = newImage.GetParameterHelmImageTag(app.Annotations)
+	hpImageSpec = newImage.GetParameterHelmImageSpec(app.Annotations, common.ImageUpdaterAnnotationPrefix)
+	hpImageName = newImage.GetParameterHelmImageName(app.Annotations, common.ImageUpdaterAnnotationPrefix)
+	hpImageTag = newImage.GetParameterHelmImageTag(app.Annotations, common.ImageUpdaterAnnotationPrefix)
 
 	if hpImageSpec == "" {
 		if hpImageName == "" {
-			hpImageName = common.DefaultHelmImageName
+			hpImageName = registryCommon.DefaultHelmImageName
 		}
 		if hpImageTag == "" {
-			hpImageTag = common.DefaultHelmImageTag
+			hpImageTag = registryCommon.DefaultHelmImageTag
 		}
 	}
 
@@ -494,7 +495,7 @@ func GetKustomizeImage(app *v1alpha1.Application, newImage *image.ContainerImage
 		return "", fmt.Errorf("cannot set Kustomize image on non-Kustomize application")
 	}
 
-	ksImageName := newImage.GetParameterKustomizeImageName(app.Annotations)
+	ksImageName := newImage.GetParameterKustomizeImageName(app.Annotations, common.ImageUpdaterAnnotationPrefix)
 
 	appSource := getApplicationSource(app)
 
@@ -524,7 +525,7 @@ func SetKustomizeImage(app *v1alpha1.Application, newImage *image.ContainerImage
 	}
 
 	var ksImageParam string
-	ksImageName := newImage.GetParameterKustomizeImageName(app.Annotations)
+	ksImageName := newImage.GetParameterKustomizeImageName(app.Annotations, common.ImageUpdaterAnnotationPrefix)
 	if ksImageName != "" {
 		ksImageParam = fmt.Sprintf("%s=%s", ksImageName, newImage.GetFullNameWithTag())
 	} else {
@@ -568,7 +569,7 @@ func GetImagesFromApplication(app *v1alpha1.Application) image.ContainerImageLis
 	// Check the image list for images with a force-update annotation, and add them if they are not already present.
 	annotations := app.Annotations
 	for _, img := range *parseImageList(annotations) {
-		if img.HasForceUpdateOptionAnnotation(annotations) {
+		if img.HasForceUpdateOptionAnnotation(annotations, common.ImageUpdaterAnnotationPrefix) {
 			img.ImageTag = nil // the tag from the image list will be a version constraint, which isn't a valid tag
 			images = append(images, img)
 		}

--- a/pkg/argocd/argocd_test.go
+++ b/pkg/argocd/argocd_test.go
@@ -8,10 +8,9 @@ import (
 
 	"github.com/argoproj-labs/argocd-image-updater/pkg/common"
 	"github.com/argoproj-labs/argocd-image-updater/pkg/kube"
-
+	registryCommon "github.com/argoproj-labs/argocd-image-updater/registry-scanner/pkg/common"
 	"github.com/argoproj-labs/argocd-image-updater/registry-scanner/pkg/image"
 	registryKube "github.com/argoproj-labs/argocd-image-updater/registry-scanner/pkg/kube"
-
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/pkg/client/clientset/versioned/fake"
@@ -66,8 +65,8 @@ func Test_GetImagesFromApplication(t *testing.T) {
 				Name:      "test-app",
 				Namespace: "argocd",
 				Annotations: map[string]string{
-					fmt.Sprintf(common.ForceUpdateOptionAnnotation, "nginx"): "true",
-					common.ImageUpdaterAnnotation:                            "nginx=nginx",
+					fmt.Sprintf(registryCommon.Prefixed(common.ImageUpdaterAnnotationPrefix, registryCommon.ForceUpdateOptionAnnotationSuffix), "nginx"): "true",
+					common.ImageUpdaterAnnotation: "nginx=nginx",
 				},
 			},
 			Spec: v1alpha1.ApplicationSpec{},
@@ -558,8 +557,8 @@ func Test_FilterApplicationsForUpdate(t *testing.T) {
 func Test_GetHelmParamAnnotations(t *testing.T) {
 	t.Run("Get parameter names without symbolic names", func(t *testing.T) {
 		annotations := map[string]string{
-			fmt.Sprintf(common.HelmParamImageSpecAnnotation, "myimg"): "image.blub",
-			fmt.Sprintf(common.HelmParamImageTagAnnotation, "myimg"):  "image.blab",
+			fmt.Sprintf(registryCommon.Prefixed(common.ImageUpdaterAnnotationPrefix, registryCommon.HelmParamImageSpecAnnotationSuffix), "myimg"): "image.blub",
+			fmt.Sprintf(registryCommon.Prefixed(common.ImageUpdaterAnnotationPrefix, registryCommon.HelmParamImageTagAnnotationSuffix), "myimg"):  "image.blab",
 		}
 		name, tag := getHelmParamNamesFromAnnotation(annotations, &image.ContainerImage{
 			ImageAlias: "",
@@ -570,8 +569,8 @@ func Test_GetHelmParamAnnotations(t *testing.T) {
 
 	t.Run("Find existing image spec annotation", func(t *testing.T) {
 		annotations := map[string]string{
-			fmt.Sprintf(common.HelmParamImageSpecAnnotation, "myimg"): "image.path",
-			fmt.Sprintf(common.HelmParamImageTagAnnotation, "myimg"):  "image.tag",
+			fmt.Sprintf(registryCommon.Prefixed(common.ImageUpdaterAnnotationPrefix, registryCommon.HelmParamImageSpecAnnotationSuffix), "myimg"): "image.path",
+			fmt.Sprintf(registryCommon.Prefixed(common.ImageUpdaterAnnotationPrefix, registryCommon.HelmParamImageTagAnnotationSuffix), "myimg"):  "image.tag",
 		}
 		name, tag := getHelmParamNamesFromAnnotation(annotations, &image.ContainerImage{
 			ImageAlias: "myimg",
@@ -582,8 +581,8 @@ func Test_GetHelmParamAnnotations(t *testing.T) {
 
 	t.Run("Find existing image name and image tag annotations", func(t *testing.T) {
 		annotations := map[string]string{
-			fmt.Sprintf(common.HelmParamImageNameAnnotation, "myimg"): "image.name",
-			fmt.Sprintf(common.HelmParamImageTagAnnotation, "myimg"):  "image.tag",
+			fmt.Sprintf(registryCommon.Prefixed(common.ImageUpdaterAnnotationPrefix, registryCommon.HelmParamImageNameAnnotationSuffix), "myimg"): "image.name",
+			fmt.Sprintf(registryCommon.Prefixed(common.ImageUpdaterAnnotationPrefix, registryCommon.HelmParamImageTagAnnotationSuffix), "myimg"):  "image.tag",
 		}
 		name, tag := getHelmParamNamesFromAnnotation(annotations, &image.ContainerImage{
 			ImageAlias: "myimg",
@@ -594,8 +593,8 @@ func Test_GetHelmParamAnnotations(t *testing.T) {
 
 	t.Run("Find non-existing image name and image tag annotations", func(t *testing.T) {
 		annotations := map[string]string{
-			fmt.Sprintf(common.HelmParamImageNameAnnotation, "otherimg"): "image.name",
-			fmt.Sprintf(common.HelmParamImageTagAnnotation, "otherimg"):  "image.tag",
+			fmt.Sprintf(registryCommon.Prefixed(common.ImageUpdaterAnnotationPrefix, registryCommon.HelmParamImageNameAnnotationSuffix), "otherimg"): "image.name",
+			fmt.Sprintf(registryCommon.Prefixed(common.ImageUpdaterAnnotationPrefix, registryCommon.HelmParamImageTagAnnotationSuffix), "otherimg"):  "image.tag",
 		}
 		name, tag := getHelmParamNamesFromAnnotation(annotations, &image.ContainerImage{
 			ImageAlias: "myimg",
@@ -606,7 +605,7 @@ func Test_GetHelmParamAnnotations(t *testing.T) {
 
 	t.Run("Find existing image tag annotations", func(t *testing.T) {
 		annotations := map[string]string{
-			fmt.Sprintf(common.HelmParamImageTagAnnotation, "myimg"): "image.tag",
+			fmt.Sprintf(registryCommon.Prefixed(common.ImageUpdaterAnnotationPrefix, registryCommon.HelmParamImageTagAnnotationSuffix), "myimg"): "image.tag",
 		}
 		name, tag := getHelmParamNamesFromAnnotation(annotations, &image.ContainerImage{
 			ImageAlias: "myimg",
@@ -795,7 +794,7 @@ func Test_SetKustomizeImage(t *testing.T) {
 				Name:      "test-app",
 				Namespace: "testns",
 				Annotations: map[string]string{
-					fmt.Sprintf(common.KustomizeApplicationNameAnnotation, "foobar"): "foobar",
+					fmt.Sprintf(registryCommon.Prefixed(common.ImageUpdaterAnnotationPrefix, registryCommon.KustomizeApplicationNameAnnotationSuffix), "foobar"): "foobar",
 				},
 			},
 			Spec: v1alpha1.ApplicationSpec{
@@ -833,8 +832,8 @@ func Test_SetHelmImage(t *testing.T) {
 				Name:      "test-app",
 				Namespace: "testns",
 				Annotations: map[string]string{
-					fmt.Sprintf(common.HelmParamImageNameAnnotation, "foobar"): "image.name",
-					fmt.Sprintf(common.HelmParamImageTagAnnotation, "foobar"):  "image.tag",
+					fmt.Sprintf(registryCommon.Prefixed(common.ImageUpdaterAnnotationPrefix, registryCommon.HelmParamImageNameAnnotationSuffix), "foobar"): "image.name",
+					fmt.Sprintf(registryCommon.Prefixed(common.ImageUpdaterAnnotationPrefix, registryCommon.HelmParamImageTagAnnotationSuffix), "foobar"):  "image.tag",
 				},
 			},
 			Spec: v1alpha1.ApplicationSpec{
@@ -887,8 +886,8 @@ func Test_SetHelmImage(t *testing.T) {
 				Name:      "test-app",
 				Namespace: "testns",
 				Annotations: map[string]string{
-					fmt.Sprintf(common.HelmParamImageNameAnnotation, "foobar"): "image.name",
-					fmt.Sprintf(common.HelmParamImageTagAnnotation, "foobar"):  "image.tag",
+					fmt.Sprintf(registryCommon.Prefixed(common.ImageUpdaterAnnotationPrefix, registryCommon.HelmParamImageNameAnnotationSuffix), "foobar"): "image.name",
+					fmt.Sprintf(registryCommon.Prefixed(common.ImageUpdaterAnnotationPrefix, registryCommon.HelmParamImageTagAnnotationSuffix), "foobar"):  "image.tag",
 				},
 			},
 			Spec: v1alpha1.ApplicationSpec{
@@ -930,8 +929,8 @@ func Test_SetHelmImage(t *testing.T) {
 				Name:      "test-app",
 				Namespace: "testns",
 				Annotations: map[string]string{
-					fmt.Sprintf(common.HelmParamImageNameAnnotation, "foobar"): "foobar.image.name",
-					fmt.Sprintf(common.HelmParamImageTagAnnotation, "foobar"):  "foobar.image.tag",
+					fmt.Sprintf(registryCommon.Prefixed(common.ImageUpdaterAnnotationPrefix, registryCommon.HelmParamImageNameAnnotationSuffix), "foobar"): "foobar.image.name",
+					fmt.Sprintf(registryCommon.Prefixed(common.ImageUpdaterAnnotationPrefix, registryCommon.HelmParamImageTagAnnotationSuffix), "foobar"):  "foobar.image.tag",
 				},
 			},
 			Spec: v1alpha1.ApplicationSpec{
@@ -984,8 +983,8 @@ func Test_SetHelmImage(t *testing.T) {
 				Name:      "test-app",
 				Namespace: "testns",
 				Annotations: map[string]string{
-					fmt.Sprintf(common.HelmParamImageNameAnnotation, "foobar"): "foobar.image.name",
-					fmt.Sprintf(common.HelmParamImageTagAnnotation, "foobar"):  "foobar.image.tag",
+					fmt.Sprintf(registryCommon.Prefixed(common.ImageUpdaterAnnotationPrefix, registryCommon.HelmParamImageNameAnnotationSuffix), "foobar"): "foobar.image.name",
+					fmt.Sprintf(registryCommon.Prefixed(common.ImageUpdaterAnnotationPrefix, registryCommon.HelmParamImageTagAnnotationSuffix), "foobar"):  "foobar.image.tag",
 				},
 			},
 			Spec: v1alpha1.ApplicationSpec{
@@ -1227,8 +1226,8 @@ func Test_parseImageList(t *testing.T) {
 	})
 	t.Run("Test kustomize override", func(t *testing.T) {
 		imgs := *parseImageList(map[string]string{
-			common.ImageUpdaterAnnotation:                                 "foo=bar",
-			fmt.Sprintf(common.KustomizeApplicationNameAnnotation, "foo"): "baz",
+			common.ImageUpdaterAnnotation: "foo=bar",
+			fmt.Sprintf(registryCommon.Prefixed(common.ImageUpdaterAnnotationPrefix, registryCommon.KustomizeApplicationNameAnnotationSuffix), "foo"): "baz",
 		})
 		assert.Equal(t, "bar", imgs[0].ImageName)
 		assert.Equal(t, "baz", imgs[0].KustomizeImage.ImageName)

--- a/pkg/argocd/argocd_test.go
+++ b/pkg/argocd/argocd_test.go
@@ -8,9 +8,11 @@ import (
 
 	"github.com/argoproj-labs/argocd-image-updater/pkg/common"
 	"github.com/argoproj-labs/argocd-image-updater/pkg/kube"
+
 	registryCommon "github.com/argoproj-labs/argocd-image-updater/registry-scanner/pkg/common"
 	"github.com/argoproj-labs/argocd-image-updater/registry-scanner/pkg/image"
 	registryKube "github.com/argoproj-labs/argocd-image-updater/registry-scanner/pkg/kube"
+
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/pkg/client/clientset/versioned/fake"

--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -206,11 +206,11 @@ func UpdateApplication(updateConf *UpdateConfiguration, state *SyncIterationStat
 			imgCtx.Debugf("Using no version constraint when looking for a new tag")
 		}
 
-		vc.Strategy = applicationImage.GetParameterUpdateStrategy(updateConf.UpdateApp.Application.Annotations)
-		vc.MatchFunc, vc.MatchArgs = applicationImage.GetParameterMatch(updateConf.UpdateApp.Application.Annotations)
-		vc.IgnoreList = applicationImage.GetParameterIgnoreTags(updateConf.UpdateApp.Application.Annotations)
+		vc.Strategy = applicationImage.GetParameterUpdateStrategy(updateConf.UpdateApp.Application.Annotations, common.ImageUpdaterAnnotationPrefix)
+		vc.MatchFunc, vc.MatchArgs = applicationImage.GetParameterMatch(updateConf.UpdateApp.Application.Annotations, common.ImageUpdaterAnnotationPrefix)
+		vc.IgnoreList = applicationImage.GetParameterIgnoreTags(updateConf.UpdateApp.Application.Annotations, common.ImageUpdaterAnnotationPrefix)
 		vc.Options = applicationImage.
-			GetPlatformOptions(updateConf.UpdateApp.Application.Annotations, updateConf.IgnorePlatforms).
+			GetPlatformOptions(updateConf.UpdateApp.Application.Annotations, updateConf.IgnorePlatforms, common.ImageUpdaterAnnotationPrefix).
 			WithMetadata(vc.Strategy.NeedsMetadata()).
 			WithLogger(imgCtx.AddField("application", app))
 
@@ -228,7 +228,7 @@ func UpdateApplication(updateConf *UpdateConfiguration, state *SyncIterationStat
 			continue
 		}
 
-		imgCredSrc := applicationImage.GetParameterPullSecret(updateConf.UpdateApp.Application.Annotations)
+		imgCredSrc := applicationImage.GetParameterPullSecret(updateConf.UpdateApp.Application.Annotations, common.ImageUpdaterAnnotationPrefix)
 		var creds *image.Credential = &image.Credential{}
 		if imgCredSrc != nil {
 			creds, err = imgCredSrc.FetchCredentials(rep.RegistryAPI, updateConf.KubeClient.KubeClient)
@@ -478,7 +478,7 @@ func marshalParamsOverride(app *v1alpha1.Application, originalData []byte) ([]by
 				// for image-spec annotation, helmAnnotationParamName holds image-spec annotation value,
 				// and helmAnnotationParamVersion is empty
 				if helmAnnotationParamVersion == "" {
-					if c.GetParameterHelmImageSpec(app.Annotations) == "" {
+					if c.GetParameterHelmImageSpec(app.Annotations, common.ImageUpdaterAnnotationPrefix) == "" {
 						// not a full image-spec, so image-tag is required
 						return nil, fmt.Errorf("could not find an image-tag annotation for image %s", c.ImageName)
 					}

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -16,7 +16,7 @@ import (
 	argomock "github.com/argoproj-labs/argocd-image-updater/pkg/argocd/mocks"
 	"github.com/argoproj-labs/argocd-image-updater/pkg/common"
 	"github.com/argoproj-labs/argocd-image-updater/pkg/kube"
-
+	registryCommon "github.com/argoproj-labs/argocd-image-updater/registry-scanner/pkg/common"
 	"github.com/argoproj-labs/argocd-image-updater/registry-scanner/pkg/image"
 	registryKube "github.com/argoproj-labs/argocd-image-updater/registry-scanner/pkg/kube"
 	"github.com/argoproj-labs/argocd-image-updater/registry-scanner/pkg/registry"
@@ -512,7 +512,7 @@ func Test_UpdateApplication(t *testing.T) {
 					Name:      "guestbook",
 					Namespace: "guestbook",
 					Annotations: map[string]string{
-						fmt.Sprintf(common.PullSecretAnnotation, "dummy"): "secret:foo/bar#creds",
+						fmt.Sprintf(registryCommon.Prefixed(common.ImageUpdaterAnnotationPrefix, registryCommon.PullSecretAnnotationSuffix), "dummy"): "secret:foo/bar#creds",
 					},
 				},
 				Spec: v1alpha1.ApplicationSpec{
@@ -683,8 +683,8 @@ func Test_UpdateApplication(t *testing.T) {
 			},
 		}
 		annotations := map[string]string{
-			common.ImageUpdaterAnnotation:                                    "foobar=gcr.io/jannfis/foobar:>=1.0.1",
-			fmt.Sprintf(common.KustomizeApplicationNameAnnotation, "foobar"): "jannfis/foobar",
+			common.ImageUpdaterAnnotation: "foobar=gcr.io/jannfis/foobar:>=1.0.1",
+			fmt.Sprintf(registryCommon.Prefixed(common.ImageUpdaterAnnotationPrefix, registryCommon.KustomizeApplicationNameAnnotationSuffix), "foobar"): "jannfis/foobar",
 		}
 		appImages := &ApplicationImages{
 			Application: v1alpha1.Application{
@@ -744,8 +744,8 @@ func Test_UpdateApplication(t *testing.T) {
 			},
 		}
 		annotations := map[string]string{
-			common.ImageUpdaterAnnotation:                                    "foobar=gcr.io/jannfis/foobar:>=1.0.1",
-			fmt.Sprintf(common.KustomizeApplicationNameAnnotation, "foobar"): "jannfis/foobar",
+			common.ImageUpdaterAnnotation: "foobar=gcr.io/jannfis/foobar:>=1.0.1",
+			fmt.Sprintf(registryCommon.Prefixed(common.ImageUpdaterAnnotationPrefix, registryCommon.KustomizeApplicationNameAnnotationSuffix), "foobar"): "jannfis/foobar",
 		}
 		appImages := &ApplicationImages{
 			Application: v1alpha1.Application{
@@ -826,8 +826,8 @@ func Test_UpdateApplication(t *testing.T) {
 					Name:      "guestbook",
 					Namespace: "guestbook",
 					Annotations: map[string]string{
-						fmt.Sprintf(common.AllowTagsOptionAnnotation, "dummy"): "regexp:^foobar$",
-						fmt.Sprintf(common.UpdateStrategyAnnotation, "dummy"):  "name",
+						fmt.Sprintf(registryCommon.Prefixed(common.ImageUpdaterAnnotationPrefix, registryCommon.AllowTagsOptionAnnotationSuffix), "dummy"): "regexp:^foobar$",
+						fmt.Sprintf(registryCommon.Prefixed(common.ImageUpdaterAnnotationPrefix, registryCommon.UpdateStrategyAnnotationSuffix), "dummy"):  "name",
 					},
 				},
 				Spec: v1alpha1.ApplicationSpec{
@@ -904,8 +904,8 @@ func Test_UpdateApplication(t *testing.T) {
 					Name:      "guestbook",
 					Namespace: "guestbook",
 					Annotations: map[string]string{
-						fmt.Sprintf(common.IgnoreTagsOptionAnnotation, "dummy"): "*",
-						fmt.Sprintf(common.UpdateStrategyAnnotation, "dummy"):   "name",
+						fmt.Sprintf(registryCommon.Prefixed(common.ImageUpdaterAnnotationPrefix, registryCommon.IgnoreTagsOptionAnnotationSuffix), "dummy"): "*",
+						fmt.Sprintf(registryCommon.UpdateStrategyAnnotationSuffix, "dummy"):                                                                 "name",
 					},
 				},
 				Spec: v1alpha1.ApplicationSpec{

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -8,44 +8,6 @@ const ImageUpdaterAnnotationPrefix = "argocd-image-updater.argoproj.io"
 // allowed for updates.
 const ImageUpdaterAnnotation = ImageUpdaterAnnotationPrefix + "/image-list"
 
-// Defaults for Helm parameter names
-const (
-	DefaultHelmImageName = "image.name"
-	DefaultHelmImageTag  = "image.tag"
-)
-
-// Helm related annotations
-const (
-	HelmParamImageNameAnnotation = ImageUpdaterAnnotationPrefix + "/%s.helm.image-name"
-	HelmParamImageTagAnnotation  = ImageUpdaterAnnotationPrefix + "/%s.helm.image-tag"
-	HelmParamImageSpecAnnotation = ImageUpdaterAnnotationPrefix + "/%s.helm.image-spec"
-)
-
-// Kustomize related annotations
-const (
-	KustomizeApplicationNameAnnotation = ImageUpdaterAnnotationPrefix + "/%s.kustomize.image-name"
-)
-
-// Image specific configuration annotations
-const (
-	OldMatchOptionAnnotation    = ImageUpdaterAnnotationPrefix + "/%s.tag-match" // Deprecated and will be removed
-	AllowTagsOptionAnnotation   = ImageUpdaterAnnotationPrefix + "/%s.allow-tags"
-	IgnoreTagsOptionAnnotation  = ImageUpdaterAnnotationPrefix + "/%s.ignore-tags"
-	ForceUpdateOptionAnnotation = ImageUpdaterAnnotationPrefix + "/%s.force-update"
-	UpdateStrategyAnnotation    = ImageUpdaterAnnotationPrefix + "/%s.update-strategy"
-	PullSecretAnnotation        = ImageUpdaterAnnotationPrefix + "/%s.pull-secret"
-	PlatformsAnnotation         = ImageUpdaterAnnotationPrefix + "/%s.platforms"
-)
-
-// Application-wide update strategy related annotations
-const (
-	ApplicationWideAllowTagsOptionAnnotation   = ImageUpdaterAnnotationPrefix + "/allow-tags"
-	ApplicationWideIgnoreTagsOptionAnnotation  = ImageUpdaterAnnotationPrefix + "/ignore-tags"
-	ApplicationWideForceUpdateOptionAnnotation = ImageUpdaterAnnotationPrefix + "/force-update"
-	ApplicationWideUpdateStrategyAnnotation    = ImageUpdaterAnnotationPrefix + "/update-strategy"
-	ApplicationWidePullSecretAnnotation        = ImageUpdaterAnnotationPrefix + "/pull-secret"
-)
-
 // Application update configuration related annotations
 const (
 	WriteBackMethodAnnotation = ImageUpdaterAnnotationPrefix + "/write-back-method"


### PR DESCRIPTION
The common helper was created in https://github.com/argoproj-labs/argocd-image-updater/pull/1010. This PR replaces the common constants with the prefix specific to argocd-image-updater.