### PR TITLE
doc(installation): add multi-cluster setup section

### DIFF
--- a/docs/install/installation.md
+++ b/docs/install/installation.md
@@ -6,6 +6,17 @@ The Argo CD Image Updater controller **must** be run in the same Kubernetes clus
 
 While the `argocd-image-updater` binary can be run locally from your workstation for one-time updates (see `Running locally` section), the standard and supported installation for continuous, automated updates is as a controller inside your cluster.
 
+### Multi-Cluster Environments
+
+In a multi-cluster setup where Argo CD, running on a central control plane cluster (let's call it cluster A), manages `Application` resources that are deployed to another cluster (cluster B), there is one important restriction:
+
+*   The Image Updater controller **must** be installed on cluster A.
+*   All `ImageUpdater` custom resources (CRs) must also be created on cluster A.
+
+The controller cannot discover or process `ImageUpdater` CRs created on cluster B.
+
+In short: The Image Updater controller and its `ImageUpdater` CRs must reside with your Argo CD `Application` resources, not with the deployed application workloads.
+
 ## <a name="install-kubernetes"></a>Installing as Kubernetes workload
 
 The most straightforward way to run the image updater is to install it as a Kubernetes workload using the provided installation manifests. These manifests will set up the controller in its own dedicated namespace (`argocd-image-updater-system` by default).


### PR DESCRIPTION
See discussion https://github.com/argoproj-labs/argocd-image-updater/discussions/1350

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on Image Updater controller placement in multi-cluster environments, clarifying that the controller and ImageUpdater resources must be deployed to the Argo CD management cluster.
  * Added clarification that ImageUpdater resources must be created for the Image Updater to begin modifying workloads.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->