### PR TITLE
feat: Add GetDurationVal to handle optional duration config from env

### DIFF
--- a/registry-scanner/pkg/env/env.go
+++ b/registry-scanner/pkg/env/env.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/argoproj-labs/argocd-image-updater/registry-scanner/pkg/log"
 )
@@ -33,6 +34,20 @@ func GetStringVal(envVar string, defaultValue string) string {
 	} else {
 		return defaultValue
 	}
+}
+
+// GetDurationVal retrieves a time.Duration value from given environment envVar
+// Returns default value if envVar is not set or if the provided value is invalid.
+func GetDurationVal(envVar string, defaultValue time.Duration) time.Duration {
+	if val := os.Getenv(envVar); val != "" {
+		duration, err := time.ParseDuration(val)
+		if err != nil {
+			log.Warnf("Invalid duration format '%s' for environment variable '%s'. Using default value: %s", val, envVar, defaultValue)
+			return defaultValue
+		}
+		return duration
+	}
+	return defaultValue
 }
 
 // Helper function to parse a number from an environment variable. Returns a

--- a/registry-scanner/pkg/env/env_test.go
+++ b/registry-scanner/pkg/env/env_test.go
@@ -3,6 +3,7 @@ package env
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -34,6 +35,29 @@ func Test_GetStringVal(t *testing.T) {
 		_ = os.Setenv("TEST_STRING_VAL", "")
 		defer os.Setenv("TEST_STRING_VAL", "")
 		assert.Equal(t, "invalid", GetStringVal("TEST_STRING_VAL", "invalid"))
+	})
+}
+
+func Test_GetDurationVal(t *testing.T) {
+	t.Run("Get duration value from existing env var", func(t *testing.T) {
+		_ = os.Setenv("TEST_DURATION_VAL", "1m")
+		defer os.Setenv("TEST_DURATION_VAL", "")
+		assert.Equal(t, time.Minute, GetDurationVal("TEST_DURATION_VAL", 2*time.Minute))
+	})
+	t.Run("Get default value from non-existing env var", func(t *testing.T) {
+		_ = os.Setenv("TEST_DURATION_VAL", "")
+		defer os.Setenv("TEST_DURATION_VAL", "")
+		assert.Equal(t, 2*time.Minute, GetDurationVal("TEST_DURATION_VAL", 2*time.Minute))
+	})
+	t.Run("Get default value for bad format env var", func(t *testing.T) {
+		_ = os.Setenv("TEST_DURATION_VAL", "bad format")
+		defer os.Setenv("TEST_DURATION_VAL", "")
+		assert.Equal(t, 2*time.Minute, GetDurationVal("TEST_DURATION_VAL", 2*time.Minute))
+	})
+	t.Run("Get 0 duration value for 0 env var", func(t *testing.T) {
+		_ = os.Setenv("TEST_DURATION_VAL", "0")
+		defer os.Setenv("TEST_DURATION_VAL", "")
+		assert.Equal(t, 0*time.Minute, GetDurationVal("TEST_DURATION_VAL", 2*time.Minute))
 	})
 }
 


### PR DESCRIPTION
Adds a new utility function `GetDurationVal` to retrieve a time.Duration from an environment variable, with a default value fallback and error logging.