### PR TITLE
chore(deps): bump golangci-lint from v1.61.0 to v1.64.8

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.61.0
+          version: v1.64.8
           args: --timeout 5m
   test:
     name: Ensure unit tests are passing


### PR DESCRIPTION
to fix various golangci-lint failures in recent PRs.