### PR TITLE
docs: fix text overflow issue in admonition block

### DIFF
--- a/docs/install/installation.md
+++ b/docs/install/installation.md
@@ -29,8 +29,7 @@ kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj-labs/argoc
 ```
 
 !!! warning
-    The installation manifests include `ClusterRoleBinding` resources that reference `argocd` namespace. If you are installing Argo CD into a different
-    namespace then make sure to update the namespace reference.
+    The installation manifests include `ClusterRoleBinding` resources that reference `argocd` namespace. If you are installing Argo CD into a different namespace then make sure to update the namespace reference.
 
 !!!note "A word on high availability"
     It is not advised to run multiple replicas of the same Argo CD Image Updater
@@ -75,8 +74,7 @@ kubectl apply -n argocd-image-updater -f https://raw.githubusercontent.com/argop
 ```
 
 !!! warning
-    The installation manifests include `ClusterRoleBinding` resources that reference `argocd` namespace. If you are installing Argo CD into a different
-    namespace then make sure to update the namespace reference.
+    The installation manifests include `ClusterRoleBinding` resources that reference `argocd` namespace. If you are installing Argo CD into a different namespace then make sure to update the namespace reference.
 
 !!!note "A word on high availability"
     It is not advised to run multiple replicas of the same Argo CD Image Updater


### PR DESCRIPTION
This PR fixes a text overflow issue in admonition blocks (e.g., !!! warning) in the documentation.
As an additional note, this issue was not present in the local environment (tested using `make serve-docs`) but appeared on the deployed page.

* https://argocd-image-updater.readthedocs.io/en/stable/install/installation/#apply-the-installation-manifests
* https://argocd-image-updater.readthedocs.io/en/stable/install/installation/#apply-the-manifests

<img width="926" alt="Screenshot 2025-02-18 at 17 34 36" src="https://github.com/user-attachments/assets/2574051a-6903-43b2-8d15-ae169952108e" />

---
I am not sure if the issue is resolved on the deployed page.  
What is the best way to check it?

Looking forward to your review 🙏 
Thank you!
