### PR TITLE
Feature/allow empty helm.image-name annotation

### DIFF
--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -517,7 +517,7 @@ func marshalParamsOverride(app *v1alpha1.Application, originalData []byte) ([]by
 
 				if helmAnnotationParamName == "" {
 					// allow empty image-name
-					fmt.Sprintf("no image-name annotation found for image %s", c.ImageName)
+					log.Debugf("no image-name annotation found for image %s", c.ImageName)
 				} else {
 					helmParamName := getHelmParam(appSource.Helm.Parameters, helmAnnotationParamName)
 					if helmParamName == nil {

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -1996,7 +1996,7 @@ replicas: 1
 						Parameters: []v1alpha1.HelmParameter{
 							{
 								Name:        "image.name",
-								Value:       "nginx",
+								Value:       "nginx-other",
 								ForceString: true,
 							},
 							{
@@ -2018,9 +2018,22 @@ replicas: 1
 			},
 		}
 
-		originalData := []byte(`random: yaml`)
-		_, err := marshalParamsOverride(&app, originalData)
+		originalData := []byte(`
+image:
+  registry: docker.io
+  repository: nginx
+  tag: v0.0.0
+`)
+		expected := `
+image:
+  registry: docker.io
+  repository: nginx
+  tag: v1.0.0
+`
+		yaml, err := marshalParamsOverride(&app, originalData)
 		assert.NoError(t, err)
+		assert.NotEmpty(t, yaml)
+		assert.Equal(t, strings.TrimSpace(strings.ReplaceAll(expected, "\t", "  ")), strings.TrimSpace(string(yaml)))
 	})
 
 	t.Run("Image-name annotation value not found in Helm source parameters list", func(t *testing.T) {

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -1977,7 +1977,7 @@ replicas: 1
 		assert.Equal(t, "could not find an image-tag annotation for image nginx", err.Error())
 	})
 
-	t.Run("Missing annotation image-name for helmvalues write-back-target", func(t *testing.T) {
+	t.Run("Allow empty annotation image-name for helmvalues write-back-target", func(t *testing.T) {
 		app := v1alpha1.Application{
 			ObjectMeta: v1.ObjectMeta{
 				Name: "testapp",
@@ -2020,8 +2020,7 @@ replicas: 1
 
 		originalData := []byte(`random: yaml`)
 		_, err := marshalParamsOverride(&app, originalData)
-		assert.Error(t, err)
-		assert.Equal(t, "could not find an image-name annotation for image nginx", err.Error())
+		assert.NoError(t, err)
 	})
 
 	t.Run("Image-name annotation value not found in Helm source parameters list", func(t *testing.T) {

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -1691,12 +1691,12 @@ replicas: 1
 test-value1: one
 nginx:
   image:
-    tag: v1.0.0
     name: nginx
+    tag: v1.0.0
 redis:
   image:
-    tag: v1.0.0
     name: redis
+    tag: v1.0.0
 `
 		yaml, err = marshalParamsOverride(&app, originalData)
 		require.NoError(t, err)
@@ -1938,7 +1938,7 @@ replicas: 1
 					"argocd-image-updater.argoproj.io/image-list":            "nginx",
 					"argocd-image-updater.argoproj.io/write-back-method":     "git",
 					"argocd-image-updater.argoproj.io/write-back-target":     "helmvalues:./test-values.yaml",
-					"argocd-image-updater.argoproj.io/nginx.helm.image-name": "image.name",
+					"argocd-image-updater.argoproj.io/nginx.helm.image-name": "dockerimage.name",
 				},
 			},
 			Spec: v1alpha1.ApplicationSpec{


### PR DESCRIPTION
In case when only image tag is required to update, like:
```yaml
apiVersion: argoproj.io/v1alpha1
kind: Application
metadata:
...
  annotations:
    argocd-image-updater.argoproj.io/image-list: app=harbor.example.com/nginx
    argocd-image-updater.argoproj.io/app.helm.image-tag: image.tag
    argocd-image-updater.argoproj.io/app.update-strategy: newest-build
    argocd-image-updater.argoproj.io/app.allow-tags: regexp:^sha-[0-9a-f]{7}$
    argocd-image-updater.argoproj.io/write-back-target: helmvalues
```
It make no sense to let `argocd-image-updater.argoproj.io/app.helm.image-name` annotation mandatorily, either I have to fill a fake image name value, still it produces meaningless configs in target `.argocd-source` or helm value files.

By this pr, I Supposed to get `values.yaml` file like
```yaml
image:
  registry: harbor.example.com
  repository: nginx
  tag: "sha-xxxx"
```
instead of
```yaml
image:
  registry: harbor.example.com
  name: harbor.example.com/nginx # which actually not used
  repository: nginx
  tag: "sha-xxxx"
```