### PR TITLE
chore: improve registry-scanner/hack/create-release.sh

### DIFF
--- a/registry-scanner/hack/create-release.sh
+++ b/registry-scanner/hack/create-release.sh
@@ -63,8 +63,7 @@ echo "${TARGET_VERSION}" > VERSION
 
 # Commit updated VERSION file
 git add VERSION
-git commit -s -m "Release ${NEW_TAG}" 
-git push "${REMOTE}" "${RELEASE_BRANCH}"
+git commit -s -m "${MESSAGE}" 
 
 # Create tag for registry-scanner
 git tag -a "${NEW_TAG}" -m "${MESSAGE}"


### PR DESCRIPTION
### Overview 
The following PR improves the registry-scanner/hack/create-release.sh with the following:
- Switching to annotated tags instead of using lightweight tags
- Automatically push the changed `VERSION` file in addition to the new tag to remote
- Added some usage examples to the header
- Improved help messages for missing arguments

I also noticed that the `VERSION` file's contents was `0.111.0`. Not sure if this was intentional because the tag listed is `0.1.0`. I changed the file to match the tag. If it should stay `0.111.0`, I can revert the change. 

### Testing: 
The below screenshots show the testing that I did to validate that my changes functioned properly. 

The output of `git tag -n registry-scanner/*` after running `./hack/create-release.sh TEST HelloHello` and `./hack/create-release.sh TEST2 HelloHello2`:
![Screenshot 2025-06-03 at 3 04 31 PM](https://github.com/user-attachments/assets/28099ddd-5ea0-4087-9cfc-1e9f3228d224)

The commits and tags in the remote after running those two commands above:
![Screenshot 2025-06-03 at 3 05 52 PM](https://github.com/user-attachments/assets/9a220dcd-3286-493a-81f7-07d80d7603c0)
![Screenshot 2025-06-03 at 3 06 28 PM](https://github.com/user-attachments/assets/728be3e6-e140-46fb-9baf-37b31534bf96)

The error messages output if you are missing either the `TARGET_VERSION` or `MESSAGE` arguments:
![Screenshot 2025-06-03 at 3 08 33 PM](https://github.com/user-attachments/assets/d49bcfbc-2834-4d68-b452-39188b49cff1)