### PR TITLE
docs: fix warning formatting in install documentation

### DIFF
--- a/docs/install/installation.md
+++ b/docs/install/installation.md
@@ -28,7 +28,7 @@ Argo CD is running. Don't worry, without any configuration, it will not start me
 kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj-labs/argocd-image-updater/stable/manifests/install.yaml
 ```
 
-!!! warning
+!!!warning
     The installation manifests include `ClusterRoleBinding` resources that reference `argocd` namespace. If you are installing Argo CD into a different
     namespace then make sure to update the namespace reference.
 
@@ -74,7 +74,7 @@ kubectl create namespace argocd-image-updater
 kubectl apply -n argocd-image-updater -f https://raw.githubusercontent.com/argoproj-labs/argocd-image-updater/stable/manifests/install.yaml
 ```
 
-!!! warning
+!!!warning
     The installation manifests include `ClusterRoleBinding` resources that reference `argocd` namespace. If you are installing Argo CD into a different
     namespace then make sure to update the namespace reference.
 


### PR DESCRIPTION
Fixes a rendering issue on the documentation site.

### Before:

![image](https://github.com/user-attachments/assets/69709a55-bff4-45aa-8fd0-5337533d029d)


### After:

![image](https://github.com/user-attachments/assets/c02ab10c-4d61-4ba9-871c-34b622d54dee)
