### PR TITLE
fix(update): Cannot use digest update strategy with forceUpdate: true without version constraint

### DIFF
--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -807,8 +807,14 @@ func GetImagesFromApplication(applicationImages *ApplicationImages) image.Contai
 
 	for _, img := range applicationImages.Images {
 		if img.ForceUpdate {
-			img.ImageTag = nil // the tag from the image list will be a version constraint, which isn't a valid tag
-			images = append(images, img.ContainerImage)
+			// Create a copy of the container image with nil tag to add to the live images list.
+			// The tag from the image list will be a version constraint, which isn't a valid tag.
+			// We preserve the original img.ContainerImage so the constraint is available later.
+			imgCopy := img.ContainerImage.WithTag(nil)
+			// Avoid duplicates if an entry already exists for this image (ignore tag for match).
+			if images.ContainsImage(img.ContainerImage, false) == nil {
+				images = append(images, imgCopy)
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/argoproj-labs/argocd-image-updater/issues/1344

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Force-update with digest strategy now preserves image tag constraints and avoids mutating original image data.
  * Prevented duplicate live-image entries when an image is force-updated.

* **Tests**
  * Added coverage for force-update with digest strategy, including Kubernetes Job scenarios to validate constraint preservation and update behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->