### PR TITLE
fix: include reference string in invalid reference format error (#1303)

### DIFF
--- a/registry-scanner/pkg/registry/registry.go
+++ b/registry-scanner/pkg/registry/registry.go
@@ -44,6 +44,7 @@ func (endpoint *RegistryEndpoint) GetTags(img *image.ContainerImage, regClient R
 	}
 	err = regClient.NewRepository(nameInRegistry)
 	if err != nil {
+		logCtx.Errorf("Failed to create repository for image '%s': %v", nameInRegistry, err)
 		return nil, err
 	}
 	tTags, err := regClient.Tags()


### PR DESCRIPTION
PR for `master-annotation-based` branch.

See https://github.com/argoproj-labs/argocd-image-updater/pull/1304
