### PR TITLE
Make `alias` unique within `images` and `namePattern` within `applicationRefs`.

### DIFF
--- a/api/v1alpha1/imageupdater_types.go
+++ b/api/v1alpha1/imageupdater_types.go
@@ -45,6 +45,8 @@ type ImageUpdaterSpec struct {
 	// ApplicationRefs is a list of rules to select Argo CD Applications within the `spec.namespace`.
 	// Each reference can also provide specific overrides for the global settings defined above.
 	// +kubebuilder:validation:MinItems=1
+	// +listType=map
+	// +listMapKey=namePattern
 	ApplicationRefs []ApplicationRef `json:"applicationRefs"`
 }
 
@@ -74,6 +76,8 @@ type ApplicationRef struct {
 	// These rules apply to applications selected by namePattern in ApplicationRefs, and each
 	// image can override global/ApplicationRef settings.
 	// +kubebuilder:validation:MinItems=1
+	// +listType=map
+	// +listMapKey=alias
 	Images []ImageConfig `json:"images"`
 }
 
@@ -103,8 +107,10 @@ type GitConfig struct {
 // and how those updates should be reflected in application manifests.
 type ImageConfig struct {
 	// Alias is a short, user-defined name for this image configuration.
+	// It MUST be unique within a single ApplicationRef's list of images.
 	// This field is mandatory.
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z0-9][a-zA-Z0-9-._]*$`
 	Alias string `json:"alias"`
 
 	// ImageName is the full identifier of the image to be tracked,

--- a/config/crd/bases/argocd-image-updater.argoproj.io_imageupdaters.yaml
+++ b/config/crd/bases/argocd-image-updater.argoproj.io_imageupdaters.yaml
@@ -101,7 +101,9 @@ spec:
                           alias:
                             description: |-
                               Alias is a short, user-defined name for this image configuration.
+                              It MUST be unique within a single ApplicationRef's list of images.
                               This field is mandatory.
+                            pattern: ^[a-zA-Z0-9][a-zA-Z0-9-._]*$
                             type: string
                           commonUpdateSettings:
                             description: CommonUpdateSettings overrides the effective
@@ -217,6 +219,9 @@ spec:
                         type: object
                       minItems: 1
                       type: array
+                      x-kubernetes-list-map-keys:
+                      - alias
+                      x-kubernetes-list-type: map
                     labelSelectors:
                       description: LabelSelectors indicates the label selectors to
                         apply for application selection
@@ -310,6 +315,9 @@ spec:
                   type: object
                 minItems: 1
                 type: array
+                x-kubernetes-list-map-keys:
+                - namePattern
+                x-kubernetes-list-type: map
               commonUpdateSettings:
                 description: |-
                   CommonUpdateSettings provides global default settings for update strategies,


### PR DESCRIPTION
[Assigning aliases to images](https://argocd-image-updater.readthedocs.io/en/latest/configuration/images/#assigning-aliases-to-images) doc says:
"Alias names should consist of alphanumerical characters only, and must be **unique** within the same application."

For CRD schema it makes no sense to have the same `aliases` within `images`  and it may lead to misunderstanding:
```
applicationRefs:
  - namePattern: "image-updater-001"
    images:
      - alias: "test1"
        imageName: "test1:1.1.0"
      - alias: "test1"  # <-- Duplicate alias
        imageName: "test2:2.2.0"
```

The namePattern should be unique within a single ImageUpdater CR's applicationRefs list. This creates ambiguity that would force to write merging or precedence logic.
```
spec:
  applicationRefs:
    - namePattern: "app-*"
      images:
        - alias: "nginx"
          imageName: "nginx:1.20"
    - namePattern: "app-*"  # <-- Duplicate namePattern
      images:
        - alias: "redis"
          imageName: "redis:6.0"
```