### PR TITLE
fix(dockerfile): fix apk add command to support getting awscli for linux/s390x via pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ FROM alpine:3.22
 
 RUN apk update && \
     apk upgrade && \
-    apk add ca-certificates git openssh-client aws-cli tini gpg gpg-agent && \
+    apk add --no-cache ca-certificates git openssh-client tini gpg gpg-agent && \
+    (apk add --no-cache aws-cli || (apk add --no-cache python3 py3-pip && pip3 install --no-cache-dir --break-system-packages awscli)) && \
     rm -rf /var/cache/apk/*
 
 RUN mkdir -p /usr/local/bin


### PR DESCRIPTION
The alpine package aws-cli is not available in `linux/s390x` platform. This PR modifies Dockerfile to install awscli package via pip if it failed to install it via the standard `apk add aws-cli` command.

The build error with `linux/s390x`:
```
#20 [linux/s390x stage-1 2/7] RUN apk update &&     apk upgrade &&     apk add ca-certificates git openssh-client aws-cli tini gpg gpg-agent &&     rm -rf /var/cache/apk/*
#20 11.99 OK: 8 MiB in 16 packages
#20 15.75 ERROR: unable to select packages:
#20 15.75   aws-cli (no such package):
#20 15.75     required by: world[aws-cli]
#20 ERROR: process "/bin/sh -c apk update &&     apk upgrade &&     apk add ca-certificates git openssh-client aws-cli tini gpg gpg-agent &&     rm -rf /var/cache/apk/*" did not complete successfully: exit code: 1
```

The `--break-system-packages` pip option is needed to avoid error like "error: externally-managed-environment
This environment is externally managed
See PEP 668 for the detailed specification."