### PR TITLE
Replace "main infinite loop" with reconciliation logic.

### DIFF
--- a/internal/controller/imageupdater_controller.go
+++ b/internal/controller/imageupdater_controller.go
@@ -122,8 +122,17 @@ func (r *ImageUpdaterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// For now, just requeue periodically.
 	// This interval might be a default, or could be overridden by logic
 	// that inspects the imageUpdater CR itself for a custom interval.
-	if r.Config.CheckInterval <= 0 {
-		reqLogger.Infof("Requeue interval is not configured or is zero; will not requeue based on time unless an error occurs or explicitly requested.")
+	if r.Config.CheckInterval < 0 {
+		reqLogger.Debugf("Requeue interval is not configured or below zero; will not requeue based on time unless an error occurs or explicitly requested.")
+		return ctrl.Result{}, nil
+	}
+
+	if r.Config.CheckInterval == 0 {
+		reqLogger.Debugf("Requeue interval is zero; will be requeued once.")
+		_, err := RunImageUpdater(r.Config, imageUpdater, false)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
 		return ctrl.Result{}, nil
 	}
 


### PR DESCRIPTION
- Instead of using infinite loop in newRunCommand, we replace it with the built-in Reconcile function.
- Remove Health and Metrics channel conditions checks. They will be replaced with `healthz` and `metricsserver` from controller-runtime manager.