### PR TITLE
fix: include reference string in invalid reference format error (#1303)

### DIFF
--- a/registry-scanner/pkg/registry/registry.go
+++ b/registry-scanner/pkg/registry/registry.go
@@ -44,6 +44,7 @@ func (ep *RegistryEndpoint) GetTags(ctx context.Context, img *image.ContainerIma
 	}
 	err = regClient.NewRepository(nameInRegistry)
 	if err != nil {
+		logCtx.Errorf("Failed to create repository for image '%s': %v", nameInRegistry, err)
 		return nil, err
 	}
 	tTags, err := regClient.Tags(ctx)


### PR DESCRIPTION
When NewRepository fails to parse an image reference, log the actual reference string that failed validation. This makes it possible to identify which image reference is causing the "invalid reference format" error.

Previously, users would see:
  Could not get tags from registry: invalid reference format

Now users will see:
  Failed to create repository for image 'invalid@reference': invalid reference format

This provides the necessary context to debug configuration issues with malformed image references.

Fixes #1303