### PR TITLE
chore(templates): extend Bug and RFE templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,5 +22,14 @@ Add any other context about the problem here.
 **Version**
 Please tell us about the version you encountered the issue with
 
+**Regression**
+Does this issue apply to (check all that apply):
+
+- [ ] Annotation-based configuration (versions starting with `0`, e.g., `0.17.0`)
+- [ ] CRD-based configuration (versions starting with `1`, e.g., `1.0.0`)
+
+**Latest working version (if applicable)**
+If you are reporting a regression, please specify the last version where this feature worked as expected.
+
 **Logs**
 Please paste any relevant logs here

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -16,5 +16,11 @@ A clear and concise description of what you want to happen.
 **Describe alternatives you've considered**
 A clear and concise description of any alternative solutions or features you've considered.
 
+**Version**
+This feature request applies to (check all that apply):
+
+- [ ] Annotation-based configuration (versions starting with `0`, e.g., `0.17.0`)
+- [ ] CRD-based configuration (versions starting with `1`, e.g., `1.0.0`)
+
 **Additional context**
 Add any other context or screenshots about the feature request here.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Regression" section to the bug report template to classify regressions (annotation-based, CRD-based, or both) and to capture the latest working version for easier triage.
  * Added a "Version" subsection to the feature request template with a small checklist to indicate which configuration approach(s) the request applies to (annotation-based, CRD-based, or both).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->