### PR TITLE
feat: preserve formatting and comments when updating Helm values file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.12.0
 	github.com/distribution/distribution/v3 v3.0.0-20230722181636-7b502560cad4
 	github.com/go-git/go-git/v5 v5.13.2
+	github.com/goccy/go-yaml v1.15.22
 	github.com/google/uuid v1.6.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/prometheus/client_golang v1.20.5
@@ -26,7 +27,6 @@ require (
 	golang.org/x/oauth2 v0.25.0
 	golang.org/x/sync v0.10.0
 	google.golang.org/grpc v1.70.0
-	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.31.0
 	k8s.io/apimachinery v0.31.0
 	k8s.io/client-go v0.31.0
@@ -154,6 +154,7 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.31.2 // indirect
 	k8s.io/apiserver v0.31.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -192,6 +192,8 @@ github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJA
 github.com/gobwas/httphead v0.1.0/go.mod h1:O/RXo79gxV8G+RqlR/otEwx4Q36zl9rqC5u12GKvMCM=
 github.com/gobwas/pool v0.2.1/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
 github.com/gobwas/ws v1.2.1/go.mod h1:hRKAFb8wOxFROYNsT1bqfWnhX+b5MFeJM9r2ZSwg/KY=
+github.com/goccy/go-yaml v1.15.22 h1:iQI1hvCoiYYiVFq76P4AI8ImgDOfgiyKnl/AWjK8/gA=
+github.com/goccy/go-yaml v1.15.22/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/gogits/go-gogs-client v0.0.0-20200905025246-8bb8a50cb355 h1:HTVNOdTWO/gHYeFnr/HwpYwY6tgMcYd+Rgf1XrHnORY=
 github.com/gogits/go-gogs-client v0.0.0-20200905025246-8bb8a50cb355/go.mod h1:cY2AIrMgHm6oOHmR7jY+9TtjzSjQ3iG7tURJG3Y6XH0=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=

--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -336,7 +336,7 @@ func getHelmParamNamesFromAnnotation(annotations map[string]string, img *image.C
 // Get a named helm parameter from a list of parameters
 func getHelmParam(params []v1alpha1.HelmParameter, name string) *v1alpha1.HelmParameter {
 	for _, param := range params {
-		if param.Name == name {
+		if param.Name == strings.Trim(name, "'\"") {
 			return &param
 		}
 	}


### PR DESCRIPTION
## Description

This PR enhances the Helm values file update functionality by preserving the original formatting and comments. Previously, updating the file would overwrite manual formatting and comments, which could be problematic for users who rely on these customizations for clarity and maintenance. By retaining inline comments and specific formatting, this change improves the user experience and reduces potential confusion after automated updates.

Additionally, this update refines how `image-name` and `image-tag` keys are handled:

- By default, key path in `image-name` and `image-tag` creates a **nested structure**. For example:

  ```yaml
  argocd-image-updater.argoproj.io/nginx.helm.image-name: image.name
  argocd-image-updater.argoproj.io/nginx.helm.image-tag: image.tag
  ```

  Produces:

  ```yaml
  image:
    name: app-name
    tag: v1.0.0
  ```

- If a user wants to update Helm values that contain dots, the key path must be quoted (either with double or single quotes):
  ```yaml
  argocd-image-updater.argoproj.io/nginx.helm.image-name: '"image.name"'
  argocd-image-updater.argoproj.io/nginx.helm.image-tag: '"image.tag"'
  ```
  This will correctly produce:
  ```yaml
  image.name: app-name
  image.tag: v1.0.0
  ```

These changes ensure greater flexibility and correctness in handling Helm values updates while maintaining user-defined formatting.