### PR TITLE
fix(helmvalues): write helm image-name with or without registry url

### DIFF
--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -2477,6 +2477,405 @@ nginx:
 		assert.NotEmpty(t, yaml)
 		assert.Equal(t, strings.TrimSpace(strings.ReplaceAll(expected, "\t", "  ")), strings.TrimSpace(string(yaml)))
 	})
+
+	t.Run("Original data with short form image name and long form in new - should convert to short form", func(t *testing.T) {
+		expected := `
+image:
+  registry: docker.io
+  name: bitnami/nginx
+  tag: v1.0.0
+replicas: 1
+`
+		app := v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "testapp",
+			},
+			Spec: v1alpha1.ApplicationSpec{
+				Source: &v1alpha1.ApplicationSource{
+					RepoURL:        "https://example.com/example",
+					TargetRevision: "main",
+					Helm: &v1alpha1.ApplicationSourceHelm{
+						Parameters: []v1alpha1.HelmParameter{
+							{
+								Name:        "image.name",
+								Value:       "docker.io/bitnami/nginx",
+								ForceString: true,
+							},
+							{
+								Name:        "image.tag",
+								Value:       "v1.0.0",
+								ForceString: true,
+							},
+						},
+					},
+				},
+			},
+			Status: v1alpha1.ApplicationStatus{
+				SourceType: v1alpha1.ApplicationSourceTypeHelm,
+				Summary: v1alpha1.ApplicationSummary{
+					Images: []string{
+						"nginx:v0.0.0",
+					},
+				},
+			},
+		}
+
+		// Original has short form - should convert long form to short form
+		originalData := []byte(`
+image:
+  registry: docker.io
+  name: bitnami/nginx
+  tag: v0.0.0
+replicas: 1
+`)
+		im := NewImage(image.NewFromIdentifier("nginx"))
+		im.ImageAlias = "nginx"
+		im.HelmImageName = "image.name"
+		im.HelmImageTag = "image.tag"
+		applicationImages := &ApplicationImages{
+			Application: app,
+			Images:      ImageList{im},
+			WriteBackConfig: &WriteBackConfig{
+				Method: WriteBackGit,
+				Target: "helmvalues:./test-values.yaml",
+			},
+		}
+
+		yamlOutput, err := marshalParamsOverride(context.Background(), applicationImages, originalData)
+		require.NoError(t, err)
+		assert.NotEmpty(t, yamlOutput)
+		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(yamlOutput)))
+	})
+
+	t.Run("Original data with long form image name - should use long form", func(t *testing.T) {
+		expected := `
+image:
+  name: docker.io/bitnami/nginx
+  tag: v1.0.0
+replicas: 1
+`
+		app := v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "testapp",
+			},
+			Spec: v1alpha1.ApplicationSpec{
+				Source: &v1alpha1.ApplicationSource{
+					RepoURL:        "https://example.com/example",
+					TargetRevision: "main",
+					Helm: &v1alpha1.ApplicationSourceHelm{
+						Parameters: []v1alpha1.HelmParameter{
+							{
+								Name:        "image.name",
+								Value:       "docker.io/bitnami/nginx",
+								ForceString: true,
+							},
+							{
+								Name:        "image.tag",
+								Value:       "v1.0.0",
+								ForceString: true,
+							},
+						},
+					},
+				},
+			},
+			Status: v1alpha1.ApplicationStatus{
+				SourceType: v1alpha1.ApplicationSourceTypeHelm,
+				Summary: v1alpha1.ApplicationSummary{
+					Images: []string{
+						"nginx:v0.0.0",
+					},
+				},
+			},
+		}
+
+		// Original has long form - should keep long form
+		originalData := []byte(`
+image:
+  name: docker.io/bitnami/nginx
+  tag: v0.0.0
+replicas: 1
+`)
+		im := NewImage(image.NewFromIdentifier("nginx"))
+		im.ImageAlias = "nginx"
+		im.HelmImageName = "image.name"
+		im.HelmImageTag = "image.tag"
+		applicationImages := &ApplicationImages{
+			Application: app,
+			Images:      ImageList{im},
+			WriteBackConfig: &WriteBackConfig{
+				Method: WriteBackGit,
+				Target: "helmvalues:./test-values.yaml",
+			},
+		}
+
+		yamlOutput, err := marshalParamsOverride(context.Background(), applicationImages, originalData)
+		require.NoError(t, err)
+		assert.NotEmpty(t, yamlOutput)
+		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(yamlOutput)))
+	})
+
+	t.Run("Non-empty original data with short form in original and short form in new - should use short form", func(t *testing.T) {
+		expected := `
+image:
+  registry: docker.io
+  name: bitnami/nginx
+  tag: v1.0.0
+replicas: 1
+`
+		app := v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "testapp",
+			},
+			Spec: v1alpha1.ApplicationSpec{
+				Source: &v1alpha1.ApplicationSource{
+					RepoURL:        "https://example.com/example",
+					TargetRevision: "main",
+					Helm: &v1alpha1.ApplicationSourceHelm{
+						Parameters: []v1alpha1.HelmParameter{
+							{
+								Name:        "image.name",
+								Value:       "bitnami/nginx",
+								ForceString: true,
+							},
+							{
+								Name:        "image.tag",
+								Value:       "v1.0.0",
+								ForceString: true,
+							},
+						},
+					},
+				},
+			},
+			Status: v1alpha1.ApplicationStatus{
+				SourceType: v1alpha1.ApplicationSourceTypeHelm,
+				Summary: v1alpha1.ApplicationSummary{
+					Images: []string{
+						"nginx:v0.0.0",
+					},
+				},
+			},
+		}
+
+		// Original has short form and new has short form - should use short form
+		originalData := []byte(`
+image:
+  registry: docker.io
+  name: bitnami/nginx
+  tag: v0.0.0
+replicas: 1
+`)
+		im := NewImage(image.NewFromIdentifier("nginx"))
+		im.ImageAlias = "nginx"
+		im.HelmImageName = "image.name"
+		im.HelmImageTag = "image.tag"
+		applicationImages := &ApplicationImages{
+			Application: app,
+			Images:      ImageList{im},
+			WriteBackConfig: &WriteBackConfig{
+				Method: WriteBackGit,
+				Target: "helmvalues:./test-values.yaml",
+			},
+		}
+
+		yamlOutput, err := marshalParamsOverride(context.Background(), applicationImages, originalData)
+		require.NoError(t, err)
+		assert.NotEmpty(t, yamlOutput)
+		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(yamlOutput)))
+	})
+}
+
+func Test_GetHelmValue(t *testing.T) {
+	t.Run("Get nested path value", func(t *testing.T) {
+		inputData := []byte(`
+image:
+  attributes:
+    name: repo-name
+    tag: v1.0.0
+`)
+		input := yaml.Node{}
+		err := yaml.Unmarshal(inputData, &input)
+		require.NoError(t, err)
+
+		value, err := getHelmValue(&input, "image.attributes.tag")
+		require.NoError(t, err)
+		assert.Equal(t, "v1.0.0", value)
+	})
+
+	t.Run("Get literal key with dots", func(t *testing.T) {
+		inputData := []byte(`image.attributes.tag: v1.0.0`)
+		input := yaml.Node{}
+		err := yaml.Unmarshal(inputData, &input)
+		require.NoError(t, err)
+
+		value, err := getHelmValue(&input, "image.attributes.tag")
+		require.NoError(t, err)
+		assert.Equal(t, "v1.0.0", value)
+	})
+
+	t.Run("Get root level key", func(t *testing.T) {
+		inputData := []byte(`
+name: repo-name
+tag: v1.0.0
+`)
+		input := yaml.Node{}
+		err := yaml.Unmarshal(inputData, &input)
+		require.NoError(t, err)
+
+		value, err := getHelmValue(&input, "name")
+		require.NoError(t, err)
+		assert.Equal(t, "repo-name", value)
+	})
+
+	t.Run("Get nested path when literal key also exists", func(t *testing.T) {
+		inputData := []byte(`
+image:
+  attributes:
+    tag: nested-value
+image.attributes.tag: literal-value
+`)
+		input := yaml.Node{}
+		err := yaml.Unmarshal(inputData, &input)
+		require.NoError(t, err)
+
+		// Should prefer nested path
+		value, err := getHelmValue(&input, "image.attributes.tag")
+		require.NoError(t, err)
+		assert.Equal(t, "nested-value", value)
+	})
+
+	t.Run("Get literal key when nested path doesn't exist", func(t *testing.T) {
+		inputData := []byte(`
+image.attributes.tag: literal-value
+other:
+  field: value
+`)
+		input := yaml.Node{}
+		err := yaml.Unmarshal(inputData, &input)
+		require.NoError(t, err)
+
+		value, err := getHelmValue(&input, "image.attributes.tag")
+		require.NoError(t, err)
+		assert.Equal(t, "literal-value", value)
+	})
+
+	t.Run("Get value from alias node", func(t *testing.T) {
+		inputData := []byte(`
+image:
+  attributes: &attrs
+    name: repo-name
+    tag: v1.0.0
+other:
+  attributes: *attrs
+`)
+		input := yaml.Node{}
+		err := yaml.Unmarshal(inputData, &input)
+		require.NoError(t, err)
+
+		value, err := getHelmValue(&input, "other.attributes.tag")
+		require.NoError(t, err)
+		assert.Equal(t, "v1.0.0", value)
+	})
+
+	t.Run("Get value from array with index", func(t *testing.T) {
+		inputData := []byte(`
+images:
+  - name: image1
+    tag: v1.0.0
+  - name: image2
+    tag: v2.0.0
+`)
+		input := yaml.Node{}
+		err := yaml.Unmarshal(inputData, &input)
+		require.NoError(t, err)
+
+		value, err := getHelmValue(&input, "images[1].tag")
+		require.NoError(t, err)
+		assert.Equal(t, "v2.0.0", value)
+	})
+
+	t.Run("Key not found returns error", func(t *testing.T) {
+		inputData := []byte(`
+image:
+  attributes:
+    name: repo-name
+`)
+		input := yaml.Node{}
+		err := yaml.Unmarshal(inputData, &input)
+		require.NoError(t, err)
+
+		_, err = getHelmValue(&input, "image.attributes.tag")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("Empty document node returns error", func(t *testing.T) {
+		input := yaml.Node{
+			Kind: yaml.DocumentNode,
+		}
+
+		_, err := getHelmValue(&input, "key")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty document node")
+	})
+
+	t.Run("Invalid root type returns error", func(t *testing.T) {
+		input := yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Value: "not-a-map",
+		}
+
+		_, err := getHelmValue(&input, "key")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unexpected type")
+	})
+
+	t.Run("Literal key found but not scalar returns error", func(t *testing.T) {
+		inputData := []byte(`
+image.attributes.tag:
+  nested: value
+`)
+		input := yaml.Node{}
+		err := yaml.Unmarshal(inputData, &input)
+		require.NoError(t, err)
+
+		_, err = getHelmValue(&input, "image.attributes.tag")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a scalar value")
+	})
+
+	t.Run("Deep nested path", func(t *testing.T) {
+		inputData := []byte(`
+level1:
+  level2:
+    level3:
+      level4:
+        value: deep-value
+`)
+		input := yaml.Node{}
+		err := yaml.Unmarshal(inputData, &input)
+		require.NoError(t, err)
+
+		value, err := getHelmValue(&input, "level1.level2.level3.level4.value")
+		require.NoError(t, err)
+		assert.Equal(t, "deep-value", value)
+	})
+
+	t.Run("Nested path with non-scalar final value falls back to literal", func(t *testing.T) {
+		inputData := []byte(`
+image:
+  attributes: value-not-nested
+image.attributes.tag: literal-value
+`)
+		input := yaml.Node{}
+		err := yaml.Unmarshal(inputData, &input)
+		require.NoError(t, err)
+
+		// When image.attributes is a scalar (not a map), nested path fails
+		// Should fall back to literal key if it exists
+		value, err := getHelmValue(&input, "image.attributes.tag")
+		require.NoError(t, err)
+		assert.Equal(t, "literal-value", value)
+	})
 }
 
 func Test_SetHelmValue(t *testing.T) {

--- a/registry-scanner/pkg/image/image.go
+++ b/registry-scanner/pkg/image/image.go
@@ -263,6 +263,32 @@ func getImageDigestFromTag(tagStr string) (string, string) {
 	}
 }
 
+// HasRegistryPrefix checks if an image name is in long form (has a registry URL prefix).
+// A long form image name has a registry URL like "docker.io/bitnami/nginx" or "gcr.io/myproject/image".
+// A short form is like "bitnami/nginx".
+func HasRegistryPrefix(imageName string) bool {
+	parts := strings.Split(imageName, "/")
+	if len(parts) > 1 {
+		// Check if the first part contains a dot, which indicates it's a registry domain
+		return strings.Contains(parts[0], ".")
+	}
+	return false
+}
+
+// ExtractShortForm extracts the short form from a long form image name by removing the registry prefix.
+// For example, "docker.io/bitnami/nginx" becomes "bitnami/nginx".
+// If the image is already in short form, it returns the original string.
+func ExtractShortForm(imageName string) string {
+	if !HasRegistryPrefix(imageName) {
+		return imageName
+	}
+	parts := strings.SplitN(imageName, "/", 2)
+	if len(parts) == 2 {
+		return parts[1]
+	}
+	return imageName
+}
+
 // LogContext returns a log context for the given image, with required fields
 // set to the image's information.
 func (img *ContainerImage) LogContext() *log.LogContext {

--- a/registry-scanner/pkg/image/image_test.go
+++ b/registry-scanner/pkg/image/image_test.go
@@ -231,3 +231,101 @@ func TestContainerImage_DiffersFrom(t *testing.T) {
 
 	assert.False(t, foo1.IsUpdatable("0.1", "^1.0"))
 }
+
+func Test_HasRegistryPrefix(t *testing.T) {
+	t.Run("Short form without registry", func(t *testing.T) {
+		assert.False(t, HasRegistryPrefix("bitnami/nginx"))
+		assert.False(t, HasRegistryPrefix("jannfis/test-image"))
+		assert.False(t, HasRegistryPrefix("library/test-image"))
+	})
+
+	t.Run("Long form with registry", func(t *testing.T) {
+		assert.True(t, HasRegistryPrefix("docker.io/bitnami/nginx"))
+		assert.True(t, HasRegistryPrefix("gcr.io/myproject/image"))
+		assert.True(t, HasRegistryPrefix("registry.example.com/image"))
+		assert.True(t, HasRegistryPrefix("quay.io/org/repo"))
+	})
+
+	t.Run("Single element without registry", func(t *testing.T) {
+		assert.False(t, HasRegistryPrefix("nginx"))
+		assert.False(t, HasRegistryPrefix("test-image"))
+	})
+
+	t.Run("Long form with IP address registry", func(t *testing.T) {
+		assert.True(t, HasRegistryPrefix("192.168.1.1:5000/image"))
+		assert.True(t, HasRegistryPrefix("10.0.0.1/image"))
+	})
+
+	t.Run("Edge cases", func(t *testing.T) {
+		// Empty string
+		assert.False(t, HasRegistryPrefix(""))
+
+		// String with slash but no dot (not a registry)
+		assert.False(t, HasRegistryPrefix("org/repo"))
+
+		// String starting with slash
+		assert.False(t, HasRegistryPrefix("/image"))
+
+		// Multiple dots in first part (still a registry)
+		assert.True(t, HasRegistryPrefix("my.registry.example.com/image"))
+	})
+
+	t.Run("Registry with port", func(t *testing.T) {
+		assert.True(t, HasRegistryPrefix("registry.example.com:5000/image"))
+		// localhost:5000 doesn't have a dot, so it's not detected as a registry
+		// This is expected behavior - registry detection requires a dot in the first part
+		assert.False(t, HasRegistryPrefix("localhost:5000/image"))
+	})
+}
+
+func Test_ExtractShortForm(t *testing.T) {
+	t.Run("Extract from long form", func(t *testing.T) {
+		assert.Equal(t, "bitnami/nginx", ExtractShortForm("docker.io/bitnami/nginx"))
+		assert.Equal(t, "myproject/image", ExtractShortForm("gcr.io/myproject/image"))
+		assert.Equal(t, "org/repo", ExtractShortForm("quay.io/org/repo"))
+	})
+
+	t.Run("Short form remains unchanged", func(t *testing.T) {
+		assert.Equal(t, "bitnami/nginx", ExtractShortForm("bitnami/nginx"))
+		assert.Equal(t, "jannfis/test-image", ExtractShortForm("jannfis/test-image"))
+		assert.Equal(t, "library/test-image", ExtractShortForm("library/test-image"))
+	})
+
+	t.Run("Single element remains unchanged", func(t *testing.T) {
+		assert.Equal(t, "nginx", ExtractShortForm("nginx"))
+		assert.Equal(t, "test-image", ExtractShortForm("test-image"))
+	})
+
+	t.Run("Registry with port", func(t *testing.T) {
+		assert.Equal(t, "image", ExtractShortForm("registry.example.com:5000/image"))
+		// localhost:5000 doesn't have a dot, so it's treated as short form
+		// This is expected behavior - registry detection requires a dot in the first part
+		assert.Equal(t, "localhost:5000/image", ExtractShortForm("localhost:5000/image"))
+	})
+
+	t.Run("Registry with multiple path segments", func(t *testing.T) {
+		assert.Equal(t, "deep/nested/path/image", ExtractShortForm("gcr.io/deep/nested/path/image"))
+		assert.Equal(t, "a/b/c", ExtractShortForm("docker.io/a/b/c"))
+	})
+
+	t.Run("Edge cases", func(t *testing.T) {
+		// Empty string
+		assert.Equal(t, "", ExtractShortForm(""))
+
+		// Only registry (no image name)
+		assert.Equal(t, "", ExtractShortForm("docker.io/"))
+
+		// String with slash but no registry (no dot)
+		assert.Equal(t, "org/repo", ExtractShortForm("org/repo"))
+	})
+
+	t.Run("IP address registry", func(t *testing.T) {
+		assert.Equal(t, "image", ExtractShortForm("192.168.1.1:5000/image"))
+		assert.Equal(t, "image", ExtractShortForm("10.0.0.1/image"))
+	})
+
+	t.Run("Multiple dots in registry name", func(t *testing.T) {
+		assert.Equal(t, "image", ExtractShortForm("my.registry.example.com/image"))
+		assert.Equal(t, "path/to/image", ExtractShortForm("my.registry.example.com/path/to/image"))
+	})
+}


### PR DESCRIPTION
Assisted-by: Cursor

Fixes #974 in master branch, by applying the fix in PR #1312 from `master-annotation-based` branch