### PR TITLE
fix: Digest strategy inconsistently writes tag names causing infinite commit loop with digested tags

### DIFF
--- a/docs/basics/update-strategies.md
+++ b/docs/basics/update-strategies.md
@@ -237,13 +237,6 @@ Argo CD Image Updater will then update the image when either
   or
 * the currently used digest differs from what is found in the registry
 
-!!!note "Tags and digests"
-    Note that the `digest` update strategy will use image digests for updating
-    the image tags in your applications, so the image running in your
-    application will appear as `some/image@sha256:<somelonghashstring>` instead
-    of `some/image:latest`. So in your running system, the tag information will
-    be effectively lost.
-
 For example, the following specification would always update the image for an
 application on each new push of the image `some/image` with the tag `latest`:
 

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -1344,6 +1344,288 @@ func Test_UpdateApplication(t *testing.T) {
 		assert.Equal(t, "latest", iuImg.ContainerImage.ImageTag.TagName)
 	})
 
+	// Test for issue #1357: digest update strategy with suffixed tags (e.g., "latest-bookworm")
+	// Previously, when an image like "nginx:latest-bookworm@sha256:..." was parsed, the tag name
+	// "latest-bookworm" was lost, causing alternating commits between the correct tag and "latest".
+	// This test verifies that the tag name is preserved correctly across multiple update cycles.
+	t.Run("Test digest update strategy with suffixed tag preserves tag name (issue #1357)", func(t *testing.T) {
+		// Use a proper 32-byte hash that when hex-encoded becomes a valid SHA256 digest
+		// The bytes 0x12, 0x34, 0x56, 0x78... become "1234567890abcdef..." when hex-encoded
+		digestBytes := [32]byte{
+			0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef,
+			0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef,
+			0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef,
+			0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef,
+		}
+		testDigest := "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+
+		mockClientFn := func(endpoint *registry.RegistryEndpoint, username, password string) (registry.RegistryClient, error) {
+			regMock := regmock.RegistryClient{}
+			regMock.On("NewRepository", mock.Anything).Return(nil)
+			regMock.On("Tags", mock.Anything).Return([]string{"latest-bookworm"}, nil)
+			// Mock ManifestForTag to return metadata with the digest
+			meta1 := &schema1.SignedManifest{} //nolint:staticcheck
+			meta1.Name = "library/nginx"
+			meta1.Tag = "latest-bookworm"
+			regMock.On("ManifestForTag", mock.Anything, "latest-bookworm").Return(meta1, nil)
+			// Mock TagMetadata to return the tag info with digest
+			regMock.On("TagMetadata", mock.Anything, mock.Anything, mock.Anything).Return(&tag.TagInfo{
+				CreatedAt: time.Now(),
+				Digest:    digestBytes,
+			}, nil)
+			return &regMock, nil
+		}
+
+		argoClient := argomock.ArgoCD{}
+		argoClient.On("UpdateSpec", mock.Anything, mock.Anything).Return(nil, nil)
+
+		kubeClient := kube.ImageUpdaterKubernetesClient{
+			KubeClient: &registryKube.KubernetesClient{
+				Clientset: fake.NewFakeKubeClient(),
+			},
+		}
+
+		// Image configuration with digest update strategy and suffixed tag
+		containerImg := image.NewFromIdentifier("nginx=docker.io/library/nginx:latest-bookworm")
+		iuImg := NewImage(containerImg)
+		iuImg.UpdateStrategy = image.StrategyDigest
+
+		imageList := ImageList{iuImg}
+
+		appImages := &ApplicationImages{
+			Application: v1alpha1.Application{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "guestbook",
+					Namespace: "guestbook",
+				},
+				Spec: v1alpha1.ApplicationSpec{
+					Source: &v1alpha1.ApplicationSource{
+						Kustomize: &v1alpha1.ApplicationSourceKustomize{
+							Images: v1alpha1.KustomizeImages{
+								// Initial state: just the tag without digest
+								"docker.io/library/nginx:latest-bookworm",
+							},
+						},
+					},
+				},
+				Status: v1alpha1.ApplicationStatus{
+					SourceType: v1alpha1.ApplicationSourceTypeKustomize,
+					Summary: v1alpha1.ApplicationSummary{
+						Images: []string{
+							"docker.io/library/nginx:latest-bookworm",
+						},
+					},
+				},
+			},
+			Images: imageList,
+			WriteBackConfig: &WriteBackConfig{
+				Method: WriteBackApplication,
+			},
+		}
+
+		res := UpdateApplication(context.Background(), &UpdateConfiguration{
+			NewRegFN:   mockClientFn,
+			ArgoClient: &argoClient,
+			KubeClient: &kubeClient,
+			UpdateApp:  appImages,
+			DryRun:     false,
+		}, NewSyncIterationState())
+
+		assert.Equal(t, 0, res.NumErrors)
+		assert.Equal(t, 0, res.NumSkipped)
+		assert.Equal(t, 1, res.NumApplicationsProcessed)
+		assert.Equal(t, 1, res.NumImagesConsidered)
+		assert.Equal(t, 1, res.NumImagesUpdated)
+
+		// Verify the updated image has both the tag name AND the digest
+		require.Len(t, appImages.Application.Spec.Source.Kustomize.Images, 1)
+		updatedImage := string(appImages.Application.Spec.Source.Kustomize.Images[0])
+
+		// The image should contain the original tag "latest-bookworm"
+		assert.Contains(t, updatedImage, "latest-bookworm", "Updated image should preserve the tag name 'latest-bookworm'")
+
+		// The image should also contain a digest
+		assert.Contains(t, updatedImage, "@sha256:", "Updated image should contain a digest")
+
+		// Now simulate the second update cycle - this is where the bug manifested
+		// The image now has both tag and digest: "nginx:latest-bookworm@sha256:..."
+		// Parse this image and verify it correctly extracts both tag name and digest
+		parsedImage := image.NewFromIdentifier(updatedImage)
+
+		// This is the critical assertion for issue #1357:
+		// The parsed image should have TagName = "latest-bookworm", not empty
+		require.NotNil(t, parsedImage.ImageTag)
+		assert.Equal(t, "latest-bookworm", parsedImage.ImageTag.TagName,
+			"Parsed image should preserve tag name 'latest-bookworm', not lose it to 'latest'")
+
+		// Simulate a second update with the same digest - should NOT trigger an update
+		// because the digest hasn't changed
+		containerImg2 := image.NewFromIdentifier("nginx=docker.io/library/nginx:latest-bookworm")
+		iuImg2 := NewImage(containerImg2)
+		iuImg2.UpdateStrategy = image.StrategyDigest
+
+		imageList2 := ImageList{iuImg2}
+
+		// Create a new app state with the previously updated image (tag + digest)
+		appImages2 := &ApplicationImages{
+			Application: v1alpha1.Application{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "guestbook",
+					Namespace: "guestbook",
+				},
+				Spec: v1alpha1.ApplicationSpec{
+					Source: &v1alpha1.ApplicationSource{
+						Kustomize: &v1alpha1.ApplicationSourceKustomize{
+							Images: v1alpha1.KustomizeImages{
+								// State after first update: tag + digest
+								v1alpha1.KustomizeImage("docker.io/library/nginx:latest-bookworm@" + testDigest),
+							},
+						},
+					},
+				},
+				Status: v1alpha1.ApplicationStatus{
+					SourceType: v1alpha1.ApplicationSourceTypeKustomize,
+					Summary: v1alpha1.ApplicationSummary{
+						Images: []string{
+							"docker.io/library/nginx:latest-bookworm@" + testDigest,
+						},
+					},
+				},
+			},
+			Images: imageList2,
+			WriteBackConfig: &WriteBackConfig{
+				Method: WriteBackApplication,
+			},
+		}
+
+		res2 := UpdateApplication(context.Background(), &UpdateConfiguration{
+			NewRegFN:   mockClientFn,
+			ArgoClient: &argoClient,
+			KubeClient: &kubeClient,
+			UpdateApp:  appImages2,
+			DryRun:     false,
+		}, NewSyncIterationState())
+
+		// No update should occur because the digest is the same
+		assert.Equal(t, 0, res2.NumErrors)
+		assert.Equal(t, 0, res2.NumImagesUpdated, "No update should occur when digest hasn't changed")
+
+		// Verify the image still has the correct tag name after being parsed
+		updatedImage2 := string(appImages2.Application.Spec.Source.Kustomize.Images[0])
+		assert.Contains(t, updatedImage2, "latest-bookworm",
+			"Image should still contain 'latest-bookworm' after second update cycle")
+	})
+
+	// Test for issue #1357: Two tags pointing to the same digest should be considered equal
+	// In the reported issue, the user has tags like "latest" and "latest-bookworm" both pointing
+	// to the same digest. When using digest update strategy, switching between these tags
+	// should NOT trigger an update since they resolve to the same content.
+	t.Run("Test two tags with same digest are considered equal (issue #1357)", func(t *testing.T) {
+		// Both tags will return the same digest
+		sharedDigestBytes := [32]byte{
+			0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef,
+			0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef,
+			0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef,
+			0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef,
+		}
+		sharedDigest := "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+
+		// Mock registry that returns BOTH tags, and both resolve to the same digest
+		mockClientFn := func(endpoint *registry.RegistryEndpoint, username, password string) (registry.RegistryClient, error) {
+			regMock := regmock.RegistryClient{}
+			regMock.On("NewRepository", mock.Anything).Return(nil)
+			// Return both tags - "latest" and "latest-bookworm" both exist
+			regMock.On("Tags", mock.Anything).Return([]string{"latest", "latest-bookworm"}, nil)
+
+			// Both tags return manifests
+			metaLatest := &schema1.SignedManifest{} //nolint:staticcheck
+			metaLatest.Name = "library/nginx"
+			metaLatest.Tag = "latest"
+			regMock.On("ManifestForTag", mock.Anything, "latest").Return(metaLatest, nil)
+
+			metaBookworm := &schema1.SignedManifest{} //nolint:staticcheck
+			metaBookworm.Name = "library/nginx"
+			metaBookworm.Tag = "latest-bookworm"
+			regMock.On("ManifestForTag", mock.Anything, "latest-bookworm").Return(metaBookworm, nil)
+
+			// CRITICAL: Both tags return the SAME digest
+			regMock.On("TagMetadata", mock.Anything, mock.Anything, mock.Anything).Return(&tag.TagInfo{
+				CreatedAt: time.Now(),
+				Digest:    sharedDigestBytes,
+			}, nil)
+
+			return &regMock, nil
+		}
+
+		argoClient := argomock.ArgoCD{}
+		argoClient.On("UpdateSpec", mock.Anything, mock.Anything).Return(nil, nil)
+
+		kubeClient := kube.ImageUpdaterKubernetesClient{
+			KubeClient: &registryKube.KubernetesClient{
+				Clientset: fake.NewFakeKubeClient(),
+			},
+		}
+
+		// User wants to track "latest-bookworm" tag with digest strategy
+		containerImg := image.NewFromIdentifier("nginx=docker.io/library/nginx:latest-bookworm")
+		iuImg := NewImage(containerImg)
+		iuImg.UpdateStrategy = image.StrategyDigest
+
+		imageList := ImageList{iuImg}
+
+		// Application currently has "latest" tag with the SAME digest
+		// This simulates the scenario where both tags point to the same image content
+		appImages := &ApplicationImages{
+			Application: v1alpha1.Application{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "guestbook",
+					Namespace: "guestbook",
+				},
+				Spec: v1alpha1.ApplicationSpec{
+					Source: &v1alpha1.ApplicationSource{
+						Kustomize: &v1alpha1.ApplicationSourceKustomize{
+							Images: v1alpha1.KustomizeImages{
+								// Current state: "latest" tag with the shared digest
+								v1alpha1.KustomizeImage("docker.io/library/nginx:latest@" + sharedDigest),
+							},
+						},
+					},
+				},
+				Status: v1alpha1.ApplicationStatus{
+					SourceType: v1alpha1.ApplicationSourceTypeKustomize,
+					Summary: v1alpha1.ApplicationSummary{
+						Images: []string{
+							"docker.io/library/nginx:latest@" + sharedDigest,
+						},
+					},
+				},
+			},
+			Images: imageList,
+			WriteBackConfig: &WriteBackConfig{
+				Method: WriteBackApplication,
+			},
+		}
+
+		res := UpdateApplication(context.Background(), &UpdateConfiguration{
+			NewRegFN:   mockClientFn,
+			ArgoClient: &argoClient,
+			KubeClient: &kubeClient,
+			UpdateApp:  appImages,
+			DryRun:     false,
+		}, NewSyncIterationState())
+
+		// Since both "latest" and "latest-bookworm" resolve to the same digest,
+		// NO update should occur - the content is identical
+		assert.Equal(t, 0, res.NumErrors)
+		assert.Equal(t, 0, res.NumImagesUpdated,
+			"No update should occur when two different tags point to the same digest")
+
+		// Verify the image was NOT changed (still has "latest" tag, not "latest-bookworm")
+		updatedImage := string(appImages.Application.Spec.Source.Kustomize.Images[0])
+		assert.Contains(t, updatedImage, "latest@"+sharedDigest,
+			"Image should remain unchanged since digest is the same")
+	})
+
 }
 
 func Test_MarshalParamsOverride(t *testing.T) {

--- a/registry-scanner/pkg/image/image.go
+++ b/registry-scanner/pkg/image/image.go
@@ -46,9 +46,15 @@ func NewFromIdentifier(identifier string) *ContainerImage {
 		if !strings.HasPrefix(imgRef, "library/") {
 			img.ImageName = strings.TrimPrefix(img.ImageName, "library/")
 		}
+		// Check for both tag and digest - an image can have both (e.g., image:tag@sha256:...)
+		// We need to handle both cases, not use else-if which would miss the tag when digest is present
 		if digested, ok := parsed.(reference.Digested); ok {
 			img.ImageTag = &tag.ImageTag{
 				TagDigest: string(digested.Digest()),
+			}
+			// Also check if there's a tag along with the digest
+			if tagged, ok := parsed.(reference.Tagged); ok {
+				img.ImageTag.TagName = tagged.Tag()
 			}
 		} else if tagged, ok := parsed.(reference.Tagged); ok {
 			img.ImageTag = &tag.ImageTag{

--- a/registry-scanner/pkg/tag/tag.go
+++ b/registry-scanner/pkg/tag/tag.go
@@ -88,13 +88,14 @@ func (tag *ImageTag) IsDigest() bool {
 }
 
 // Equals checks whether two tags are equal. Will consider any digest set for
-// the tag with precedence, otherwise uses a tag's name.
+// either tag with precedence, otherwise uses the tag names.
 func (tag *ImageTag) Equals(aTag *ImageTag) bool {
-	if tag.IsDigest() {
+	// If either tag has a digest, compare by digest
+	if tag.IsDigest() || aTag.IsDigest() {
 		return tag.TagDigest == aTag.TagDigest
-	} else {
-		return tag.TagName == aTag.TagName
 	}
+	// Otherwise compare by tag name
+	return tag.TagName == aTag.TagName
 }
 
 // Tags returns a list of verbatim tag names as string slice

--- a/registry-scanner/pkg/tag/tag_test.go
+++ b/registry-scanner/pkg/tag/tag_test.go
@@ -28,7 +28,7 @@ func Test_ImageTagEqual(t *testing.T) {
 
 	t.Run("Digests are similar but version is not", func(t *testing.T) {
 		tag1 := NewImageTag("v1.0.0", time.Now(), "abcdef")
-		tag2 := NewImageTag("v1.0.1", time.Now(), "abcdef")
+		tag2 := NewImageTag("v1.0.0-variant2", time.Now(), "abcdef")
 		assert.True(t, tag1.Equals(tag2))
 	})
 
@@ -54,6 +54,9 @@ func Test_ImageTagEqual(t *testing.T) {
 		tag1 := NewImageTag("v1.0.0", time.Now(), "abc")
 		tag2 := NewImageTag("v1.0.0", time.Now(), "")
 		assert.False(t, tag1.Equals(tag2))
+		// Also verify the reverse - first tag has no digest, 2nd tag has digest
+		// This scenario occurs when comparing an existing image (no digest) with a new image (has digest)
+		assert.False(t, tag2.Equals(tag1))
 	})
 
 }


### PR DESCRIPTION
Fixes #1357 in `master`, similar to #1386 to `master-annotation-based` branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Image references with both tags and digests are parsed correctly, preserving original tag names.
  * Tag equality now compares digests when present, preventing unnecessary updates when different tags point to the same digest.

* **Tests**
  * Added tests for digest-based update flows, suffixed tags preservation, and tag/digest parsing scenarios.

* **Documentation**
  * Removed explanatory note about digest updates replacing visible tag information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->