### PR TITLE
chore(ci): improve workflow build-push-images.yaml to create multi-ar…

### DIFF
--- a/.github/workflows/build-push-images.yaml
+++ b/.github/workflows/build-push-images.yaml
@@ -46,9 +46,9 @@ jobs:
 
       - name: Build and push platform-specific image
         run: |
-          set -ex
-          docker login --username "${DOCKER_USERNAME}" --password "${DOCKER_PASSWORD}" quay.io
-          IMAGE_TAG=v${{ steps.version.outputs.version }}-${{ steps.platform.outputs.arch-tag }} make docker-build docker-push
+          set -euo pipefail
+          echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin quay.io
+          IMAGE_TAG="v${{ steps.version.outputs.version }}-${{ steps.platform.outputs.arch-tag }}" make docker-build docker-push
         env:
           DOCKER_USERNAME: ${{ secrets.QUAY_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.QUAY_TOKEN }}
@@ -70,7 +70,8 @@ jobs:
 
       - name: Login to registry
         run: |
-          docker login --username "${DOCKER_USERNAME}" --password "${DOCKER_PASSWORD}" quay.io
+          set -euo pipefail
+          echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin quay.io
         env:
           DOCKER_USERNAME: ${{ secrets.QUAY_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.QUAY_TOKEN }}


### PR DESCRIPTION
…ch manifest

Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added multi-architecture Docker image build and publish for AMD64 and ARM64.
  * Automated creation and publication of a multi-arch manifest so deployments pull the correct platform image.
  * Adopted architecture-specific image tagging (version-ARCH) and automated registry login for publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->