### PR TITLE
fix: CRD: Move `platforms` in the `commonUpdateSettings`.

### DIFF
--- a/api/v1alpha1/imageupdater_types.go
+++ b/api/v1alpha1/imageupdater_types.go
@@ -127,12 +127,6 @@ type ImageConfig struct {
 	// +optional
 	*CommonUpdateSettings `json:"commonUpdateSettings,omitempty"`
 
-	// Platforms specifies a list of target platforms (e.g., "linux/amd64", "linux/arm64").
-	// If specified, the image updater will consider these platforms when checking for new versions or digests.
-	// +listType=atomic
-	// +optional
-	Platforms []string `json:"platforms,omitempty"`
-
 	// ManifestTarget defines how and where to update this image in Kubernetes manifests.
 	// Only one of Helm or Kustomize should be specified within this block.
 	// This whole block is optional if the image update isn't written to a manifest in a structured way.
@@ -171,6 +165,12 @@ type CommonUpdateSettings struct {
 	// This acts as the default if not overridden.
 	// +optional
 	PullSecret *string `json:"pullSecret,omitempty"`
+
+	// Platforms specifies a list of target platforms (e.g., "linux/amd64", "linux/arm64").
+	// If specified, the image updater will consider these platforms when checking for new versions or digests.
+	// +listType=atomic
+	// +optional
+	Platforms []string `json:"platforms,omitempty"`
 }
 
 // WriteBackConfig defines how and where to write back image updates.

--- a/config/crd/bases/argocd-image-updater.argoproj.io_imageupdaters.yaml
+++ b/config/crd/bases/argocd-image-updater.argoproj.io_imageupdaters.yaml
@@ -75,6 +75,14 @@ spec:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
+                        platforms:
+                          description: |-
+                            Platforms specifies a list of target platforms (e.g., "linux/amd64", "linux/arm64").
+                            If specified, the image updater will consider these platforms when checking for new versions or digests.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
                         pullSecret:
                           description: |-
                             PullSecret is the pull secret to use for images.
@@ -124,6 +132,14 @@ spec:
                                 description: |-
                                   IgnoreTags is a list of glob-like patterns of tags to ignore.
                                   This acts as the default and can be overridden at more specific levels.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              platforms:
+                                description: |-
+                                  Platforms specifies a list of target platforms (e.g., "linux/amd64", "linux/arm64").
+                                  If specified, the image updater will consider these platforms when checking for new versions or digests.
                                 items:
                                   type: string
                                 type: array
@@ -205,14 +221,6 @@ spec:
                             - message: Exactly one of helm or kustomize must be specified
                                 within manifestTargets if the block is present.
                               rule: 'has(self.helm) ? !has(self.kustomize) : has(self.kustomize)'
-                          platforms:
-                            description: |-
-                              Platforms specifies a list of target platforms (e.g., "linux/amd64", "linux/arm64").
-                              If specified, the image updater will consider these platforms when checking for new versions or digests.
-                            items:
-                              type: string
-                            type: array
-                            x-kubernetes-list-type: atomic
                         required:
                         - alias
                         - imageName
@@ -339,6 +347,14 @@ spec:
                     description: |-
                       IgnoreTags is a list of glob-like patterns of tags to ignore.
                       This acts as the default and can be overridden at more specific levels.
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  platforms:
+                    description: |-
+                      Platforms specifies a list of target platforms (e.g., "linux/amd64", "linux/arm64").
+                      If specified, the image updater will consider these platforms when checking for new versions or digests.
                     items:
                       type: string
                     type: array

--- a/config/samples/argocd-image-updater_v1alpha1_imageupdater.yaml
+++ b/config/samples/argocd-image-updater_v1alpha1_imageupdater.yaml
@@ -13,6 +13,7 @@ spec:
     allowTags: "regexp:^[0-9a-f]{7}$"
     ignoreTags: [ "latest", "master" ]
     pullSecret: "secret:<namespace>/<secret_name>#<field>"
+    platforms: [ "linux/arm64", "linux/amd64" ]
   writeBackConfig:
     method: "git:secret:argocd-image-updater/git-creds"
     gitConfig: # Group git-related settings. Should be ignored when writeBackMethod: "argocd"
@@ -31,6 +32,7 @@ spec:
         allowTags: "regexp:^[0-9a-f]{7}$"
         ignoreTags: [ "latest", "master" ]
         pullSecret: "secret:<namespace>/<secret_name>#<field>"
+        platforms: [ "linux/arm64", "linux/amd64" ]
       writeBackConfig:
         method: "git:secret:argocd-image-updater/git-creds"
         gitConfig: # Group git-related settings. Should be ignored when writeBackMethod: "argocd"
@@ -50,7 +52,7 @@ spec:
             allowTags: "regexp:^[0-9a-f]{7}$"
             ignoreTags: [ "latest", "master" ]
             pullSecret: "secret:<namespace>/<secret_name>#<field>"
-          platforms: [ "linux/arm64", "linux/amd64" ]
+            platforms: [ "linux/arm64", "windows" ]
           manifestTargets:
             helm:
               name: "dex.image.name"

--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -409,6 +409,7 @@ func newContainerImageFromCommonSettings(ctx context.Context, settings *iuapi.Co
 			AllowTags:      "",
 			PullSecret:     "",
 			IgnoreTags:     []string{},
+			Platforms:      []string{},
 		}
 	}
 
@@ -432,6 +433,9 @@ func newContainerImageFromCommonSettings(ctx context.Context, settings *iuapi.Co
 	if settings.IgnoreTags != nil {
 		img.IgnoreTags = settings.IgnoreTags
 	}
+	if settings.Platforms != nil {
+		img.Platforms = settings.Platforms
+	}
 
 	return img
 }
@@ -448,7 +452,6 @@ func parseImageListIuCR(ctx context.Context, images []iuapi.ImageConfig, appSett
 		img := newContainerImageFromCommonSettings(ctx, im.CommonUpdateSettings, appSettings)
 		imgIdentity := image.NewFromIdentifier(im.Alias + "=" + im.ImageName)
 		img.ContainerImage = imgIdentity
-		img.Platforms = im.Platforms
 
 		if im.ManifestTarget != nil && im.ManifestTarget.Kustomize != nil {
 			if kustomizeImage := im.ManifestTarget.Kustomize.Name; kustomizeImage != "" {

--- a/pkg/argocd/argocd_test.go
+++ b/pkg/argocd/argocd_test.go
@@ -1179,6 +1179,7 @@ func Test_parseImageListIuCR(t *testing.T) {
 			AllowTags:      "",
 			PullSecret:     "",
 			IgnoreTags:     []string{},
+			Platforms:      []string{},
 		}
 
 		if kustomizeName != "" {


### PR DESCRIPTION
As requested in #1193 we are moving `platforms` slice in `commonUpdateSettings`.