### PR TITLE
fix(manifests): use secretKeyRef instead of configMapKeyRef for QUAY_WEBHOOK_SECRET; add resource request and limit

### DIFF
--- a/manifests/base/deployment/argocd-image-updater-deployment.yaml
+++ b/manifests/base/deployment/argocd-image-updater-deployment.yaml
@@ -127,7 +127,7 @@ spec:
                 optional: true
         - name: QUAY_WEBHOOK_SECRET
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
                 name: argocd-image-updater-secret
                 key: webhook.quay-secret
                 optional: true
@@ -170,6 +170,13 @@ spec:
             port: 8080
           initialDelaySeconds: 3
           periodSeconds: 30
+        resources:
+          limits:
+            cpu: 500m
+            memory: 1024Mi
+          requests:
+            cpu: 250m
+            memory: 512Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -235,7 +235,7 @@ spec:
               optional: true
         - name: QUAY_WEBHOOK_SECRET
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: webhook.quay-secret
               name: argocd-image-updater-secret
               optional: true
@@ -280,6 +280,13 @@ spec:
             port: 8080
           initialDelaySeconds: 3
           periodSeconds: 30
+        resources:
+          limits:
+            cpu: 500m
+            memory: 1024Mi
+          requests:
+            cpu: 250m
+            memory: 512Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
I copied the resource quest and limit values from crd branch. They feel pretty small, especially the request. For comparison, this is the default resources request and limit for GitOps components: https://docs.redhat.com/en/documentation/red_hat_openshift_gitops/1.18/html-single/installing_gitops/index#sizing-requirements-for-gitops_preparing-gitops-install

If we follow dex, that would be:

```yaml
  resources:
    requests:
      cpu: 250m
      memory: 128Mi
    limits:
      cpu: 500m
      memory: 256Mi
```
@dkarpele WDYT?