### PR TITLE
fix: determine the suitable github api base url from repo url

### DIFF
--- a/ext/git/creds.go
+++ b/ext/git/creds.go
@@ -42,7 +42,6 @@ const (
 	// githubAccessTokenUsername is a username that is used to with the github access token
 	githubAccessTokenUsername = "x-access-token"
 	forceBasicAuthHeaderEnv   = "ARGOCD_GIT_AUTH_HEADER"
-	defaultGithubApiUrl       = "https://api.github.com"
 )
 
 func init() {
@@ -462,27 +461,6 @@ func (g GitHubAppCreds) getAccessToken() (string, error) {
 	githubAppTokenCache.Set(key, itr, time.Minute*60)
 
 	return itr.Token(ctx)
-}
-
-func (g GitHubAppCreds) getBaseURL() string {
-	if g.baseURL != "" {
-		return strings.TrimSuffix(g.baseURL, "/")
-	}
-	if g.repoURL == "" {
-		return defaultGithubApiUrl
-	}
-
-	repoUrl, err := url.Parse(g.repoURL)
-	if err != nil || repoUrl.Hostname() == "github.com" {
-		return defaultGithubApiUrl
-	}
-
-	// GitHub Enterprise
-	scheme := repoUrl.Scheme
-	if scheme == "" {
-		scheme = "https"
-	}
-	return fmt.Sprintf("%s://%s/api/v3", scheme, repoUrl.Host)
 }
 
 func (g GitHubAppCreds) HasClientCert() bool {

--- a/ext/git/creds2.go
+++ b/ext/git/creds2.go
@@ -1,0 +1,32 @@
+package git
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+const (
+	defaultGithubApiUrl = "https://api.github.com"
+)
+
+func (g GitHubAppCreds) getBaseURL() string {
+	if g.baseURL != "" {
+		return strings.TrimSuffix(g.baseURL, "/")
+	}
+	if g.repoURL == "" {
+		return defaultGithubApiUrl
+	}
+
+	repoUrl, err := url.Parse(g.repoURL)
+	if err != nil || repoUrl.Hostname() == "github.com" {
+		return defaultGithubApiUrl
+	}
+
+	// GitHub Enterprise
+	scheme := repoUrl.Scheme
+	if scheme == "" {
+		scheme = "https"
+	}
+	return fmt.Sprintf("%s://%s/api/v3", scheme, repoUrl.Host)
+}

--- a/ext/git/creds2_test.go
+++ b/ext/git/creds2_test.go
@@ -1,0 +1,31 @@
+package git
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGitHubAppCreds_getBaseURL(t *testing.T) {
+	g := GitHubAppCreds{
+		appID:        123,
+		appInstallId: 1234,
+	}
+	assert.Equal(t, defaultGithubApiUrl, g.getBaseURL())
+
+	g.baseURL = "https://example.com/api"
+	assert.Equal(t, g.baseURL, g.getBaseURL())
+
+	g.baseURL = ""
+	g.repoURL = "https://github.com/org/repo"
+	assert.Equal(t, defaultGithubApiUrl, g.getBaseURL())
+
+	g.repoURL = "http://github.com/org/repo"
+	assert.Equal(t, defaultGithubApiUrl, g.getBaseURL())
+
+	g.repoURL = "https://example.com/org/repo"
+	assert.Equal(t, "https://example.com/api/v3", g.getBaseURL())
+
+	g.repoURL = "http://example.com/org/repo"
+	assert.Equal(t, "http://example.com/api/v3", g.getBaseURL())
+}

--- a/ext/git/creds_test.go
+++ b/ext/git/creds_test.go
@@ -367,3 +367,27 @@ func TestGoogleCloudCreds_Environ_cleanup(t *testing.T) {
 	io.Close(closer)
 	assert.NotContains(t, store.creds, nonce)
 }
+
+func TestGitHubAppCreds_getBaseURL(t *testing.T) {
+	g := GitHubAppCreds{
+		appID:        123,
+		appInstallId: 1234,
+	}
+	assert.Equal(t, defaultGithubApiUrl, g.getBaseURL())
+
+	g.baseURL = "https://example.com/api"
+	assert.Equal(t, g.baseURL, g.getBaseURL())
+
+	g.baseURL = ""
+	g.repoURL = "https://github.com/org/repo"
+	assert.Equal(t, defaultGithubApiUrl, g.getBaseURL())
+
+	g.repoURL = "http://github.com/org/repo"
+	assert.Equal(t, defaultGithubApiUrl, g.getBaseURL())
+
+	g.repoURL = "https://example.com/org/repo"
+	assert.Equal(t, "https://example.com/api/v3", g.getBaseURL())
+
+	g.repoURL = "http://example.com/org/repo"
+	assert.Equal(t, "http://example.com/api/v3", g.getBaseURL())
+}

--- a/ext/git/creds_test.go
+++ b/ext/git/creds_test.go
@@ -367,27 +367,3 @@ func TestGoogleCloudCreds_Environ_cleanup(t *testing.T) {
 	io.Close(closer)
 	assert.NotContains(t, store.creds, nonce)
 }
-
-func TestGitHubAppCreds_getBaseURL(t *testing.T) {
-	g := GitHubAppCreds{
-		appID:        123,
-		appInstallId: 1234,
-	}
-	assert.Equal(t, defaultGithubApiUrl, g.getBaseURL())
-
-	g.baseURL = "https://example.com/api"
-	assert.Equal(t, g.baseURL, g.getBaseURL())
-
-	g.baseURL = ""
-	g.repoURL = "https://github.com/org/repo"
-	assert.Equal(t, defaultGithubApiUrl, g.getBaseURL())
-
-	g.repoURL = "http://github.com/org/repo"
-	assert.Equal(t, defaultGithubApiUrl, g.getBaseURL())
-
-	g.repoURL = "https://example.com/org/repo"
-	assert.Equal(t, "https://example.com/api/v3", g.getBaseURL())
-
-	g.repoURL = "http://example.com/org/repo"
-	assert.Equal(t, "http://example.com/api/v3", g.getBaseURL())
-}


### PR DESCRIPTION
Fix the issue raised in discussion https://github.com/argoproj-labs/argocd-image-updater/discussions/1038

When the github enterprise api base url is not set, try to determine it based on repo url.