### PR TITLE
feat: add helm release helm param to fix multi helm sources updates

### DIFF
--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -430,8 +430,60 @@ func SetHelmImage(app *v1alpha1.Application, newImage *image.ContainerImage) err
 		return fmt.Errorf("cannot set Helm params on non-Helm application")
 	}
 
-	appName := app.GetName()
-	appNamespace := app.GetNamespace()
+	desiredReleaseName := newImage.GetParameterHelmReleaseName(app.Annotations, common.ImageUpdaterAnnotationPrefix)
+
+	var matchedSource *v1alpha1.ApplicationSource
+	if app.Spec.HasMultipleSources() {
+		for i := range app.Spec.Sources {
+			source := &app.Spec.Sources[i]
+			if source.Helm == nil {
+				continue
+			}
+			if desiredReleaseName != "" {
+				if source.Helm.ReleaseName == desiredReleaseName {
+					matchedSource = source
+					break
+				}
+			}
+		}
+		if matchedSource == nil {
+			if desiredReleaseName != "" {
+				log.WithContext().
+					AddField("application", app.GetName()).
+					Warnf("No matching source found for release name %q", desiredReleaseName)
+				return nil
+			}
+			for i := range app.Spec.Sources {
+				if app.Spec.Sources[i].Helm != nil {
+					matchedSource = &app.Spec.Sources[i]
+					break
+				}
+			}
+		}
+	} else {
+		matchedSource = app.Spec.Source
+	}
+
+	if matchedSource == nil {
+		return fmt.Errorf("no valid Helm source found")
+	}
+
+	if matchedSource.Helm == nil {
+		matchedSource.Helm = &v1alpha1.ApplicationSourceHelm{}
+	}
+
+	if matchedSource.Helm.Parameters == nil {
+		matchedSource.Helm.Parameters = make([]v1alpha1.HelmParameter, 0)
+	}
+
+	actualReleaseName := matchedSource.Helm.ReleaseName
+	if desiredReleaseName != "" && actualReleaseName != "" && desiredReleaseName != actualReleaseName {
+		log.WithContext().
+			AddField("application", app.GetName()).
+			Warnf("Skipping image update for %s: annotation release-name=%q but actual Helm releaseName=%q",
+				newImage.GetFullNameWithTag(), desiredReleaseName, actualReleaseName)
+		return nil
+	}
 
 	var hpImageName, hpImageTag, hpImageSpec string
 
@@ -449,16 +501,13 @@ func SetHelmImage(app *v1alpha1.Application, newImage *image.ContainerImage) err
 	}
 
 	log.WithContext().
-		AddField("application", appName).
+		AddField("application", app.GetName()).
 		AddField("image", newImage.GetFullNameWithoutTag()).
-		AddField("namespace", appNamespace).
+		AddField("release", actualReleaseName).
 		Debugf("target parameters: image-spec=%s image-name=%s, image-tag=%s", hpImageSpec, hpImageName, hpImageTag)
 
 	mergeParams := make([]v1alpha1.HelmParameter, 0)
 
-	// The logic behind this is that image-spec is an override - if this is set,
-	// we simply ignore any image-name and image-tag parameters that might be
-	// there.
 	if hpImageSpec != "" {
 		p := v1alpha1.HelmParameter{Name: hpImageSpec, Value: newImage.GetFullNameWithTag(), ForceString: true}
 		mergeParams = append(mergeParams, p)
@@ -473,17 +522,7 @@ func SetHelmImage(app *v1alpha1.Application, newImage *image.ContainerImage) err
 		}
 	}
 
-	appSource := getApplicationSource(app)
-
-	if appSource.Helm == nil {
-		appSource.Helm = &v1alpha1.ApplicationSourceHelm{}
-	}
-
-	if appSource.Helm.Parameters == nil {
-		appSource.Helm.Parameters = make([]v1alpha1.HelmParameter, 0)
-	}
-
-	appSource.Helm.Parameters = mergeHelmParams(appSource.Helm.Parameters, mergeParams)
+	matchedSource.Helm.Parameters = mergeHelmParams(matchedSource.Helm.Parameters, mergeParams)
 
 	return nil
 }

--- a/registry-scanner/pkg/common/constants.go
+++ b/registry-scanner/pkg/common/constants.go
@@ -10,9 +10,10 @@ const (
 
 // Helm related annotations
 const (
-	HelmParamImageNameAnnotationSuffix = "/%s.helm.image-name"
-	HelmParamImageTagAnnotationSuffix  = "/%s.helm.image-tag"
-	HelmParamImageSpecAnnotationSuffix = "/%s.helm.image-spec"
+	HelmParamImageNameAnnotationSuffix   = "/%s.helm.image-name"
+	HelmParamImageTagAnnotationSuffix    = "/%s.helm.image-tag"
+	HelmParamImageSpecAnnotationSuffix   = "/%s.helm.image-spec"
+	HelmParamReleaseNameAnnotationSuffix = "/%s.helm.release-name"
 )
 
 // Kustomize related annotations

--- a/registry-scanner/pkg/image/options.go
+++ b/registry-scanner/pkg/image/options.go
@@ -43,6 +43,17 @@ func (img *ContainerImage) GetParameterHelmImageSpec(annotations map[string]stri
 	return val
 }
 
+// GetParameterHelmReleaseName gets the value for release-name option for the
+// image from a set of annotations
+func (img *ContainerImage) GetParameterHelmReleaseName(annotations map[string]string, annotationPrefix string) string {
+	key := fmt.Sprintf(common.Prefixed(annotationPrefix, common.HelmParamReleaseNameAnnotationSuffix), img.normalizedSymbolicName())
+	val, ok := annotations[key]
+	if !ok {
+		return ""
+	}
+	return val
+}
+
 // GetParameterKustomizeImageName gets the value for image-spec option for the
 // image from a set of annotations
 func (img *ContainerImage) GetParameterKustomizeImageName(annotations map[string]string, annotationPrefix string) string {


### PR DESCRIPTION
Introduces an implementation idea to fix the bug where multiple helm sources applications doesn't update the correct pod with the correct image.

The approach is to introduce a `argocd-image-updater.argoproj.io/%s.helm.release-name` label to specify which helm release is targeted by an alias.

I'm not sure it's the correct approach, but tested on my side and it seems to be working as expected.

related to #821 