### PR TITLE
chore(ci): add github manual workflow build-push-images.yaml

### DIFF
--- a/.github/workflows/build-push-images.yaml
+++ b/.github/workflows/build-push-images.yaml
@@ -1,0 +1,43 @@
+name: docker-build-and-push-images
+on:
+  workflow_dispatch:
+    inputs:
+      runners:
+        description: 'Runners to use (JSON array, e.g., ["ubuntu-latest", "ubuntu-24.04-arm"] or ["ubuntu-latest"])'
+        required: true
+        type: string
+        default: '["ubuntu-latest", "ubuntu-24.04-arm"]'
+  
+jobs:
+  build-push-images:
+    name: Build and push images (${{ matrix.runner }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        runner: ${{ fromJSON(inputs.runners) }}
+    steps:
+      - name: Delete tool cache to preserve space
+        run: rm -rf /opt/hostedtoolcache || true
+
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Get version
+        id: version
+        run: |
+          echo version=$(cat VERSION) >> $GITHUB_OUTPUT
+
+      - name: Setup Golang
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Build and push image
+        run: |
+          set -ex
+          docker login --username "${DOCKER_USERNAME}" --password "${DOCKER_PASSWORD}" quay.io
+          IMAGE_TAG=v${{ steps.version.outputs.version }} make docker-build docker-push
+        env:
+          DOCKER_USERNAME: ${{ secrets.QUAY_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.QUAY_TOKEN }}

--- a/.github/workflows/create-release-draft.yaml
+++ b/.github/workflows/create-release-draft.yaml
@@ -12,6 +12,7 @@ jobs:
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
     name: Create release draft
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,5 +31,6 @@ COPY --from=builder /src/argocd-image-updater/dist/argocd-image-updater /manager
 COPY hack/git-ask-pass.sh /usr/local/bin/git-ask-pass.sh
 
 USER 1000
+WORKDIR /app
 
 ENTRYPOINT ["/sbin/tini", "--", "/manager"]

--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 	- $(CONTAINER_TOOL) buildx create --name image-updater-builder
 	$(CONTAINER_TOOL) buildx use image-updater-builder
 	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
-	- $(CONTAINER_TOOL) buildx rm image-updater-builder
+	- $(CONTAINER_TOOL) buildx rm --force image-updater-builder
 	rm Dockerfile.cross
 
 .PHONY: build-installer

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -41,6 +41,10 @@ Once you are happy with the result, approve/merge the Pull Request.
 Merging the Pull Request will start an [automated release process](https://github.com/argoproj-labs/argocd-image-updater/blob/master/.github/workflows/create-release-draft.yaml) that will build all the artifacts
 and create a draft release.
 
+The above workflow will also build and push multi-arch container images to
+[argocd-image-updater quay.io repository](https://quay.io/repository/argoprojlabs/argocd-image-updater). In case of workflow glitch and the images are not published,
+you can run workflow [docker-build-and-push-images](https://github.com/argoproj-labs/argocd-image-updater/blob/master/.github/workflows/build-push-images.yaml) in GitHub UI to build and publish the specified images.
+
 ## Publish the release
 
 You should now have a draft release or Argo Image Updater with all required artifacts attached as binaries.


### PR DESCRIPTION
add a github workflow to build and push images in specific platforms on demand as a fallback. See https://github.com/chengfang/argocd-image-updater/actions/runs/19221625680 for sample run and output. This workflow builds the images on native platforms with much faster speed (around 5 minutes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline with automated multi-architecture Docker image builds and deployment to container registry.
  * Improved Docker build process configuration for consistency.

* **Documentation**
  * Added release workflow documentation including automated image publishing and manual fallback procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->