### PR TITLE
fix: configure the global logger for argo-cd utilities

### DIFF
--- a/ext/git/client.go
+++ b/ext/git/client.go
@@ -24,7 +24,6 @@ import (
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/google/uuid"
-	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/knownhosts"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -35,6 +34,8 @@ import (
 	"github.com/argoproj/argo-cd/v3/util/env"
 	executil "github.com/argoproj/argo-cd/v3/util/exec"
 	"github.com/argoproj/argo-cd/v3/util/proxy"
+
+	"github.com/argoproj-labs/argocd-image-updater/registry-scanner/pkg/log"
 )
 
 var ErrInvalidRepoURL = fmt.Errorf("repo URL is invalid")
@@ -489,7 +490,7 @@ func (m *nativeGitClient) getRefs() ([]*plumbing.Reference, error) {
 	myLockUUID, err := uuid.NewRandom()
 	myLockId := ""
 	if err != nil {
-		log.Debug("Error generating git references cache lock id: ", err)
+		log.Debugf("Error generating git references cache lock id: %v", err)
 	} else {
 		myLockId = myLockUUID.String()
 	}

--- a/ext/git/creds.go
+++ b/ext/git/creds.go
@@ -22,11 +22,12 @@ import (
 	argoio "github.com/argoproj/gitops-engine/pkg/utils/io"
 	"github.com/argoproj/gitops-engine/pkg/utils/text"
 	"github.com/bradleyfalzon/ghinstallation/v2"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/argoproj/argo-cd/v3/common"
 	certutil "github.com/argoproj/argo-cd/v3/util/cert"
 	argoioutils "github.com/argoproj/argo-cd/v3/util/io"
+
+	"github.com/argoproj-labs/argocd-image-updater/registry-scanner/pkg/log"
 )
 
 var (
@@ -286,10 +287,10 @@ func (c SSHCreds) Environ() (io.Closer, []string, error) {
 	}
 	defer func() {
 		if err = file.Close(); err != nil {
-			log.WithFields(log.Fields{
-				common.SecurityField:    common.SecurityMedium,
-				common.SecurityCWEField: common.SecurityCWEMissingReleaseOfFileDescriptor,
-			}).Errorf("error closing file %q: %v", file.Name(), err)
+			log.WithContext().
+				AddField(common.SecurityField, common.SecurityMedium).
+				AddField(common.SecurityCWEField, common.SecurityCWEMissingReleaseOfFileDescriptor).
+				Errorf("error closing file %q: %v", file.Name(), err)
 		}
 	}()
 
@@ -304,7 +305,7 @@ func (c SSHCreds) Environ() (io.Closer, []string, error) {
 		env = append(env, fmt.Sprintf("GIT_SSL_CAINFO=%s", c.caPath))
 	}
 	if c.insecure {
-		log.Warn("temporarily disabling strict host key checking (i.e. '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'), please don't use in production")
+		log.Warnf("temporarily disabling strict host key checking (i.e. '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'), please don't use in production")
 		// StrictHostKeyChecking will add the host to the knownhosts file,  we don't want that - a security issue really,
 		// UserKnownHostsFile=/dev/null is therefore used so we write the new insecure host to /dev/null
 		args = append(args, "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null")


### PR DESCRIPTION
- Configure the global logger for argo-cd utilities in `run.go`. This will solve the problem with log formatting for "git" log messages. With the flag `--logformat=json` log will look like:
```
{"level":"info","msg":"Initializing https://e2e-repository:8081/testdata.git to /var/folders/2j/0pgmqhq95pv6l80wmfl7fdxc0000gn/T/git-image-updater-0071725550356","time":"2025-11-05T18:48:29+01:00"}
{"application":"image-updater-007","level":"trace","msg":"targetRevision for update is 'master'","time":"2025-11-05T18:48:29+01:00"}
{"dir":"/var/folders/2j/0pgmqhq95pv6l80wmfl7fdxc0000gn/T/git-image-updater-0071725550356","execID":"95870","level":"info","msg":"git fetch origin master --force --prune --depth 1","time":"2025-11-05T18:48:29+01:00"}
{"duration":19089291,"execID":"95870","level":"debug","msg":"","time":"2025-11-05T18:48:29+01:00"}
{"execID":"95870","level":"error","msg":"`git fetch origin master --force --prune --depth 1` failed exit status 128: fatal: unable to access 'https://e2e-repository:8081/testdata.git/': Could not resolve host: e2e-repository","time":"2025-11-05T18:48:29+01:00"}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved logging initialization to apply consistent log levels and formatting throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->