### PR TITLE
fix: preserve existing Helm tag parameter when image has no tag (#1351)

### DIFF
--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -706,8 +706,15 @@ func SetHelmImage(ctx context.Context, app *argocdapi.Application, newImage *ima
 	} else {
 		mergeParams = append(mergeParams,
 			argocdapi.HelmParameter{Name: hpImageName, Value: newImage.GetFullNameWithoutTag(), ForceString: true},
-			argocdapi.HelmParameter{Name: hpImageTag, Value: newImage.GetTagWithDigest(), ForceString: true},
 		)
+		// Only set the tag parameter if we have a non-empty tag value.
+		// When forceUpdate is enabled and no tag is specified, the tag can be empty.
+		// Setting an empty tag would overwrite existing tag values and cause invalid image references.
+		if tagValue := newImage.GetTagWithDigest(); tagValue != "" {
+			mergeParams = append(mergeParams,
+				argocdapi.HelmParameter{Name: hpImageTag, Value: tagValue, ForceString: true},
+			)
+		}
 	}
 
 	appSource := getApplicationSource(ctx, app)


### PR DESCRIPTION
When forceUpdate is enabled with an imageName that has no tag specified, SetHelmImage was setting the Helm tag parameter to an empty string. This caused "invalid reference format" errors when the image reference was later parsed (e.g., "example-registry/docker/frontend-partners:").

This fix modifies SetHelmImage to skip setting the tag parameter when the new image has no tag, preserving the existing tag value instead.

Fixes #1351

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where Helm image tag parameters could be overwritten with empty values during updates.

* **Tests**
  * Added test cases validating that existing image tag parameters are preserved when updating Helm images without a specified tag.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->