### PR TITLE
Move to yaml.v3 and preserve comments, multiline strings, anchors in helm values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	golang.org/x/oauth2 v0.25.0
 	golang.org/x/sync v0.11.0
 	google.golang.org/grpc v1.70.0
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.31.0
 	k8s.io/apimachinery v0.31.0
 	k8s.io/client-go v0.31.0
@@ -154,7 +154,7 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/apiextensions-apiserver v0.31.2 // indirect
 	k8s.io/apiserver v0.31.0 // indirect
 	k8s.io/cli-runtime v0.31.0 // indirect

--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -627,6 +627,7 @@ func setHelmValue(currentValues *yaml.Node, key string, value interface{}) error
 				// If we're at the final key, set the value and return
 				if current.Kind == yaml.ScalarNode {
 					current.Value = value.(string)
+					current.Tag = "!!str"
 				} else {
 					return fmt.Errorf("unexpected type %s for key %s", nodeKindString(current.Kind), k)
 				}
@@ -640,10 +641,12 @@ func setHelmValue(currentValues *yaml.Node, key string, value interface{}) error
 					&yaml.Node{
 						Kind:  yaml.ScalarNode,
 						Value: k,
+						Tag:   "!!str",
 					},
 					&yaml.Node{
 						Kind:  yaml.ScalarNode,
 						Value: value.(string),
+						Tag:   "!!str",
 					},
 				)
 				return nil
