### PR TITLE
chore(doc): remove warning about incompatibility with Argo CD Applications in any namespace

### DIFF
--- a/docs/configuration/applications.md
+++ b/docs/configuration/applications.md
@@ -9,11 +9,6 @@ Argo CD applications.
 
 ## <a name="imageupdater-cr"></a>Creating an ImageUpdater custom resource
 
-!!!warning
-  Argo CD Image Updater is not currently compatible with the
-  [Argo CD Applications in any namespace](https://argo-cd.readthedocs.io/en/stable/operator-manual/app-any-namespace/)
-  feature. All `Application` resources must be declared in Argo CD control plane's namespace (which is usually argocd.)
-
 To configure Argo CD Image Updater, you create an `ImageUpdater` custom resource
 that defines which applications to monitor and how to update their images.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,10 +16,6 @@ that are managed by
     respective
     [release notes](https://github.com/argoproj-labs/argocd-image-updater/releases).
 
-    Argo CD Image Updater is not currently compatible with
-    [Argo CD Applications in any namespace](https://argo-cd.readthedocs.io/en/stable/operator-manual/app-any-namespace/).
-
-
 ## Overview
 
 The Argo CD Image Updater can check for new versions of the container images


### PR DESCRIPTION
Closes #1340 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed compatibility restriction notices from Argo CD Image Updater documentation regarding Application namespace support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->