### PR TITLE
chore(crd): optimize docker build process

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,22 @@
+.github
 .vscode/
 .idea/
 .DS_Store
+bin/
 dist/
+**/docs/
+**/vendor/
+registry-scanner/config
+registry-scanner/hack
+registry-scanner/test
+scripts/
+test/e2e
+test/testdata
+test/utils
 *.iml
 # delve debug binaries
 cmd/**/debug
 debug.test
 **/coverage.out
+**/CHANGELOG.md
+**/README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN mkdir -p /src/argocd-image-updater
 WORKDIR /src/argocd-image-updater
 # Copy the Go Modules manifests
 COPY go.mod go.sum ./
-COPY registry-scanner ./
+COPY registry-scanner/go.mod registry-scanner/go.sum ./registry-scanner/
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download


### PR DESCRIPTION
- Ignore directories that are not necessary for project building
- It was a bug that `go.mod` was replaced by `registry-scanner/go.mod` in Dockerfile. I fixed that. Content of `registry-scanner` dir will be copied later with `COPY . .`