### PR TITLE
fix: Prevent segfault with empty kustomization

### DIFF
--- a/pkg/argocd/git.go
+++ b/pkg/argocd/git.go
@@ -337,8 +337,18 @@ func writeKustomization(app *v1alpha1.Application, wbc *WriteBackConfig, gitC gi
 	if kustFile == "" {
 		return fmt.Errorf("could not find kustomization in %s", base), false
 	}
+	source := getApplicationSource(app)
+	if source == nil {
+		return fmt.Errorf("failed to find source for kustomization in %s", base), false
+	}
 
-	filterFunc, err := imagesFilter(getApplicationSource(app).Kustomize.Images)
+	kustomize := source.Kustomize
+	images := v1alpha1.KustomizeImages{}
+	if kustomize != nil {
+		images = kustomize.Images
+	}
+
+	filterFunc, err := imagesFilter(images)
 	if err != nil {
 		return err, false
 	}


### PR DESCRIPTION
I'm not entirely sure when this happens, but the kustomize can be nil. Accessing Images then leads to a nil-deref.
With this approach, the updater defaults to empty images when it cannot get the real ones.