### PR TITLE
chore(ci): update ci-tests.yaml and create-release-draft.yaml to use go version from go.mod

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version-file: go.mod
       - name: Download all Go modules
         run: |
           go mod download
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version-file: go.mod
           cache: false
         env:
           GO111MODULE: off
@@ -80,7 +80,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version-file: go.mod
       - name: Run tests
         env:
           GNUPG_DISABLED: true
@@ -127,7 +127,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version-file: go.mod
       - name: Download all Go modules
         run: |
           cd registry-scanner

--- a/.github/workflows/create-release-draft.yaml
+++ b/.github/workflows/create-release-draft.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version-file: go.mod
 
       - name: Build binaries
         id: binaries


### PR DESCRIPTION
Fixes #1131 

the go versions in the GitHub action workflows are hardcoded. Updated files that include the issue to fix that. 
