### PR TITLE
fix(helmvalues): git write-back to helmvalues file produces wrong structure

### DIFF
--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -890,7 +890,7 @@ func getApplicationType(app *argocdapi.Application, wbc *WriteBackConfig) Applic
 // getApplicationSourceType returns the source type of the application
 func getApplicationSourceType(app *argocdapi.Application, wbc *WriteBackConfig) argocdapi.ApplicationSourceType {
 	if wbc != nil {
-		if target := wbc.Target; strings.HasPrefix(target, common.KustomizationPrefix) {
+		if wbc.KustomizeBase != "" {
 			return argocdapi.ApplicationSourceTypeKustomize
 		}
 	}

--- a/pkg/argocd/argocd_test.go
+++ b/pkg/argocd/argocd_test.go
@@ -221,7 +221,7 @@ func Test_GetApplicationType(t *testing.T) {
 		}
 		// Create a WriteBackConfig with kustomization target to test the logic
 		wbc := &WriteBackConfig{
-			Target: "kustomization:.",
+			KustomizeBase: ".",
 		}
 		appType := GetApplicationType(application, wbc)
 		assert.Equal(t, ApplicationTypeKustomize, appType)
@@ -302,7 +302,7 @@ func Test_GetApplicationSourceType(t *testing.T) {
 
 		// Create a WriteBackConfig with kustomization target to test the logic
 		wbc := &WriteBackConfig{
-			Target: "kustomization:.",
+			KustomizeBase: ".",
 		}
 
 		appType := GetApplicationSourceType(application, wbc)

--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -379,7 +379,7 @@ func marshalParamsOverride(ctx context.Context, applicationImages *ApplicationIm
 			return []byte{}, nil
 		}
 
-		if wbc != nil && strings.HasPrefix(wbc.Target, common.HelmPrefix) {
+		if wbc != nil && !strings.HasPrefix(filepath.Base(wbc.Target), common.DefaultTargetFilePrefix) {
 			images := GetImagesAndAliasesFromApplication(applicationImages)
 
 			var helmNewValues yaml.Node

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -1617,7 +1617,7 @@ replicas: 1
 			Application: app,
 			Images:      ImageList{im},
 			WriteBackConfig: &WriteBackConfig{
-				Target: "helmvalues:./test-values.yaml",
+				Target: "./test-values.yaml",
 			},
 		}
 
@@ -1672,7 +1672,7 @@ replicas: 1
 			Application: app,
 			Images:      ImageList{im},
 			WriteBackConfig: &WriteBackConfig{
-				Target: "helmvalues:./test-values.yaml",
+				Target: "./test-values.yaml",
 			},
 		}
 
@@ -1782,7 +1782,7 @@ replicas: 1
 			Application: app,
 			Images:      ImageList{imNginx, imRedis},
 			WriteBackConfig: &WriteBackConfig{
-				Target: "helmvalues:./test-values.yaml",
+				Target: "./test-values.yaml",
 			},
 		}
 
@@ -1913,7 +1913,7 @@ replicas: 1
 			Application: app,
 			Images:      ImageList{imFoo, imBar, imBbb},
 			WriteBackConfig: &WriteBackConfig{
-				Target: "helmvalues:./test-values.yaml",
+				Target: "./test-values.yaml",
 			},
 		}
 
@@ -1981,7 +1981,7 @@ replicas: 1
 			Application: app,
 			Images:      ImageList{im},
 			WriteBackConfig: &WriteBackConfig{
-				Target: "helmvalues:./test-values.yaml",
+				Target: "./test-values.yaml",
 			},
 		}
 
@@ -2046,7 +2046,7 @@ replicas: 1
 			Application: app,
 			Images:      ImageList{im},
 			WriteBackConfig: &WriteBackConfig{
-				Target: "helmvalues:./test-values.yaml",
+				Target: "./test-values.yaml",
 			},
 		}
 
