### PR TITLE
fix(build): add step to Makefile to generate signing gpg key (#922); chore: fix the .phony target name for multiarch-image-push (#923)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,8 @@ release-binaries:
 	BINNAME=argocd-image-updater-win64.exe OUTDIR=dist/release OS=windows ARCH=amd64 make controller
 	rm -f dist/release/release-v${VERSION}.sha256 dist/release/release-v${VERSION}.sha256.asc
 	for bin in dist/release/argocd-image-updater-*; do sha256sum "$$bin" >> dist/release/release-v${VERSION}.sha256; done
-	gpg -a --detach-sign dist/release/release-v${VERSION}.sha256
+	gpg --batch --generate-key hack/gpg-key.conf
+	gpg --default-key noreply@argoproj.io -a --detach-sign dist/release/release-v${VERSION}.sha256
 	gpg -a --verify dist/release/release-v${VERSION}.sha256.asc
 
 .PHONY: extract-binary

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ multiarch-image:
 		--platform ${RELEASE_IMAGE_PLATFORMS} ${DOCKERX_PUSH} \
 		.
 
-.PHONY: multiarch-image
+.PHONY: multiarch-image-push
 multiarch-image-push:
 	docker buildx build \
 		-t ${IMAGE_PREFIX}${IMAGE_NAME}:${IMAGE_TAG} \

--- a/hack/gpg-key.conf
+++ b/hack/gpg-key.conf
@@ -1,0 +1,13 @@
+%no-protection
+%echo Generating a standard key
+Key-Type: RSA
+Key-Length: 3072
+Subkey-Type: RSA
+Subkey-Length: 3072
+Name-Real: argocd-image-updater
+Name-Comment: signing key
+Name-Email: noreply@argoproj.io
+Expire-Date: 1
+%commit
+%echo done
+


### PR DESCRIPTION
cherry-pick the fix from release-0.15 branch (somehow these fixes were not in master).