### PR TITLE
fix(image): avoid repeating registryURL in image.GetFullNameWithoutTag and GetFullNameWithTag func

### DIFF
--- a/registry-scanner/pkg/image/image.go
+++ b/registry-scanner/pkg/image/image.go
@@ -80,7 +80,9 @@ func (img *ContainerImage) String() string {
 func (img *ContainerImage) GetFullNameWithoutTag() string {
 	str := ""
 	if img.RegistryURL != "" {
-		str += img.RegistryURL + "/"
+		if !strings.HasPrefix(img.ImageName, img.RegistryURL+"/") {
+			str += img.RegistryURL + "/"
+		}
 	}
 	str += img.ImageName
 	return str
@@ -91,7 +93,9 @@ func (img *ContainerImage) GetFullNameWithoutTag() string {
 func (img *ContainerImage) GetFullNameWithTag() string {
 	str := ""
 	if img.RegistryURL != "" {
-		str += img.RegistryURL + "/"
+		if !strings.HasPrefix(img.ImageName, img.RegistryURL+"/") {
+			str += img.RegistryURL + "/"
+		}
 	}
 	str += img.ImageName
 	if img.ImageTag != nil {

--- a/registry-scanner/pkg/image/image_test.go
+++ b/registry-scanner/pkg/image/image_test.go
@@ -63,6 +63,13 @@ func Test_ParseImageTags(t *testing.T) {
 		assert.Equal(t, "0.1", image.ImageTag.TagName)
 		assert.Equal(t, "docker.io/jannfis/test-image:0.1", image.GetFullNameWithTag())
 		assert.Equal(t, "docker.io/jannfis/test-image", image.GetFullNameWithoutTag())
+
+		// if the image name starts with registryURL, GetFullNameWithoutTag and GetFullNameWithTag
+		// should return the correct full image name without repeating registryURL.
+		// Wrong full image name: docker.io/docker.io/jannfis/test-image
+		image.ImageName = "docker.io/jannfis/test-image"
+		assert.Equal(t, "docker.io/jannfis/test-image:0.1", image.GetFullNameWithTag())
+		assert.Equal(t, "docker.io/jannfis/test-image", image.GetFullNameWithoutTag())
 	})
 
 	t.Run("Parse valid image name with digest tag", func(t *testing.T) {


### PR DESCRIPTION
when image name contains the registryURL, calling GetFullNameWithTag and GetFullNameWithoutTag func produces malformed full image name (e.g., `image: docker.io/docker.io/bitnamilegacy/nginx:1.27.5`), which causes the pod to fail to start.