@@ -2100,7 +2100,7 @@ replicas: 1
 			Application: app,
 			Images:      ImageList{im},
 			WriteBackConfig: &WriteBackConfig{
-				Target: "helmvalues:./test-values.yaml",
+				Target: "./test-values.yaml",
 			},
 		}
 
@@ -2152,7 +2152,7 @@ replicas: 1
 			Application: app,
 			Images:      ImageList{im},
 			WriteBackConfig: &WriteBackConfig{
-				Target: "helmvalues:./test-values.yaml",
+				Target: "./test-values.yaml",
 			},
 		}
 
@@ -2205,7 +2205,7 @@ replicas: 1
 			Application: app,
 			Images:      ImageList{im},
 			WriteBackConfig: &WriteBackConfig{
-				Target: "helmvalues:./test-values.yaml",
+				Target: "./test-values.yaml",
 			},
 		}
 
@@ -2257,7 +2257,7 @@ replicas: 1
 			Application: app,
 			Images:      ImageList{im},
 			WriteBackConfig: &WriteBackConfig{
-				Target: "helmvalues:./test-values.yaml",
+				Target: "./test-values.yaml",
 			},
 		}
 
@@ -2311,7 +2311,7 @@ replicas: 1
 			Images:      ImageList{im},
 			WriteBackConfig: &WriteBackConfig{
 				Method: WriteBackGit,
-				Target: "helmvalues:./test-values.yaml",
+				Target: "./test-values.yaml",
 			},
 		}
 
@@ -2362,7 +2362,7 @@ replicas: 1
 			Images:      ImageList{im},
 			WriteBackConfig: &WriteBackConfig{
 				Method: WriteBackGit,
-				Target: "helmvalues:./test-values.yaml",
+				Target: "./test-values.yaml",
 			},
 		}
 		_, err := marshalParamsOverride(context.Background(), applicationImages, nil)
@@ -2469,7 +2469,7 @@ nginx:
 			Application: app,
 			Images:      ImageList{im},
 			WriteBackConfig: &WriteBackConfig{
-				Target: "helmvalues:./test-values.yaml",
+				Target: "./test-values.yaml",
 			},
 		}
 		yaml, err := marshalParamsOverride(context.Background(), applicationImages, originalData)
@@ -2537,7 +2537,7 @@ replicas: 1
 			Images:      ImageList{im},
 			WriteBackConfig: &WriteBackConfig{
 				Method: WriteBackGit,
-				Target: "helmvalues:./test-values.yaml",
+				Target: "./test-values.yaml",
 			},
 		}
 
@@ -2604,7 +2604,7 @@ replicas: 1
 			Images:      ImageList{im},
 			WriteBackConfig: &WriteBackConfig{
 				Method: WriteBackGit,
-				Target: "helmvalues:./test-values.yaml",
+				Target: "./test-values.yaml",
 			},
 		}
 
@@ -2673,7 +2673,7 @@ replicas: 1
 			Images:      ImageList{im},
 			WriteBackConfig: &WriteBackConfig{
 				Method: WriteBackGit,
-				Target: "helmvalues:./test-values.yaml",
+				Target: "./test-values.yaml",
 			},
 		}
 

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -18,6 +18,9 @@ const (
 	DefaultHelmImageTag  = "image.tag"
 )
 
+// DefaultTargetFilePrefix the prefix of the default git write-back target
+const DefaultTargetFilePrefix = ".argocd-source-"
+
 // DefaultTargetFilePattern configurations related to the write-back functionality
 const DefaultTargetFilePattern = ".argocd-source-%s_%s.yaml"
 const DefaultTargetFilePatternWithoutNamespace = ".argocd-source-%s.yaml"


### PR DESCRIPTION
Fixes https://github.com/argoproj-labs/argocd-image-updater/issues/1335

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved detection of application source types to more reliably identify kustomize and helm sources.
  * Adjusted parameter-handling conditions to better handle overridden chart and values paths, reducing misclassification and improving update accuracy.
* **Tests**
  * Updated test inputs and setups to reflect the new configuration field usage; no behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->