@@ -652,6 +655,7 @@ func setHelmValue(currentValues *yaml.Node, key string, value interface{}) error
 					&yaml.Node{
 						Kind:  yaml.ScalarNode,
 						Value: k,
+						Tag:   "!!str",
 					},
 					&yaml.Node{
 						Kind:    yaml.MappingNode,

--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // Stores some statistics about the results of a run
@@ -459,7 +459,7 @@ func marshalParamsOverride(app *v1alpha1.Application, originalData []byte) ([]by
 		if strings.HasPrefix(app.Annotations[common.WriteBackTargetAnnotation], common.HelmPrefix) {
 			images := GetImagesAndAliasesFromApplication(app)
 
-			helmNewValues := yaml.MapSlice{}
+			helmNewValues := yaml.Node{}
 			err = yaml.Unmarshal(originalData, &helmNewValues)
 			if err != nil {
 				return nil, err
@@ -505,7 +505,7 @@ func marshalParamsOverride(app *v1alpha1.Application, originalData []byte) ([]by
 				}
 			}
 
-			override, err = yaml.Marshal(helmNewValues)
+			override, err = yaml.Marshal(&helmNewValues)
 		} else {
 			var params helmOverride
 			newParams := helmOverride{
@@ -572,72 +572,94 @@ func mergeKustomizeOverride(t *kustomizeOverride, o *kustomizeOverride) {
 	}
 }
 
-// Check if a key exists in a MapSlice and return its index and value
-func findHelmValuesKey(m yaml.MapSlice, key string) (int, bool) {
-	for i, item := range m {
-		if item.Key == key {
-			return i, true
+// Check if a key exists in a MappingNode and return the index of its value
+func findHelmValuesKey(m *yaml.Node, key string) (int, bool) {
+	for i, item := range m.Content {
+		if i%2 == 0 && item.Value == key {
+			return i + 1, true
 		}
 	}
 	return -1, false
 }
 
+func nodeKindString(k yaml.Kind) string {
+	return map[yaml.Kind]string{
+		yaml.DocumentNode: "DocumentNode",
+		yaml.SequenceNode: "SequenceNode",
+		yaml.MappingNode:  "MappingNode",
+		yaml.ScalarNode:   "ScalarNode",
+		yaml.AliasNode:    "AliasNode",
+	}[k]
+}
+
 // set value of the parameter passed from the annotations.
-func setHelmValue(currentValues *yaml.MapSlice, key string, value interface{}) error {
+func setHelmValue(currentValues *yaml.Node, key string, value interface{}) error {
+	current := currentValues
+
+	// an unmarshalled document has a DocumentNode at the root, but
+	// we navigate from a MappingNode.
+	if current.Kind == yaml.DocumentNode {
+		current = current.Content[0]
+	}
+
+	if current.Kind != yaml.MappingNode {
+		return fmt.Errorf("unexpected type %s for root", nodeKindString(current.Kind))
+	}
+
 	// Check if the full key exists
-	if idx, found := findHelmValuesKey(*currentValues, key); found {
-		(*currentValues)[idx].Value = value
+	if idx, found := findHelmValuesKey(current, key); found {
+		(*current).Content[idx].Value = value.(string)
 		return nil
 	}
 
 	var err error
 	keys := strings.Split(key, ".")
-	current := currentValues
-	var parent *yaml.MapSlice
-	parentIdx := -1
 
 	for i, k := range keys {
-		if idx, found := findHelmValuesKey(*current, k); found {
+		if idx, found := findHelmValuesKey(current, k); found {
+			// Navigate deeper into the map
+			current = (*current).Content[idx]
+			// unpack one level of alias; an alias of an alias is not supported
+			if current.Kind == yaml.AliasNode {
+				current = current.Alias
+			}
 			if i == len(keys)-1 {
 				// If we're at the final key, set the value and return
-				(*current)[idx].Value = value
-				return nil
-			} else {
-				// Navigate deeper into the map
-				if nestedMap, ok := (*current)[idx].Value.(yaml.MapSlice); ok {
-					parent = current
-					parentIdx = idx
-					current = &nestedMap
+				if current.Kind == yaml.ScalarNode {
+					current.Value = value.(string)
 				} else {
-					return fmt.Errorf("unexpected type %T for key %s", (*current)[idx].Value, k)
+					return fmt.Errorf("unexpected type %s for key %s", nodeKindString(current.Kind), k)
 				}
+				return nil
+			} else if current.Kind != yaml.MappingNode {
+				return fmt.Errorf("unexpected type %s for key %s", nodeKindString(current.Kind), k)
 			}
 		} else {
-			newCurrent := yaml.MapSlice{}
-			var newParent yaml.MapSlice
-
 			if i == len(keys)-1 {
-				newParent = append(*current, yaml.MapItem{Key: k, Value: value})
+				current.Content = append(current.Content,
+					&yaml.Node{
+						Kind:  yaml.ScalarNode,
+						Value: k,
+					},
+					&yaml.Node{
+						Kind:  yaml.ScalarNode,
+						Value: value.(string),
+					},
+				)
+				return nil
 			} else {
-				newParent = append(*current, yaml.MapItem{Key: k, Value: newCurrent})
+				current.Content = append(current.Content,
+					&yaml.Node{
+						Kind:  yaml.ScalarNode,
+						Value: k,
+					},
+					&yaml.Node{
+						Kind:    yaml.MappingNode,
+						Content: []*yaml.Node{},
+					},
+				)
+				current = current.Content[len(current.Content)-1]
 			}
-
-			if parent == nil {
-				*currentValues = newParent
-			} else {
-				// if parentIdx has not been set (parent element is also new), set it to the last element
-				if parentIdx == -1 {
-					parentIdx = len(*parent) - 1
-					if parentIdx < 0 {
-						parentIdx = 0
-					}
-				}
-				(*parent)[parentIdx].Value = newParent
-			}
-
-			parent = &newParent
-			current = &newCurrent
-			parentIdx = -1
 		}
 	}
 

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -1179,10 +1179,10 @@ func Test_MarshalParamsOverride(t *testing.T) {
 	t.Run("Valid Kustomize source", func(t *testing.T) {
 		expected := `
 kustomize:
-    images:
-        - baz
-        - foo
-        - bar
+  images:
+    - baz
+    - foo
+    - bar
 `
 		app := v1alpha1.Application{
 			ObjectMeta: v1.ObjectMeta{
@@ -1210,8 +1210,8 @@ kustomize:
 		}
 		originalData := []byte(`
 kustomize:
-    images:
-        - baz
+  images:
+    - baz
 `)
 		yaml, err := marshalParamsOverride(&app, originalData)
 		require.NoError(t, err)
@@ -1222,10 +1222,10 @@ kustomize:
 	t.Run("Merge images param", func(t *testing.T) {
 		expected := `
 kustomize:
-    images:
-        - existing:latest
-        - updated:latest
-        - new
+  images:
+    - existing:latest
+    - updated:latest
+    - new
 `
 		app := v1alpha1.Application{
 			ObjectMeta: v1.ObjectMeta{
@@ -1252,9 +1252,9 @@ kustomize:
 		}
 		originalData := []byte(`
 kustomize:
-    images:
-        - existing:latest
-        - updated:old
+  images:
+    - existing:latest
+    - updated:old
 `)
 		yaml, err := marshalParamsOverride(&app, originalData)
 		require.NoError(t, err)
@@ -1291,16 +1291,16 @@ kustomize:
 	t.Run("Valid Helm source", func(t *testing.T) {
 		expected := `
 helm:
-    parameters:
-        - name: baz
-          value: baz
-          forcestring: false
-        - name: foo
-          value: bar
-          forcestring: true
-        - name: bar
-          value: foo
-          forcestring: true
+  parameters:
+    - name: baz
+      value: baz
+      forcestring: false
+    - name: foo
+      value: bar
+      forcestring: true
+    - name: bar
+      value: foo
+      forcestring: true
 `
 		app := v1alpha1.Application{
 			ObjectMeta: v1.ObjectMeta{
@@ -1351,13 +1351,13 @@ helm:
 	t.Run("Empty originalData error with valid Helm source", func(t *testing.T) {
 		expected := `
 helm:
-    parameters:
-        - name: foo
-          value: bar
-          forcestring: true
-        - name: bar
-          value: foo
-          forcestring: true
+  parameters:
+    - name: foo
+      value: bar
+      forcestring: true
+    - name: bar
+      value: foo
+      forcestring: true
 `
 		app := v1alpha1.Application{
 			ObjectMeta: v1.ObjectMeta{
@@ -1402,13 +1402,13 @@ helm:
 	t.Run("Invalid unmarshal originalData error with valid Helm source", func(t *testing.T) {
 		expected := `
 helm:
-    parameters:
-        - name: foo
-          value: bar
-          forcestring: true
-        - name: bar
-          value: foo
-          forcestring: true
+  parameters:
+    - name: foo
+      value: bar
+      forcestring: true
+    - name: bar
+      value: foo
+      forcestring: true
 `
 		app := v1alpha1.Application{
 			ObjectMeta: v1.ObjectMeta{
@@ -1588,8 +1588,8 @@ replicas: 1
 		expected = `
 test-value1: one
 image:
-    spec:
-        foo: nginx:v1.0.0
+  spec:
+    foo: nginx:v1.0.0
 `
 		yaml, err = marshalParamsOverride(&app, originalData)
 		require.NoError(t, err)
@@ -1690,13 +1690,13 @@ replicas: 1
 		expected = `
 test-value1: one
 nginx:
-    image:
-        tag: v1.0.0
-        name: nginx
+  image:
+    tag: v1.0.0
+    name: nginx
 redis:
-    image:
-        tag: v1.0.0
-        name: redis
+  image:
+    tag: v1.0.0
+    name: redis
 `
 		yaml, err = marshalParamsOverride(&app, originalData)
 		require.NoError(t, err)
@@ -1811,8 +1811,8 @@ replicas: 1
 		expected := `
 test-value1: one
 image:
-    name: nginx
-    tag: v1.0.0
+  name: nginx
+  tag: v1.0.0
 replicas: 1
 `
 
@@ -1860,7 +1860,7 @@ replicas: 1
 		originalData := []byte(`
 test-value1: one
 image:
-    name: nginx
+  name: nginx
 replicas: 1
 `)
 
@@ -1873,8 +1873,8 @@ replicas: 1
 	t.Run("Failed to setValue image parameter version", func(t *testing.T) {
 		expected := `
 image:
-    tag: v1.0.0
-    name: nginx
+  tag: v1.0.0
+  name: nginx
 replicas: 1
 `
 		app := v1alpha1.Application{
@@ -2201,16 +2201,16 @@ func Test_SetHelmValue(t *testing.T) {
 	t.Run("Update existing Key", func(t *testing.T) {
 		expected := `
 image:
-    attributes:
-        name: repo-name
-        tag: v2.0.0
+  attributes:
+    name: repo-name
+    tag: v2.0.0
 `
 
 		inputData := []byte(`
 image:
-    attributes:
-        name: repo-name
-        tag: v1.0.0
+  attributes:
+    name: repo-name
+    tag: v1.0.0
 `)
 		input := yaml.Node{}
 		err := yaml.Unmarshal(inputData, &input)
@@ -2222,7 +2222,7 @@ image:
 		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
 
-		output, err := yaml.Marshal(&input)
+		output, err := marshalWithIndent(&input, 2)
 		require.NoError(t, err)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})
@@ -2241,7 +2241,7 @@ image:
 		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
 
-		output, err := yaml.Marshal(&input)
+		output, err := marshalWithIndent(&input, 2)
 		require.NoError(t, err)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})
@@ -2249,15 +2249,15 @@ image:
 	t.Run("Key not found", func(t *testing.T) {
 		expected := `
 image:
-    attributes:
-        name: repo-name
-        tag: v2.0.0
+  attributes:
+    name: repo-name
+    tag: v2.0.0
 `
 
 		inputData := []byte(`
 image:
-    attributes:
-        name: repo-name
+  attributes:
+    name: repo-name
 `)
 		input := yaml.Node{}
 		err := yaml.Unmarshal(inputData, &input)
@@ -2269,7 +2269,7 @@ image:
 		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
 
-		output, err := yaml.Marshal(&input)
+		output, err := marshalWithIndent(&input, 2)
 		require.NoError(t, err)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})
@@ -2280,9 +2280,7 @@ name: repo-name
 tag: v2.0.0
 `
 
-		inputData := []byte(`
-name: repo-name
-`)
+		inputData := []byte(`name: repo-name`)
 		input := yaml.Node{}
 		err := yaml.Unmarshal(inputData, &input)
 		require.NoError(t, err)
@@ -2293,7 +2291,7 @@ name: repo-name
 		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
 
-		output, err := yaml.Marshal(&input)
+		output, err := marshalWithIndent(&input, 2)
 		require.NoError(t, err)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})
@@ -2314,7 +2312,7 @@ name: repo-name
 		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
 
-		output, err := yaml.Marshal(&input)
+		output, err := marshalWithIndent(&input, 2)
 		require.NoError(t, err)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})
@@ -2322,7 +2320,7 @@ name: repo-name
 	t.Run("Unexpected type for key", func(t *testing.T) {
 		inputData := []byte(`
 image:
-    attributes: v1.0.0
+  attributes: v1.0.0
 `)
 		input := yaml.Node{}
 		err := yaml.Unmarshal(inputData, &input)
@@ -2339,28 +2337,28 @@ image:
 	t.Run("Aliases, comments, and multiline strings are preserved", func(t *testing.T) {
 		expected := `
 image:
-    attributes:
-        name: &repo repo-name
-        tag: v2.0.0
-        # this is a comment
-        multiline: |
-            one
-            two
-            three
-        alias: *repo
+  attributes:
+    name: &repo repo-name
+    tag: v2.0.0
+    # this is a comment
+    multiline: |
+      one
+      two
+      three
+    alias: *repo
 `
 
 		inputData := []byte(`
 image:
-    attributes:
-        name: &repo repo-name
-        tag: v1.0.0
-        # this is a comment
-        multiline: |
-            one
-            two
-            three
-        alias: *repo
+  attributes:
+    name: &repo repo-name
+    tag: v1.0.0
+    # this is a comment
+    multiline: |
+      one
+      two
+      three
+    alias: *repo
 `)
 		input := yaml.Node{}
 		err := yaml.Unmarshal(inputData, &input)
@@ -2372,7 +2370,7 @@ image:
 		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
 
-		output, err := yaml.Marshal(&input)
+		output, err := marshalWithIndent(&input, 2)
 		require.NoError(t, err)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})
@@ -2380,20 +2378,20 @@ image:
 	t.Run("Aliases to mappings are followed", func(t *testing.T) {
 		expected := `
 global:
-    attributes: &attrs
-        name: &repo repo-name
-        tag: v2.0.0
+  attributes: &attrs
+    name: &repo repo-name
+    tag: v2.0.0
 image:
-    attributes: *attrs
+  attributes: *attrs
 `
 
 		inputData := []byte(`
 global:
-    attributes: &attrs
-        name: &repo repo-name
-        tag: v1.0.0
+  attributes: &attrs
+    name: &repo repo-name
+    tag: v1.0.0
 image:
-    attributes: *attrs
+  attributes: *attrs
 `)
 		input := yaml.Node{}
 		err := yaml.Unmarshal(inputData, &input)
@@ -2405,7 +2403,7 @@ image:
 		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
 
-		output, err := yaml.Marshal(&input)
+		output, err := marshalWithIndent(&input, 2)
 		require.NoError(t, err)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})
@@ -2413,18 +2411,18 @@ image:
 	t.Run("Aliases to scalars are followed", func(t *testing.T) {
 		expected := `
 image:
-    attributes:
-        name: repo-name
-        version: &ver v2.0.0
-        tag: *ver
+  attributes:
+    name: repo-name
+    version: &ver v2.0.0
+    tag: *ver
 `
 
 		inputData := []byte(`
 image:
-    attributes:
-        name: repo-name
-        version: &ver v1.0.0
-        tag: *ver
+  attributes:
+    name: repo-name
+    version: &ver v1.0.0
+    tag: *ver
 `)
 		input := yaml.Node{}
 		err := yaml.Unmarshal(inputData, &input)
@@ -2436,7 +2434,7 @@ image:
 		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
 
-		output, err := yaml.Marshal(&input)
+		output, err := marshalWithIndent(&input, 2)
 		require.NoError(t, err)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/argoproj-labs/argocd-image-updater/ext/git"
 	gitmock "github.com/argoproj-labs/argocd-image-updater/ext/git/mocks"
@@ -1179,10 +1179,10 @@ func Test_MarshalParamsOverride(t *testing.T) {
 	t.Run("Valid Kustomize source", func(t *testing.T) {
 		expected := `
 kustomize:
-  images:
-  - baz
-  - foo
-  - bar
+    images:
+        - baz
+        - foo
+        - bar
 `
 		app := v1alpha1.Application{
 			ObjectMeta: v1.ObjectMeta{
@@ -1210,8 +1210,8 @@ kustomize:
 		}
 		originalData := []byte(`
 kustomize:
-  images:
-  - baz
+    images:
+        - baz
 `)
 		yaml, err := marshalParamsOverride(&app, originalData)
 		require.NoError(t, err)
@@ -1222,10 +1222,10 @@ kustomize:
 	t.Run("Merge images param", func(t *testing.T) {
 		expected := `
 kustomize:
-  images:
-  - existing:latest
-  - updated:latest
-  - new
+    images:
+        - existing:latest
+        - updated:latest
+        - new
 `
 		app := v1alpha1.Application{
 			ObjectMeta: v1.ObjectMeta{
@@ -1252,9 +1252,9 @@ kustomize:
 		}
 		originalData := []byte(`
 kustomize:
-  images:
-  - existing:latest
-  - updated:old
+    images:
+        - existing:latest
+        - updated:old
 `)
 		yaml, err := marshalParamsOverride(&app, originalData)
 		require.NoError(t, err)
@@ -1291,16 +1291,16 @@ kustomize:
 	t.Run("Valid Helm source", func(t *testing.T) {
 		expected := `
 helm:
-  parameters:
-	- name: baz
-		value: baz
-		forcestring: false
-	- name: foo
-		value: bar
-		forcestring: true
-	- name: bar
-		value: foo
-		forcestring: true
+    parameters:
+        - name: baz
+          value: baz
+          forcestring: false
+        - name: foo
+          value: bar
+          forcestring: true
+        - name: bar
+          value: foo
+          forcestring: true
 `
 		app := v1alpha1.Application{
 			ObjectMeta: v1.ObjectMeta{
@@ -1351,13 +1351,13 @@ helm:
 	t.Run("Empty originalData error with valid Helm source", func(t *testing.T) {
 		expected := `
 helm:
-  parameters:
-	- name: foo
-		value: bar
-		forcestring: true
-	- name: bar
-		value: foo
-		forcestring: true
+    parameters:
+        - name: foo
+          value: bar
+          forcestring: true
+        - name: bar
+          value: foo
+          forcestring: true
 `
 		app := v1alpha1.Application{
 			ObjectMeta: v1.ObjectMeta{
@@ -1402,13 +1402,13 @@ helm:
 	t.Run("Invalid unmarshal originalData error with valid Helm source", func(t *testing.T) {
 		expected := `
 helm:
-  parameters:
-	- name: foo
-		value: bar
-		forcestring: true
-	- name: bar
-		value: foo
-		forcestring: true
+    parameters:
+        - name: foo
+          value: bar
+          forcestring: true
+        - name: bar
+          value: foo
+          forcestring: true
 `
 		app := v1alpha1.Application{
 			ObjectMeta: v1.ObjectMeta{
@@ -1588,8 +1588,8 @@ replicas: 1
 		expected = `
 test-value1: one
 image:
-  spec:
-    foo: nginx:v1.0.0
+    spec:
+        foo: nginx:v1.0.0
 `
 		yaml, err = marshalParamsOverride(&app, originalData)
 		require.NoError(t, err)
@@ -1690,13 +1690,13 @@ replicas: 1
 		expected = `
 test-value1: one
 nginx:
-  image:
-    tag: v1.0.0
-    name: nginx
+    image:
+        tag: v1.0.0
+        name: nginx
 redis:
-  image:
-    tag: v1.0.0
-    name: redis
+    image:
+        tag: v1.0.0
+        name: redis
 `
 		yaml, err = marshalParamsOverride(&app, originalData)
 		require.NoError(t, err)
@@ -1811,8 +1811,8 @@ replicas: 1
 		expected := `
 test-value1: one
 image:
-  name: nginx
-  tag: v1.0.0
+    name: nginx
+    tag: v1.0.0
 replicas: 1
 `
 
@@ -1860,7 +1860,7 @@ replicas: 1
 		originalData := []byte(`
 test-value1: one
 image:
-  name: nginx
+    name: nginx
 replicas: 1
 `)
 
@@ -1873,8 +1873,8 @@ replicas: 1
 	t.Run("Failed to setValue image parameter version", func(t *testing.T) {
 		expected := `
 image:
-  tag: v1.0.0
-  name: nginx
+    tag: v1.0.0
+    name: nginx
 replicas: 1
 `
 		app := v1alpha1.Application{
@@ -2199,23 +2199,86 @@ replicas: 1
 
 func Test_SetHelmValue(t *testing.T) {
 	t.Run("Update existing Key", func(t *testing.T) {
-		expected := yaml.MapSlice{
-			{Key: "image", Value: yaml.MapSlice{
-				{Key: "attributes", Value: yaml.MapSlice{
-					{Key: "name", Value: "repo-name"},
-					{Key: "tag", Value: "v2.0.0"},
-				}},
-			}},
+		expected := yaml.Node{
+			Kind: yaml.MappingNode,
+			Content: []*yaml.Node{
+				{
+					Kind:  yaml.ScalarNode,
+					Value: "image",
+				},
+				{
+					Kind: yaml.MappingNode,
+					Content: []*yaml.Node{
+						{
+							Kind:  yaml.ScalarNode,
+							Value: "attributes",
+						},
+						{
+							Kind: yaml.MappingNode,
+							Content: []*yaml.Node{
+								{
+									Kind:  yaml.ScalarNode,
+									Value: "name",
+								},
+								{
+									Kind:  yaml.ScalarNode,
+									Value: "repo-name",
+								},
+								{
+									Kind:  yaml.ScalarNode,
+									Value: "tag",
+								},
+								{
+									Kind:  yaml.ScalarNode,
+									Value: "v2.0.0",
+								},
+							},
+						},
+					},
+				},
+			},
 		}
 
-		input := yaml.MapSlice{
-			{Key: "image", Value: yaml.MapSlice{
-				{Key: "attributes", Value: yaml.MapSlice{
-					{Key: "name", Value: "repo-name"},
-					{Key: "tag", Value: "v1.0.0"},
-				}},
-			}},
+		input := yaml.Node{
+			Kind: yaml.MappingNode,
+			Content: []*yaml.Node{
+				{
+					Kind:  yaml.ScalarNode,
+					Value: "image",
+				},
+				{
+					Kind: yaml.MappingNode,
+					Content: []*yaml.Node{
+						{
+							Kind:  yaml.ScalarNode,
+							Value: "attributes",
+						},
+						{
+							Kind: yaml.MappingNode,
+							Content: []*yaml.Node{
+								{
+									Kind:  yaml.ScalarNode,
+									Value: "name",
+								},
+								{
+									Kind:  yaml.ScalarNode,
+									Value: "repo-name",
+								},
+								{
+									Kind:  yaml.ScalarNode,
+									Value: "tag",
+								},
+								{
+									Kind:  yaml.ScalarNode,
+									Value: "v1.0.0",
+								},
+							},
+						},
+					},
+				},
+			},
 		}
+
 		key := "image.attributes.tag"
 		value := "v2.0.0"
 
@@ -2225,13 +2288,34 @@ func Test_SetHelmValue(t *testing.T) {
 	})
 
 	t.Run("Update Key with dots", func(t *testing.T) {
-		expected := yaml.MapSlice{
-			{Key: "image.attributes.tag", Value: "v2.0.0"},
+		expected := yaml.Node{
+			Kind: yaml.MappingNode,
+			Content: []*yaml.Node{
+				{
+					Kind:  yaml.ScalarNode,
+					Value: "image.attributes.tag",
+				},
+				{
+					Kind:  yaml.ScalarNode,
+					Value: "v2.0.0",
+				},
+			},
 		}
 
-		input := yaml.MapSlice{
-			{Key: "image.attributes.tag", Value: "v1.0.0"},
+		input := yaml.Node{
+			Kind: yaml.MappingNode,
+			Content: []*yaml.Node{
+				{
+					Kind:  yaml.ScalarNode,
+					Value: "image.attributes.tag",
+				},
+				{
+					Kind:  yaml.ScalarNode,
+					Value: "v1.0.0",
+				},
+			},
 		}
+
 		key := "image.attributes.tag"
 		value := "v2.0.0"
 
@@ -2241,21 +2325,76 @@ func Test_SetHelmValue(t *testing.T) {
 	})
 
 	t.Run("Key not found", func(t *testing.T) {
-		expected := yaml.MapSlice{
-			{Key: "image", Value: yaml.MapSlice{
-				{Key: "attributes", Value: yaml.MapSlice{
-					{Key: "name", Value: "repo-name"},
-					{Key: "tag", Value: "v2.0.0"},
-				}},
-			}},
+		expected := yaml.Node{
+			Kind: yaml.MappingNode,
+			Content: []*yaml.Node{
+				{
+					Kind:  yaml.ScalarNode,
+					Value: "image",
+				},
+				{
+					Kind: yaml.MappingNode,
+					Content: []*yaml.Node{
+						{
+							Kind:  yaml.ScalarNode,
+							Value: "attributes",
+						},
+						{
+							Kind: yaml.MappingNode,
+							Content: []*yaml.Node{
+								{
+									Kind:  yaml.ScalarNode,
+									Value: "name",
+								},
+								{
+									Kind:  yaml.ScalarNode,
+									Value: "repo-name",
+								},
+								{
+									Kind:  yaml.ScalarNode,
+									Value: "tag",
+								},
+								{
+									Kind:  yaml.ScalarNode,
+									Value: "v2.0.0",
+								},
+							},
+						},
+					},
+				},
+			},
 		}
 
-		input := yaml.MapSlice{
-			{Key: "image", Value: yaml.MapSlice{
-				{Key: "attributes", Value: yaml.MapSlice{
-					{Key: "name", Value: "repo-name"},
-				}},
-			}},
+		input := yaml.Node{
+			Kind: yaml.MappingNode,
+			Content: []*yaml.Node{
+				{
+					Kind:  yaml.ScalarNode,
+					Value: "image",
+				},
+				{
+					Kind: yaml.MappingNode,
+					Content: []*yaml.Node{
+						{
+							Kind:  yaml.ScalarNode,
+							Value: "attributes",
+						},
+						{
+							Kind: yaml.MappingNode,
+							Content: []*yaml.Node{
+								{
+									Kind:  yaml.ScalarNode,
+									Value: "name",
+								},
+								{
+									Kind:  yaml.ScalarNode,
+									Value: "repo-name",
+								},
+							},
+						},
+					},
+				},
+			},
 		}
 
 		key := "image.attributes.tag"
@@ -2267,13 +2406,40 @@ func Test_SetHelmValue(t *testing.T) {
 	})
 
 	t.Run("Root key not found", func(t *testing.T) {
-		expected := yaml.MapSlice{
-			{Key: "name", Value: "repo-name"},
-			{Key: "tag", Value: "v2.0.0"},
+		expected := yaml.Node{
+			Kind: yaml.MappingNode,
+			Content: []*yaml.Node{
+				{
+					Kind:  yaml.ScalarNode,
+					Value: "name",
+				},
+				{
+					Kind:  yaml.ScalarNode,
+					Value: "repo-name",
+				},
+				{
+					Kind:  yaml.ScalarNode,
+					Value: "tag",
+				},
+				{
+					Kind:  yaml.ScalarNode,
+					Value: "v2.0.0",
+				},
+			},
 		}
 
-		input := yaml.MapSlice{
-			{Key: "name", Value: "repo-name"},
+		input := yaml.Node{
+			Kind: yaml.MappingNode,
+			Content: []*yaml.Node{
+				{
+					Kind:  yaml.ScalarNode,
+					Value: "name",
+				},
+				{
+					Kind:  yaml.ScalarNode,
+					Value: "repo-name",
+				},
+			},
 		}
 
 		key := "tag"
@@ -2285,15 +2451,42 @@ func Test_SetHelmValue(t *testing.T) {
 	})
 
 	t.Run("Empty values with deep key", func(t *testing.T) {
-		expected := yaml.MapSlice{
-			{Key: "image", Value: yaml.MapSlice{
-				{Key: "attributes", Value: yaml.MapSlice{
-					{Key: "tag", Value: "v2.0.0"},
-				}},
-			}},
+		expected := yaml.Node{
+			Kind: yaml.MappingNode,
+			Content: []*yaml.Node{
+				{
+					Kind:  yaml.ScalarNode,
+					Value: "image",
+				},
+				{
+					Kind: yaml.MappingNode,
+					Content: []*yaml.Node{
+						{
+							Kind:  yaml.ScalarNode,
+							Value: "attributes",
+						},
+						{
+							Kind: yaml.MappingNode,
+							Content: []*yaml.Node{
+								{
+									Kind:  yaml.ScalarNode,
+									Value: "tag",
+								},
+								{
+									Kind:  yaml.ScalarNode,
+									Value: "v2.0.0",
+								},
+							},
+						},
+					},
+				},
+			},
 		}
 
-		input := yaml.MapSlice{}
+		input := yaml.Node{
+			Kind:    yaml.MappingNode,
+			Content: []*yaml.Node{},
+		}
 
 		key := "image.attributes.tag"
 		value := "v2.0.0"
@@ -2304,17 +2497,35 @@ func Test_SetHelmValue(t *testing.T) {
 	})
 
 	t.Run("Unexpected type for key", func(t *testing.T) {
-		input := yaml.MapSlice{
-			{Key: "image", Value: yaml.MapSlice{
-				{Key: "attributes", Value: "v1.0.0"},
-			}},
+		input := yaml.Node{
+			Kind: yaml.MappingNode,
+			Content: []*yaml.Node{
+				{
+					Kind:  yaml.ScalarNode,
+					Value: "image",
+				},
+				{
+					Kind: yaml.MappingNode,
+					Content: []*yaml.Node{
+						{
+							Kind:  yaml.ScalarNode,
+							Value: "attributes",
+						},
+						{
+							Kind:  yaml.ScalarNode,
+							Value: "v1.0.0",
+						},
+					},
+				},
+			},
 		}
+
 		key := "image.attributes.tag"
 		value := "v2.0.0"
 
 		err := setHelmValue(&input, key, value)
 		assert.Error(t, err)
-		assert.Equal(t, "unexpected type string for key attributes", err.Error())
+		assert.Equal(t, "unexpected type ScalarNode for key attributes", err.Error())
 	})
 }
 

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -2199,331 +2199,139 @@ replicas: 1
 
 func Test_SetHelmValue(t *testing.T) {
 	t.Run("Update existing Key", func(t *testing.T) {
-		expected := yaml.Node{
-			Kind: yaml.MappingNode,
-			Content: []*yaml.Node{
-				{
-					Kind:  yaml.ScalarNode,
-					Value: "image",
-				},
-				{
-					Kind: yaml.MappingNode,
-					Content: []*yaml.Node{
-						{
-							Kind:  yaml.ScalarNode,
-							Value: "attributes",
-						},
-						{
-							Kind: yaml.MappingNode,
-							Content: []*yaml.Node{
-								{
-									Kind:  yaml.ScalarNode,
-									Value: "name",
-								},
-								{
-									Kind:  yaml.ScalarNode,
-									Value: "repo-name",
-								},
-								{
-									Kind:  yaml.ScalarNode,
-									Value: "tag",
-								},
-								{
-									Kind:  yaml.ScalarNode,
-									Value: "v2.0.0",
-								},
-							},
-						},
-					},
-				},
-			},
-		}
+		expected := `
+image:
+    attributes:
+        name: repo-name
+        tag: v2.0.0
+`
 
-		input := yaml.Node{
-			Kind: yaml.MappingNode,
-			Content: []*yaml.Node{
-				{
-					Kind:  yaml.ScalarNode,
-					Value: "image",
-				},
-				{
-					Kind: yaml.MappingNode,
-					Content: []*yaml.Node{
-						{
-							Kind:  yaml.ScalarNode,
-							Value: "attributes",
-						},
-						{
-							Kind: yaml.MappingNode,
-							Content: []*yaml.Node{
-								{
-									Kind:  yaml.ScalarNode,
-									Value: "name",
-								},
-								{
-									Kind:  yaml.ScalarNode,
-									Value: "repo-name",
-								},
-								{
-									Kind:  yaml.ScalarNode,
-									Value: "tag",
-								},
-								{
-									Kind:  yaml.ScalarNode,
-									Value: "v1.0.0",
-								},
-							},
-						},
-					},
-				},
-			},
-		}
+		inputData := []byte(`
+image:
+    attributes:
+        name: repo-name
+        tag: v1.0.0
+`)
+		input := yaml.Node{}
+		err := yaml.Unmarshal(inputData, &input)
+		require.NoError(t, err)
 
 		key := "image.attributes.tag"
 		value := "v2.0.0"
 
-		err := setHelmValue(&input, key, value)
+		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
-		assert.Equal(t, expected, input)
+
+		output, err := yaml.Marshal(&input)
+		require.NoError(t, err)
+		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})
 
 	t.Run("Update Key with dots", func(t *testing.T) {
-		expected := yaml.Node{
-			Kind: yaml.MappingNode,
-			Content: []*yaml.Node{
-				{
-					Kind:  yaml.ScalarNode,
-					Value: "image.attributes.tag",
-				},
-				{
-					Kind:  yaml.ScalarNode,
-					Value: "v2.0.0",
-				},
-			},
-		}
+		expected := `image.attributes.tag: v2.0.0`
 
-		input := yaml.Node{
-			Kind: yaml.MappingNode,
-			Content: []*yaml.Node{
-				{
-					Kind:  yaml.ScalarNode,
-					Value: "image.attributes.tag",
-				},
-				{
-					Kind:  yaml.ScalarNode,
-					Value: "v1.0.0",
-				},
-			},
-		}
+		inputData := []byte(`image.attributes.tag: v1.0.0`)
+		input := yaml.Node{}
+		err := yaml.Unmarshal(inputData, &input)
+		require.NoError(t, err)
 
 		key := "image.attributes.tag"
 		value := "v2.0.0"
 
-		err := setHelmValue(&input, key, value)
+		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
-		assert.Equal(t, expected, input)
+
+		output, err := yaml.Marshal(&input)
+		require.NoError(t, err)
+		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})
 
 	t.Run("Key not found", func(t *testing.T) {
-		expected := yaml.Node{
-			Kind: yaml.MappingNode,
-			Content: []*yaml.Node{
-				{
-					Kind:  yaml.ScalarNode,
-					Value: "image",
-				},
-				{
-					Kind: yaml.MappingNode,
-					Content: []*yaml.Node{
-						{
-							Kind:  yaml.ScalarNode,
-							Value: "attributes",
-						},
-						{
-							Kind: yaml.MappingNode,
-							Content: []*yaml.Node{
-								{
-									Kind:  yaml.ScalarNode,
-									Value: "name",
-								},
-								{
-									Kind:  yaml.ScalarNode,
-									Value: "repo-name",
-								},
-								{
-									Kind:  yaml.ScalarNode,
-									Value: "tag",
-								},
-								{
-									Kind:  yaml.ScalarNode,
-									Value: "v2.0.0",
-								},
-							},
-						},
-					},
-				},
-			},
-		}
+		expected := `
+image:
+    attributes:
+        name: repo-name
+        tag: v2.0.0
+`
 
-		input := yaml.Node{
-			Kind: yaml.MappingNode,
-			Content: []*yaml.Node{
-				{
-					Kind:  yaml.ScalarNode,
-					Value: "image",
-				},
-				{
-					Kind: yaml.MappingNode,
-					Content: []*yaml.Node{
-						{
-							Kind:  yaml.ScalarNode,
-							Value: "attributes",
-						},
-						{
-							Kind: yaml.MappingNode,
-							Content: []*yaml.Node{
-								{
-									Kind:  yaml.ScalarNode,
-									Value: "name",
-								},
-								{
-									Kind:  yaml.ScalarNode,
-									Value: "repo-name",
-								},
-							},
-						},
-					},
-				},
-			},
-		}
+		inputData := []byte(`
+image:
+    attributes:
+        name: repo-name
+`)
+		input := yaml.Node{}
+		err := yaml.Unmarshal(inputData, &input)
+		require.NoError(t, err)
 
 		key := "image.attributes.tag"
 		value := "v2.0.0"
 
-		err := setHelmValue(&input, key, value)
+		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
-		assert.Equal(t, expected, input)
+
+		output, err := yaml.Marshal(&input)
+		require.NoError(t, err)
+		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})
 
 	t.Run("Root key not found", func(t *testing.T) {
-		expected := yaml.Node{
-			Kind: yaml.MappingNode,
-			Content: []*yaml.Node{
-				{
-					Kind:  yaml.ScalarNode,
-					Value: "name",
-				},
-				{
-					Kind:  yaml.ScalarNode,
-					Value: "repo-name",
-				},
-				{
-					Kind:  yaml.ScalarNode,
-					Value: "tag",
-				},
-				{
-					Kind:  yaml.ScalarNode,
-					Value: "v2.0.0",
-				},
-			},
-		}
+		expected := `
+name: repo-name
+tag: v2.0.0
+`
 
-		input := yaml.Node{
-			Kind: yaml.MappingNode,
-			Content: []*yaml.Node{
-				{
-					Kind:  yaml.ScalarNode,
-					Value: "name",
-				},
-				{
-					Kind:  yaml.ScalarNode,
-					Value: "repo-name",
-				},
-			},
-		}
+		inputData := []byte(`
+name: repo-name
+`)
+		input := yaml.Node{}
+		err := yaml.Unmarshal(inputData, &input)
+		require.NoError(t, err)
 
 		key := "tag"
 		value := "v2.0.0"
 
-		err := setHelmValue(&input, key, value)
+		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
-		assert.Equal(t, expected, input)
+
+		output, err := yaml.Marshal(&input)
+		require.NoError(t, err)
+		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})
 
 	t.Run("Empty values with deep key", func(t *testing.T) {
-		expected := yaml.Node{
-			Kind: yaml.MappingNode,
-			Content: []*yaml.Node{
-				{
-					Kind:  yaml.ScalarNode,
-					Value: "image",
-				},
-				{
-					Kind: yaml.MappingNode,
-					Content: []*yaml.Node{
-						{
-							Kind:  yaml.ScalarNode,
-							Value: "attributes",
-						},
-						{
-							Kind: yaml.MappingNode,
-							Content: []*yaml.Node{
-								{
-									Kind:  yaml.ScalarNode,
-									Value: "tag",
-								},
-								{
-									Kind:  yaml.ScalarNode,
-									Value: "v2.0.0",
-								},
-							},
-						},
-					},
-				},
-			},
-		}
+		// this uses inline syntax because the input data
+		// needed is an empty map, which can only be expressed as {}.
+		expected := `{image: {attributes: {tag: v2.0.0}}}`
 
-		input := yaml.Node{
-			Kind:    yaml.MappingNode,
-			Content: []*yaml.Node{},
-		}
+		inputData := []byte(`{}`)
+		input := yaml.Node{}
+		err := yaml.Unmarshal(inputData, &input)
+		require.NoError(t, err)
 
 		key := "image.attributes.tag"
 		value := "v2.0.0"
 
-		err := setHelmValue(&input, key, value)
+		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
-		assert.Equal(t, expected, input)
+
+		output, err := yaml.Marshal(&input)
+		require.NoError(t, err)
+		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})
 
 	t.Run("Unexpected type for key", func(t *testing.T) {
-		input := yaml.Node{
-			Kind: yaml.MappingNode,
-			Content: []*yaml.Node{
-				{
-					Kind:  yaml.ScalarNode,
-					Value: "image",
-				},
-				{
-					Kind: yaml.MappingNode,
-					Content: []*yaml.Node{
-						{
-							Kind:  yaml.ScalarNode,
-							Value: "attributes",
-						},
-						{
-							Kind:  yaml.ScalarNode,
-							Value: "v1.0.0",
-						},
-					},
-				},
-			},
-		}
+		inputData := []byte(`
+image:
+    attributes: v1.0.0
+`)
+		input := yaml.Node{}
+		err := yaml.Unmarshal(inputData, &input)
+		require.NoError(t, err)
 
 		key := "image.attributes.tag"
 		value := "v2.0.0"
 
-		err := setHelmValue(&input, key, value)
+		err = setHelmValue(&input, key, value)
 		assert.Error(t, err)
 		assert.Equal(t, "unexpected type ScalarNode for key attributes", err.Error())
 	})


### PR DESCRIPTION
Similar to #1039 (and conflicts with it). In our codefresh install developers have complained that various parts of the original yaml aren't preserved:
- comments
- multiline string formatting for parameters like scripts
- anchors (the current code resolves all anchors and writes back with no anchors, resulting in duplicative config)

In particular we have cases where multiple jobs are defined in a chart which use the same images, which should all be updated via a single reference. yaml.v2 doesn't support this, but yaml.v3 does; the Node structure preserves pre-, post- and end-of-line comments, keeps the string formatting marker with the string for marshalling, and allows us to navigate aliases without losing them.

In this PR, I first switched to yaml.v3, then, like #1039, simplified the test cases for this code to not use the internal structures we unmarshal to but instead do yaml-to-yaml comparisons; this is easier to read and maintain and less code. Finally I added tests for the features described above.

I've only supported one level of aliasing; you can have multiple aliases through the path as you navigate the document but you can't have a mapping which is an alias for a mapping which is an alias for a mapping. Supporting that may mean the code could get stuck in a loop, and it doesn't seem like a sensible document structure anyway, just make the direct reference?

I don't currently support or set tags in the yaml, eg !!str. This would be an issue if you try to set  a field which is not tagged as a string.

Unlike #1039, this does not also update the path syntax used for updates.