### PR TITLE
fix: Digest strategy inconsistently writes tag names causing infinite commit loop with digested tags

### DIFF
--- a/docs/basics/update-strategies.md
+++ b/docs/basics/update-strategies.md
@@ -227,13 +227,6 @@ Argo CD Image Updater will then update the image when either
   or
 * the currently used digest differs from what is found in the registry
 
-!!!note "Tags and digests"
-    Note that the `digest` update strategy will use image digests for updating
-    the image tags in your applications, so the image running in your
-    application will appear as `some/image@sha256:<somelonghashstring>` instead
-    of `some/image:latest`. So in your running system, the tag information will
-    be effectively lost.
-
 For example, the following specification would always update the image for an
 application on each new push of the image `some/image` with the tag `latest`:
 

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -1173,6 +1173,169 @@ func Test_UpdateApplication(t *testing.T) {
 		assert.Equal(t, 0, res.NumImagesUpdated)
 	})
 
+	// Test for issue #1357: digest update strategy with suffixed tags (e.g., "latest-bookworm")
+	// Previously, when an image like "nginx:latest-bookworm@sha256:..." was parsed, the tag name
+	// "latest-bookworm" was lost, causing alternating commits between the correct tag and "latest".
+	// This test verifies that the tag name is preserved correctly across multiple update cycles.
+	t.Run("Test digest update strategy with suffixed tag preserves tag name (issue #1357)", func(t *testing.T) {
+		// Use a proper 32-byte hash that when hex-encoded becomes a valid SHA256 digest
+		// The bytes 0x12, 0x34, 0x56, 0x78... become "1234567890abcdef..." when hex-encoded
+		digestBytes := [32]byte{
+			0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef,
+			0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef,
+			0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef,
+			0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef,
+		}
+		testDigest := "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+
+		mockClientFn := func(endpoint *registry.RegistryEndpoint, username, password string) (registry.RegistryClient, error) {
+			regMock := regmock.RegistryClient{}
+			regMock.On("NewRepository", mock.Anything).Return(nil)
+			regMock.On("Tags", mock.Anything).Return([]string{"latest-bookworm"}, nil)
+			// Mock ManifestForTag to return metadata with the digest
+			regMock.On("ManifestForTag", "latest-bookworm").Return(nil, nil)
+			// Mock TagMetadata to return the tag info with digest
+			regMock.On("TagMetadata", mock.Anything, mock.Anything).Return(&tag.TagInfo{
+				CreatedAt: time.Now(),
+				Digest:    digestBytes,
+			}, nil)
+			return &regMock, nil
+		}
+
+		argoClient := argomock.ArgoCD{}
+		argoClient.On("UpdateSpec", mock.Anything, mock.Anything).Return(nil, nil)
+
+		kubeClient := kube.ImageUpdaterKubernetesClient{
+			KubeClient: &registryKube.KubernetesClient{
+				Clientset: fake.NewFakeKubeClient(),
+			},
+		}
+
+		// Annotation to use digest update strategy
+		annotations := map[string]string{
+			common.ImageUpdaterAnnotation: "nginx=docker.io/library/nginx:latest-bookworm",
+			fmt.Sprintf(registryCommon.Prefixed(common.ImageUpdaterAnnotationPrefix, registryCommon.UpdateStrategyAnnotationSuffix), "nginx"): "digest",
+		}
+
+		appImages := &ApplicationImages{
+			Application: v1alpha1.Application{
+				ObjectMeta: v1.ObjectMeta{
+					Name:        "guestbook",
+					Namespace:   "guestbook",
+					Annotations: annotations,
+				},
+				Spec: v1alpha1.ApplicationSpec{
+					Source: &v1alpha1.ApplicationSource{
+						Kustomize: &v1alpha1.ApplicationSourceKustomize{
+							Images: v1alpha1.KustomizeImages{
+								// Initial state: just the tag without digest
+								"docker.io/library/nginx:latest-bookworm",
+							},
+						},
+					},
+				},
+				Status: v1alpha1.ApplicationStatus{
+					SourceType: v1alpha1.ApplicationSourceTypeKustomize,
+					Summary: v1alpha1.ApplicationSummary{
+						Images: []string{
+							"docker.io/library/nginx:latest-bookworm",
+						},
+					},
+				},
+			},
+			Images: *parseImageList(annotations),
+		}
+
+		res := UpdateApplication(&UpdateConfiguration{
+			NewRegFN:   mockClientFn,
+			ArgoClient: &argoClient,
+			KubeClient: &kubeClient,
+			UpdateApp:  appImages,
+			DryRun:     false,
+		}, NewSyncIterationState())
+
+		assert.Equal(t, 0, res.NumErrors)
+		assert.Equal(t, 0, res.NumSkipped)
+		assert.Equal(t, 1, res.NumApplicationsProcessed)
+		assert.Equal(t, 1, res.NumImagesConsidered)
+		assert.Equal(t, 1, res.NumImagesUpdated)
+
+		// Verify the updated image has both the tag name AND the digest
+		updatedImage := string(appImages.Application.Spec.Source.Kustomize.Images[0])
+
+		// The image should contain the original tag "latest-bookworm"
+		assert.Contains(t, updatedImage, "latest-bookworm", "Updated image should preserve the tag name 'latest-bookworm'")
+
+		// The image should also contain a digest
+		assert.Contains(t, updatedImage, "@sha256:", "Updated image should contain a digest")
+
+		// Now simulate the second update cycle - this is where the bug manifested
+		// The image now has both tag and digest: "nginx:latest-bookworm@sha256:..."
+		// Parse this image and verify it correctly extracts both tag name and digest
+		parsedImage := image.NewFromIdentifier(updatedImage)
+
+		// This is the critical assertion for issue #1357:
+		// The parsed image should have TagName = "latest-bookworm", not empty
+		if parsedImage.ImageTag != nil {
+			assert.Equal(t, "latest-bookworm", parsedImage.ImageTag.TagName,
+				"Parsed image should preserve tag name 'latest-bookworm', not lose it to 'latest'")
+		}
+
+		// Simulate a second update with the same digest - should NOT trigger an update
+		// because the digest hasn't changed
+		annotations2 := map[string]string{
+			common.ImageUpdaterAnnotation: "nginx=docker.io/library/nginx:latest-bookworm",
+			fmt.Sprintf(registryCommon.Prefixed(common.ImageUpdaterAnnotationPrefix, registryCommon.UpdateStrategyAnnotationSuffix), "nginx"): "digest",
+		}
+
+		// Create a new app state with the previously updated image (tag + digest)
+		appImages2 := &ApplicationImages{
+			Application: v1alpha1.Application{
+				ObjectMeta: v1.ObjectMeta{
+					Name:        "guestbook",
+					Namespace:   "guestbook",
+					Annotations: annotations2,
+				},
+				Spec: v1alpha1.ApplicationSpec{
+					Source: &v1alpha1.ApplicationSource{
+						Kustomize: &v1alpha1.ApplicationSourceKustomize{
+							Images: v1alpha1.KustomizeImages{
+								// State after first update: tag + digest
+								v1alpha1.KustomizeImage("docker.io/library/nginx:latest-bookworm@" + testDigest),
+							},
+						},
+					},
+				},
+				Status: v1alpha1.ApplicationStatus{
+					SourceType: v1alpha1.ApplicationSourceTypeKustomize,
+					Summary: v1alpha1.ApplicationSummary{
+						Images: []string{
+							"docker.io/library/nginx:latest-bookworm@" + testDigest,
+						},
+					},
+				},
+			},
+			Images: *parseImageList(annotations2),
+		}
+
+		res2 := UpdateApplication(&UpdateConfiguration{
+			NewRegFN:   mockClientFn,
+			ArgoClient: &argoClient,
+			KubeClient: &kubeClient,
+			UpdateApp:  appImages2,
+			DryRun:     false,
+		}, NewSyncIterationState())
+
+		// No update should occur because the digest is the same
+		assert.Equal(t, 0, res2.NumErrors)
+		assert.Equal(t, 0, res2.NumImagesUpdated, "No update should occur when digest hasn't changed")
+
+		// Verify the image still has the correct tag name after being parsed
+		updatedImage2 := string(appImages2.Application.Spec.Source.Kustomize.Images[0])
+		assert.Contains(t, updatedImage2, "latest-bookworm",
+			"Image should still contain 'latest-bookworm' after second update cycle")
+	})
+
 }
 
 func Test_MarshalParamsOverride(t *testing.T) {

--- a/registry-scanner/pkg/image/image.go
+++ b/registry-scanner/pkg/image/image.go
@@ -45,9 +45,15 @@ func NewFromIdentifier(identifier string) *ContainerImage {
 		if !strings.HasPrefix(imgRef, "library/") {
 			img.ImageName = strings.TrimPrefix(img.ImageName, "library/")
 		}
+		// Check for both tag and digest - an image can have both (e.g., image:tag@sha256:...)
+		// We need to handle both cases, not use else-if which would miss the tag when digest is present
 		if digested, ok := parsed.(reference.Digested); ok {
 			img.ImageTag = &tag.ImageTag{
 				TagDigest: string(digested.Digest()),
+			}
+			// Also check if there's a tag along with the digest
+			if tagged, ok := parsed.(reference.Tagged); ok {
+				img.ImageTag.TagName = tagged.Tag()
 			}
 		} else if tagged, ok := parsed.(reference.Tagged); ok {
 			img.ImageTag = &tag.ImageTag{

--- a/registry-scanner/pkg/tag/tag.go
+++ b/registry-scanner/pkg/tag/tag.go
@@ -98,13 +98,14 @@ func (tag *ImageTag) IsDigest() bool {
 }
 
 // Equals checks whether two tags are equal. Will consider any digest set for
-// the tag with precedence, otherwise uses a tag's name.
+// either tag with precedence, otherwise uses the tag names.
 func (tag *ImageTag) Equals(aTag *ImageTag) bool {
-	if tag.IsDigest() {
+	// If either tag has a digest, compare by digest
+	if tag.IsDigest() || aTag.IsDigest() {
 		return tag.TagDigest == aTag.TagDigest
-	} else {
-		return tag.TagName == aTag.TagName
 	}
+	// Otherwise compare by tag name
+	return tag.TagName == aTag.TagName
 }
 
 // Checks whether given tag is contained in tag list in O(n) time

--- a/registry-scanner/pkg/tag/tag_test.go
+++ b/registry-scanner/pkg/tag/tag_test.go
@@ -27,7 +27,7 @@ func Test_ImageTagEqual(t *testing.T) {
 
 	t.Run("Digests are similar but version is not", func(t *testing.T) {
 		tag1 := NewImageTag("v1.0.0", time.Now(), "abcdef")
-		tag2 := NewImageTag("v1.0.1", time.Now(), "abcdef")
+		tag2 := NewImageTag("v1.0.0-variant2", time.Now(), "abcdef")
 		assert.True(t, tag1.Equals(tag2))
 	})
 
@@ -53,8 +53,8 @@ func Test_ImageTagEqual(t *testing.T) {
 		tag1 := NewImageTag("v1.0.0", time.Now(), "abc")
 		tag2 := NewImageTag("v1.0.0", time.Now(), "")
 		assert.False(t, tag1.Equals(tag2))
+		assert.False(t, tag2.Equals(tag1))
 	})
-
 }
 
 func Test_AppendToImageTagList(t *testing.T) {


### PR DESCRIPTION
Fixes #1357 in `master-annotation-based` branch