### PR TITLE
Set up custom container registry and git server for image-updater e2e tests.

### DIFF
--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -10,6 +10,9 @@ git-container-build: copy-testdata
 git-container-push: git-container-build
 	docker push $(IMAGE_SLUG)
 
+remove-docker-images:
+	docker rmi $$(docker images | grep $(IMAGE_REPO) | awk '{print $$3}')
+
 copy-testdata:
 	cp -r testdata containers/git
 
@@ -20,6 +23,12 @@ install-prereqs:
 	sleep 5
 	make git-container-push
 	kubectl apply -n argocd-image-updater-e2e -f prereqs/repo/install.yaml
+
+delete-prereqs: 
+	kubectl delete -n argocd-image-updater-e2e -f prereqs/repo/install.yaml
+	kubectl delete -n argocd-image-updater-e2e -f prereqs/registry/registry.yaml
+	kustomize build prereqs/argocd | kubectl -n argocd-image-updater-e2e delete -f -
+	make remove-docker-images
 
 .PHONY: git-container-build
 .PHONY: git-container-push

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -4,11 +4,6 @@ This directory contains the end-to-end tests for Argo CD Image Updater. The
 tests are implemented using [kuttl](https://kuttl.dev) and require some
 prerequisites.
 
-**This is work-in-progress at a very early stage**. The end-to-end tests are
-not yet expected to work flawlessly, and they require an opinionated setup to
-run. If you are going to use the end-to-end tests, it is expected that you are
-prepared to hack on them. Do not ask for support, please.
-
 # Components
 
 The end-to-end tests are comprised of the following components:
@@ -45,3 +40,11 @@ The end-to-end tests are comprised of the following components:
 
 1. Run `make install-prereqs` to install all the pre-requisites on your local
    cluster.
+
+## Run the test suite
+
+1. Run `./e2e-test.sh` to run all the tests located in `./suite`.
+
+## Known issues
+
+1. `./suite/004-multiple-images` is failing now.

--- a/test/e2e/bin/install.sh
+++ b/test/e2e/bin/install.sh
@@ -8,7 +8,7 @@ BASE_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )/.
 sudo mkdir -p /etc/rancher/k3s
 sudo mkdir -p /etc/docker
 
-sudo cp ${BASE_DIR}/assets/registries.yaml /etc/rancher/k3s/registry.yaml
+sudo cp ${BASE_DIR}/assets/registries.yaml /etc/rancher/k3s/registries.yaml
 sudo cp ${BASE_DIR}/assets/registry.crt /etc/rancher/k3s/local.crt
 sudo cp ${BASE_DIR}/assets/daemon.json /etc/docker/daemon.json
 

--- a/test/e2e/containers/git/entrypoint.sh
+++ b/test/e2e/containers/git/entrypoint.sh
@@ -38,7 +38,7 @@ main() {
 
 initialize_services() {
   # Check permissions on $GIT_PROJECT_ROOT
-  chown -R git:git $GIT_PROJECT_ROOT
+  chown -R nginx:git $GIT_PROJECT_ROOT
   chmod -R 775 $GIT_PROJECT_ROOT
 
   /usr/bin/spawn-fcgi \


### PR DESCRIPTION
1. Update `/etc/rancher/k3s/registry.yaml` to `registries.yaml` according to https://docs.k3s.io/installation/private-registry
2. Use `nginx:git` permissions for git project root for private git server. It fixes 500 connection error.
3. Add `delete-prereqs` Makefile rule.
4. Update README.md