### PR TITLE
fix: Pass the context to the ext/git module

### DIFF
--- a/ext/git/git.go
+++ b/ext/git/git.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"net/url"
 	"regexp"
 	"strings"
@@ -83,11 +84,11 @@ func IsHTTPURL(url string) bool {
 }
 
 // TestRepo tests if a repo exists and is accessible with the given credentials
-func TestRepo(repo string, creds Creds, insecure bool, enableLfs bool, proxy string) error {
+func TestRepo(ctx context.Context, repo string, creds Creds, insecure bool, enableLfs bool, proxy string) error {
 	clnt, err := NewClient(repo, creds, insecure, enableLfs, proxy)
 	if err != nil {
 		return err
 	}
-	_, err = clnt.LsRemote("HEAD")
+	_, err = clnt.LsRemote(ctx, "HEAD")
 	return err
 }

--- a/ext/git/mocks/Client.go
+++ b/ext/git/mocks/Client.go
@@ -3,6 +3,8 @@
 package mocks
 
 import (
+	"context"
+
 	git "github.com/argoproj-labs/argocd-image-updater/ext/git"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -13,7 +15,7 @@ type Client struct {
 }
 
 // Add provides a mock function with given fields: path
-func (_m *Client) Add(path string) error {
+func (_m *Client) Add(ctx context.Context, path string) error {
 	ret := _m.Called(path)
 
 	if len(ret) == 0 {
@@ -31,7 +33,7 @@ func (_m *Client) Add(path string) error {
 }
 
 // Branch provides a mock function with given fields: sourceBranch, targetBranch
-func (_m *Client) Branch(sourceBranch string, targetBranch string) error {
+func (_m *Client) Branch(ctx context.Context, sourceBranch string, targetBranch string) error {
 	ret := _m.Called(sourceBranch, targetBranch)
 
 	if len(ret) == 0 {
@@ -49,7 +51,7 @@ func (_m *Client) Branch(sourceBranch string, targetBranch string) error {
 }
 
 // ChangedFiles provides a mock function with given fields: revision, targetRevision
-func (_m *Client) ChangedFiles(revision string, targetRevision string) ([]string, error) {
+func (_m *Client) ChangedFiles(ctx context.Context, revision string, targetRevision string) ([]string, error) {
 	ret := _m.Called(revision, targetRevision)
 
 	if len(ret) == 0 {
@@ -79,7 +81,7 @@ func (_m *Client) ChangedFiles(revision string, targetRevision string) ([]string
 }
 
 // Checkout provides a mock function with given fields: revision, submoduleEnabled
-func (_m *Client) Checkout(revision string, submoduleEnabled bool) error {
+func (_m *Client) Checkout(ctx context.Context, revision string, submoduleEnabled bool) error {
 	ret := _m.Called(revision, submoduleEnabled)
 
 	if len(ret) == 0 {
@@ -97,7 +99,7 @@ func (_m *Client) Checkout(revision string, submoduleEnabled bool) error {
 }
 
 // Commit provides a mock function with given fields: pathSpec, opts
-func (_m *Client) Commit(pathSpec string, opts *git.CommitOptions) error {
+func (_m *Client) Commit(ctx context.Context, pathSpec string, opts *git.CommitOptions) error {
 	ret := _m.Called(pathSpec, opts)
 
 	if len(ret) == 0 {
@@ -115,7 +117,7 @@ func (_m *Client) Commit(pathSpec string, opts *git.CommitOptions) error {
 }
 
 // CommitSHA provides a mock function with given fields:
-func (_m *Client) CommitSHA() (string, error) {
+func (_m *Client) CommitSHA(context.Context) (string, error) {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
@@ -143,7 +145,7 @@ func (_m *Client) CommitSHA() (string, error) {
 }
 
 // Config provides a mock function with given fields: username, email
-func (_m *Client) Config(username string, email string) error {
+func (_m *Client) Config(ctx context.Context, username string, email string) error {
 	ret := _m.Called(username, email)
 
 	if len(ret) == 0 {
@@ -175,7 +177,7 @@ func (_m *Client) SigningConfig(signingkey string) error {
 }
 
 // Fetch provides a mock function with given fields: revision
-func (_m *Client) Fetch(revision string) error {
+func (_m *Client) Fetch(ctx context.Context, revision string) error {
 	ret := _m.Called(revision)
 
 	if len(ret) == 0 {
@@ -193,7 +195,7 @@ func (_m *Client) Fetch(revision string) error {
 }
 
 // Fetch provides a mock function with given fields: revision
-func (_m *Client) ShallowFetch(revision string, depth int) error {
+func (_m *Client) ShallowFetch(ctx context.Context, revision string, depth int) error {
 	ret := _m.Called(revision)
 
 	if len(ret) == 0 {
@@ -211,7 +213,7 @@ func (_m *Client) ShallowFetch(revision string, depth int) error {
 }
 
 // Init provides a mock function with given fields:
-func (_m *Client) Init() error {
+func (_m *Client) Init(context.Context) error {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
@@ -229,8 +231,8 @@ func (_m *Client) Init() error {
 }
 
 // IsAnnotatedTag provides a mock function with given fields: _a0
-func (_m *Client) IsAnnotatedTag(_a0 string) bool {
-	ret := _m.Called(_a0)
+func (_m *Client) IsAnnotatedTag(ctx context.Context, revision string) bool {
+	ret := _m.Called(revision)
 
 	if len(ret) == 0 {
 		panic("no return value specified for IsAnnotatedTag")
@@ -238,7 +240,7 @@ func (_m *Client) IsAnnotatedTag(_a0 string) bool {
 
 	var r0 bool
 	if rf, ok := ret.Get(0).(func(string) bool); ok {
-		r0 = rf(_a0)
+		r0 = rf(revision)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
@@ -247,7 +249,7 @@ func (_m *Client) IsAnnotatedTag(_a0 string) bool {
 }
 
 // LsFiles provides a mock function with given fields: path, enableNewGitFileGlobbing
-func (_m *Client) LsFiles(path string, enableNewGitFileGlobbing bool) ([]string, error) {
+func (_m *Client) LsFiles(ctx context.Context, path string, enableNewGitFileGlobbing bool) ([]string, error) {
 	ret := _m.Called(path, enableNewGitFileGlobbing)
 
 	if len(ret) == 0 {
@@ -277,7 +279,7 @@ func (_m *Client) LsFiles(path string, enableNewGitFileGlobbing bool) ([]string,
 }
 
 // LsLargeFiles provides a mock function with given fields:
-func (_m *Client) LsLargeFiles() ([]string, error) {
+func (_m *Client) LsLargeFiles(context.Context) ([]string, error) {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
@@ -307,7 +309,7 @@ func (_m *Client) LsLargeFiles() ([]string, error) {
 }
 
 // LsRefs provides a mock function with given fields:
-func (_m *Client) LsRefs() (*git.Refs, error) {
+func (_m *Client) LsRefs(context.Context) (*git.Refs, error) {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
@@ -337,7 +339,7 @@ func (_m *Client) LsRefs() (*git.Refs, error) {
 }
 
 // LsRemote provides a mock function with given fields: revision
-func (_m *Client) LsRemote(revision string) (string, error) {
+func (_m *Client) LsRemote(ctx context.Context, revision string) (string, error) {
 	ret := _m.Called(revision)
 
 	if len(ret) == 0 {
@@ -365,7 +367,7 @@ func (_m *Client) LsRemote(revision string) (string, error) {
 }
 
 // Push provides a mock function with given fields: remote, branch, force
-func (_m *Client) Push(remote string, branch string, force bool) error {
+func (_m *Client) Push(ctx context.Context, remote string, branch string, force bool) error {
 	ret := _m.Called(remote, branch, force)
 
 	if len(ret) == 0 {
@@ -383,7 +385,7 @@ func (_m *Client) Push(remote string, branch string, force bool) error {
 }
 
 // RevisionMetadata provides a mock function with given fields: revision
-func (_m *Client) RevisionMetadata(revision string) (*git.RevisionMetadata, error) {
+func (_m *Client) RevisionMetadata(ctx context.Context, revision string) (*git.RevisionMetadata, error) {
 	ret := _m.Called(revision)
 
 	if len(ret) == 0 {
@@ -431,7 +433,7 @@ func (_m *Client) Root() string {
 }
 
 // Submodule provides a mock function with given fields:
-func (_m *Client) Submodule() error {
+func (_m *Client) Submodule(context.Context) error {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
@@ -449,7 +451,7 @@ func (_m *Client) Submodule() error {
 }
 
 // SymRefToBranch provides a mock function with given fields: symRef
-func (_m *Client) SymRefToBranch(symRef string) (string, error) {
+func (_m *Client) SymRefToBranch(ctx context.Context, symRef string) (string, error) {
 	ret := _m.Called(symRef)
 
 	if len(ret) == 0 {
@@ -477,8 +479,8 @@ func (_m *Client) SymRefToBranch(symRef string) (string, error) {
 }
 
 // VerifyCommitSignature provides a mock function with given fields: _a0
-func (_m *Client) VerifyCommitSignature(_a0 string) (string, error) {
-	ret := _m.Called(_a0)
+func (_m *Client) VerifyCommitSignature(ctx context.Context, revision string) (string, error) {
+	ret := _m.Called(revision)
 
 	if len(ret) == 0 {
 		panic("no return value specified for VerifyCommitSignature")
@@ -487,16 +489,16 @@ func (_m *Client) VerifyCommitSignature(_a0 string) (string, error) {
 	var r0 string
 	var r1 error
 	if rf, ok := ret.Get(0).(func(string) (string, error)); ok {
-		return rf(_a0)
+		return rf(revision)
 	}
 	if rf, ok := ret.Get(0).(func(string) string); ok {
-		r0 = rf(_a0)
+		r0 = rf(revision)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
 	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(_a0)
+		r1 = rf(revision)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/ext/git/mocks/Creds.go
+++ b/ext/git/mocks/Creds.go
@@ -3,6 +3,7 @@
 package mocks
 
 import (
+	"context"
 	io "io"
 
 	mock "github.com/stretchr/testify/mock"
@@ -14,7 +15,7 @@ type Creds struct {
 }
 
 // Environ provides a mock function with given fields:
-func (_m *Creds) Environ() (io.Closer, []string, error) {
+func (_m *Creds) Environ(context.Context) (io.Closer, []string, error) {
 	ret := _m.Called()
 
 	var r0 io.Closer

--- a/ext/git/mocks/GenericHTTPSCreds.go
+++ b/ext/git/mocks/GenericHTTPSCreds.go
@@ -3,6 +3,7 @@
 package mocks
 
 import (
+	"context"
 	io "io"
 
 	mock "github.com/stretchr/testify/mock"
@@ -14,7 +15,7 @@ type GenericHTTPSCreds struct {
 }
 
 // Environ provides a mock function with given fields:
-func (_m *GenericHTTPSCreds) Environ() (io.Closer, []string, error) {
+func (_m *GenericHTTPSCreds) Environ(context.Context) (io.Closer, []string, error) {
 	ret := _m.Called()
 
 	var r0 io.Closer

--- a/ext/git/workaround.go
+++ b/ext/git/workaround.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"fmt"
 	neturl "net/url"
 
@@ -16,8 +17,8 @@ import (
 // As workaround methods `newUploadPackSession`, `newClient` and `listRemote` were copied from https://github.com/src-d/go-git/blob/master/remote.go and modified to use
 // transport with InsecureSkipVerify flag is verification should be disabled.
 
-func newUploadPackSession(url string, auth transport.AuthMethod, insecure bool, creds Creds, proxy string) (transport.UploadPackSession, error) {
-	c, ep, err := newClient(url, insecure, creds, proxy)
+func newUploadPackSession(ctx context.Context, url string, auth transport.AuthMethod, insecure bool, creds Creds, proxy string) (transport.UploadPackSession, error) {
+	c, ep, err := newClient(ctx, url, insecure, creds, proxy)
 	if err != nil {
 		return nil, err
 	}
@@ -25,7 +26,7 @@ func newUploadPackSession(url string, auth transport.AuthMethod, insecure bool, 
 	return c.NewUploadPackSession(ep, auth)
 }
 
-func newClient(url string, insecure bool, creds Creds, proxy string) (transport.Transport, *transport.Endpoint, error) {
+func newClient(ctx context.Context, url string, insecure bool, creds Creds, proxy string) (transport.Transport, *transport.Endpoint, error) {
 	ep, err := transport.NewEndpoint(url)
 	if err != nil {
 		return nil, nil, err
@@ -57,11 +58,11 @@ func newClient(url string, insecure bool, creds Creds, proxy string) (transport.
 		return c, ep, nil
 	}
 
-	return http.NewClient(GetRepoHTTPClient(url, insecure, creds, proxy)), ep, nil
+	return http.NewClient(GetRepoHTTPClient(ctx, url, insecure, creds, proxy)), ep, nil
 }
 
-func listRemote(r *git.Remote, o *git.ListOptions, insecure bool, creds Creds, proxy string) (rfs []*plumbing.Reference, err error) {
-	s, err := newUploadPackSession(r.Config().URLs[0], o.Auth, insecure, creds, proxy)
+func listRemote(ctx context.Context, r *git.Remote, o *git.ListOptions, insecure bool, creds Creds, proxy string) (rfs []*plumbing.Reference, err error) {
+	s, err := newUploadPackSession(ctx, r.Config().URLs[0], o.Auth, insecure, creds, proxy)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Pass the context to `ext/git` module to correctly show log lines:
For example 
https://github.com/argoproj-labs/argocd-image-updater/blob/950af4b2c92ab616a2a79e190de734e73c778204/ext/git/client.go#L329

will be shown with the context, like this:
```
{"application":"argocd-image-updater-e2e/image-updater-007","controller":"imageupdater","controllerGroup":"argocd-image-updater.argoproj.io","controllerKind":"ImageUpdater","imageUpdater_name":"image-updater-007-2","imageUpdater_namespace":"argocd-image-updater-e2e","level":"info","logger":"reconcile","msg":"Initializing https://127.0.0.1:30003/testdata.git to /var/folders/2j/0pgmqhq95pv6l80wmfl7fdxc0000gn/T/git-image-updater-0071719812720","time":"2025-10-31T18:45:16+01:00"}
```

- Configure the global logger for argo-cd utilities in `run.go`. This will solve the problem with log formatting for "git" log messages. With the flag `--logformat=json` log will look like:
```
{"application":"argocd-image-updater-e2e/image-updater-007","controller":"imageupdater","controllerGroup":"argocd-image-updater.argoproj.io","controllerKind":"ImageUpdater","imageUpdater_name":"image-updater-007-2","imageUpdater_namespace":"argocd-image-updater-e2e","level":"info","logger":"reconcile","msg":"Initializing https://127.0.0.1:30003/testdata.git to /var/folders/2j/0pgmqhq95pv6l80wmfl7fdxc0000gn/T/git-image-updater-0071031222387","time":"2025-10-31T21:05:18+01:00"}
{"application":"argocd-image-updater-e2e/image-updater-007","controller":"imageupdater","controllerGroup":"argocd-image-updater.argoproj.io","controllerKind":"ImageUpdater","imageUpdater_name":"image-updater-007-2","imageUpdater_namespace":"argocd-image-updater-e2e","level":"trace","logger":"reconcile","msg":"targetRevision for update is 'master'","time":"2025-10-31T21:05:18+01:00"}
{"dir":"/var/folders/2j/0pgmqhq95pv6l80wmfl7fdxc0000gn/T/git-image-updater-0071031222387","execID":"18901","level":"info","msg":"git fetch origin master --force --prune --depth 1","time":"2025-10-31T21:05:18+01:00"}
{"duration":1589209875,"execID":"18901","level":"debug","msg":"","time":"2025-10-31T21:05:19+01:00"}
{"args":"[git fetch origin master --force --prune --depth 1]","dir":"/var/folders/2j/0pgmqhq95pv6l80wmfl7fdxc0000gn/T/git-image-updater-0071031222387","level":"info","msg":"Trace","operation_name":"exec git","time":"2025-10-31T21:05:19+01:00","time_ms":1589.2935420000001}
{"dir":"/var/folders/2j/0pgmqhq95pv6l80wmfl7fdxc0000gn/T/git-image-updater-0071031222387","execID":"82914","level":"info","msg":"git checkout --force master","time":"2025-10-31T21:05:19+01:00"}
{"duration":14332042,"execID":"82914","level":"debug","msg":"branch 'master' set up to track 'origin/master'.\n","time":"2025-10-31T21:05:19+01:00"}
{"args":"[git checkout --force master]","dir":"/var/folders/2j/0pgmqhq95pv6l80wmfl7fdxc0000gn/T/git-image-updater-0071031222387","level":"info","msg":"Trace","operation_name":"exec git","time":"2025-10-31T21:05:19+01:00","time_ms":14.409459}
{"dir":"/var/folders/2j/0pgmqhq95pv6l80wmfl7fdxc0000gn/T/git-image-updater-0071031222387","execID":"a6ae2","level":"info","msg":"git clean -ffdx","time":"2025-10-31T21:05:19+01:00"}
{"duration":6248292,"execID":"a6ae2","level":"debug","msg":"","time":"2025-10-31T21:05:19+01:00"}
{"args":"[git clean -ffdx]","dir":"/var/folders/2j/0pgmqhq95pv6l80wmfl7fdxc0000gn/T/git-image-updater-0071031222387","level":"info","msg":"Trace","operation_name":"exec git","time":"2025-10-31T21:05:19+01:00","time_ms":6.322125}
...
```

These messages still don't have context. To fix this we should re-implement the function `executil.RunWithExecRunOpts`. It requires more work. See GITOPS-8087