### PR TITLE
fix: nil pointer when the target file becomes empty or contains null data.

### DIFF
--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -631,6 +631,13 @@ func mergeHelmOverride(t *helmOverride, o *helmOverride) {
 }
 
 func mergeKustomizeOverride(t *kustomizeOverride, o *kustomizeOverride) {
+	if o.Kustomize.Images == nil {
+		return
+	}
+	if t.Kustomize.Images == nil {
+		emptyImages := make(v1alpha1.KustomizeImages, 0)
+		t.Kustomize.Images = &emptyImages
+	}
 	for _, newImage := range *o.Kustomize.Images {
 		found := false
 		newContainerImage := image.NewFromIdentifier(string(newImage))


### PR DESCRIPTION
Closes #1342 

Patch for annotation based version.