### PR TITLE
test(e2e): create infrastructure for git write-back policy

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -178,14 +178,6 @@ jobs:
           docker system prune -af
           echo "=== Disk space after cleanup ==="
           df -h /
-      - name: Install K3D
-        run: |
-          set -ex
-          curl -fsSL https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
-          sudo mkdir -p $HOME/.kube && sudo chown -R runner $HOME/.kube
-          k3d cluster create --servers 3 --image rancher/k3s:${{ matrix.k3s-version }}-k3s1
-          kubectl version
-          k3d version
       - name: Checkout code
         uses: actions/checkout@v5
       - name: Setup Golang
@@ -206,28 +198,18 @@ jobs:
       - name: Download Go dependencies
         run: |
           cd test/ginkgo && go mod download
-      - name: Build local image updater, deploy operator
+      - name: Install K3D
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
+          sudo mkdir -p "$HOME/.kube" && sudo chown -R runner "$HOME/.kube"
+      - name: Deploy operator and run e2e tests
         env:
           ARGOCD_CLUSTER_CONFIG_NAMESPACES: argocd-e2e-cluster-config
           K3D_CLUSTER_NAME: k3s-default
+          LOCAL: false
         run: |
           set -o pipefail
-          make -C test/ginkgo test-e2e-ci
-
-      - name: Verify operator deployment
-        run: |
-          echo "--- Checking operator deployment ---"
-          kubectl get deployment -n argocd-operator-system
-          echo "--- Checking operator pods ---"
-          kubectl get pods -n argocd-operator-system
-          echo "--- Checking operator logs (last 50 lines) ---"
-          OPERATOR_POD=$(kubectl get po -n argocd-operator-system -o=name | grep controller-manager | head -1)
-          kubectl logs -n argocd-operator-system "$OPERATOR_POD" -c manager --tail=50 || true
-
-      - name: Run ginkgo tests
-        run: |
-          set -o pipefail
-          make e2e-tests-parallel-ginkgo 2>&1 | tee /tmp/e2e-test-ginkgo.log
+          make -C test/ginkgo test-e2e 2>&1 | tee /tmp/e2e-test-ginkgo.log
 
       - name: Save application controller and server logs
         if: ${{ failure() }}

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ test-results
 *.goe
 **/kuttl-test.json
 **/kubeconfig
+# Private keys and certificates (should be generated at runtime, not committed)
+*.key
+*.crt
+# htpasswd files (should be generated at runtime, not committed)
+**/htpasswd

--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,7 @@ e2e-tests-sequential-ginkgo: ginkgo
 .PHONY: e2e-tests-parallel-ginkgo
 e2e-tests-parallel-ginkgo: ginkgo
 	@echo "Running operator parallel Ginkgo E2E tests..."
-	$(GINKGO_CLI) -p -v -procs=1 --trace --timeout 90m -r ./test/ginkgo/parallel
+	$(GINKGO_CLI) -p -v -procs=2 --trace --timeout 90m -r ./test/ginkgo/parallel
 
 GINKGO_CLI = $(shell pwd)/bin/ginkgo
 .PHONY: ginkgo

--- a/test/ginkgo/Makefile
+++ b/test/ginkgo/Makefile
@@ -1,3 +1,7 @@
+# Assisted-by: Claude AI model
+
+CURRENT_DIR=$(shell pwd)
+CONTAINER_TOOL ?= docker
 # Default image for argocd-operator. Can be overridden.
 ARGOCD_OPERATOR_IMAGE ?= quay.io/argoprojlabs/argocd-operator:latest
 
@@ -38,13 +42,17 @@ KUSTOMIZE ?= $(CURDIR)/../../bin/kustomize
 KUBECTL ?= kubectl
 K3D ?= k3d
 
-K3D_CLUSTER_NAME ?= test-e2e-local
+K3D_CLUSTER_NAME ?= test-e2e
+LOCAL ?= true
 
 ifndef ignore-not-found
   ignore-not-found = false
 endif
 
-.PHONY: deploy-argocd-operator undeploy-argocd-operator kustomize test-e2e-local test-e2e-ci k3d-cluster-create k3d-cluster-delete k3d-image-import
+.PHONY: deploy-argocd-operator undeploy-argocd-operator kustomize test-e2e \
+   k3d-cluster-create k3d-cluster-delete k3d-image-import configure-docker-daemon \
+   git-container-build git-container-push create-local-container-registry
+
 kustomize:
 	$(MAKE) -C ../../ kustomize
 
@@ -59,9 +67,11 @@ deploy-argocd-operator: kustomize ## Deploy argocd-operator from a stable git re
 	cd $$TMP_DIR && \
 		$(KUSTOMIZE) edit set image quay.io/argoprojlabs/argocd-operator=$(ARGOCD_OPERATOR_IMAGE) && \
 		$(KUSTOMIZE) edit add patch --path patch.yaml; \
-	$(KUSTOMIZE) build $$TMP_DIR | $(KUBECTL) apply --server-side=true -f -; \
+	$(KUSTOMIZE) build $$TMP_DIR | $(KUBECTL) apply --server-side=true --validate=false -f -; \
 	rm -rf $$TMP_DIR; \
 	echo "Argo CD Operator deployment initiated.";
+	echo "--- Waiting for argocd-operator to be ready ---";
+	$(KUBECTL) wait --for=condition=available --timeout=300s deployment/argocd-operator-controller-manager -n argocd-operator-system
 
 undeploy-argocd-operator: kustomize ## Undeploy argocd-operator.
 	@echo "Undeploying Argo CD Operator..."
@@ -74,39 +84,65 @@ undeploy-argocd-operator: kustomize ## Undeploy argocd-operator.
 
 k3d-cluster-create: ## Create k3d cluster for e2e tests
 	@echo "--- Creating k3d cluster $(K3D_CLUSTER_NAME) ---"
-	$(K3D) cluster create $(K3D_CLUSTER_NAME)
+	@$(K3D) cluster create $(K3D_CLUSTER_NAME) \
+	--port '30000:30000@server:0' \
+	--registry-config "${CURRENT_DIR}/prereqs/assets/registries.yaml"
+	@bash -c '. "${CURRENT_DIR}/prereqs/assets/wait-utils.sh" && wait_for_cluster_ready 120 $(KUBECTL)' || exit 1
 
 k3d-cluster-delete: ## Delete k3d cluster for e2e tests
 	@echo "--- Deleting k3d cluster $(K3D_CLUSTER_NAME) ---"
 	$(K3D) cluster delete $(K3D_CLUSTER_NAME)
+
+configure-docker-daemon: ## Configure Docker daemon.json to allow insecure registry at 127.0.0.1:30000
+	@echo "--- Configuring Docker daemon.json for insecure registry 127.0.0.1:30000 ---"
+	@bash "${CURRENT_DIR}/prereqs/assets/configure-docker-daemon.sh"
 
 k3d-image-import: ## Import local image to k3d cluster
 	@echo "--- Importing image $(ARGOCD_IMAGE_UPDATER_IMAGE) to k3d cluster $(K3D_CLUSTER_NAME) ---"
 	$(K3D) image import $(ARGOCD_IMAGE_UPDATER_IMAGE) -c $(K3D_CLUSTER_NAME)
 
 # Currently run only parallel tests because we don't have sequential tests yet.
-test-e2e-local: ## Build local image updater, deploy operator, and run parallel e2e tests.
+test-e2e: ## Build local image updater, deploy operator, and run parallel e2e tests.
+	@echo "--- Configuring Docker daemon for insecure registry ---"
+	$(MAKE) configure-docker-daemon
+	@echo "--- Building local argocd-image-updater image ---"
+	$(MAKE) -C ../../ docker-build
 	@echo "--- Creating k3d cluster---"
 	$(MAKE) k3d-cluster-create
-	@echo "--- Building local argocd-image-updater image ---"
-	$(MAKE) -C ../../ docker-build
 	@echo "--- Importing image to k3d cluster ---"
 	$(MAKE) k3d-image-import
 	@echo "--- Deploying argocd-operator with local image-updater ---"
 	$(MAKE) deploy-argocd-operator
-	@echo "--- Waiting for argocd-operator to be ready ---"
-	$(KUBECTL) wait --for=condition=available --timeout=300s deployment/argocd-operator-controller-manager -n argocd-operator-system
+	@echo "--- Deploying local container registry ---"
+	$(MAKE) create-local-container-registry
 	@echo "--- Running Parallel E2E tests ---"
 	$(MAKE) -C ../../ e2e-tests-parallel-ginkgo
+ifeq ($(LOCAL),true)
 	@echo "--- Deleting k3d cluster ---"
 	$(MAKE) k3d-cluster-delete
+endif
 
-test-e2e-ci: ## Build local image updater, deploy operator.
-	@echo "--- Building local argocd-image-updater image ---"
-	$(MAKE) -C ../../ docker-build
-	@echo "--- Importing image to k3d cluster ---"
-	$(MAKE) k3d-image-import
-	@echo "--- Deploying argocd-operator with local image-updater ---"
-	$(MAKE) deploy-argocd-operator
-	@echo "--- Waiting for argocd-operator to be ready ---"
-	$(KUBECTL) wait --for=condition=available --timeout=300s deployment/argocd-operator-controller-manager -n argocd-operator-system
+GIT_IMAGE_REPO		?= 127.0.0.1:30000
+GIT_IMAGE_NAME		?= git-http
+GIT_IMAGE_TAG		?= latest
+
+GIT_IMAGE_SLUG		:= $(GIT_IMAGE_REPO)/$(GIT_IMAGE_NAME):$(GIT_IMAGE_TAG)
+
+git-container-build: ## Build git container image
+	$(CONTAINER_TOOL) build -t $(GIT_IMAGE_SLUG) -f ./prereqs/containers/git/Dockerfile ./prereqs/containers/git
+
+git-container-push: git-container-build ## Push git container image
+	$(CONTAINER_TOOL) push $(GIT_IMAGE_SLUG)
+
+create-local-container-registry: ## Create local container registry
+	@echo "--- Generating TLS certificates and secrets for registry ---"
+	@bash "${CURRENT_DIR}/prereqs/assets/generate-registry-tls-secrets.sh"
+	@echo "--- Applying registry manifests ---"
+	@$(KUBECTL) apply -n argocd-operator-system -f prereqs/assets/registry.yaml
+	@$(KUBECTL) rollout -n argocd-operator-system status deployment e2e-registry-public
+	@$(KUBECTL) wait --for=condition=available --timeout=30s deployment/e2e-registry-public -n argocd-operator-system
+	@bash -c '. "${CURRENT_DIR}/prereqs/assets/wait-utils.sh" && wait_for_registry_ready 60'
+	@$(MAKE) git-container-push
+	@echo "--- Verifying operator deployment ---"
+	@$(KUBECTL) get deployment -n argocd-operator-system || true
+	@$(KUBECTL) get pods -n argocd-operator-system || true

--- a/test/ginkgo/fixture/imageupdater/fixture.go
+++ b/test/ginkgo/fixture/imageupdater/fixture.go
@@ -1,0 +1,174 @@
+package imageupdater
+
+import (
+	"context"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	//lint:ignore ST1001 "This is a common practice in Gomega tests for readability."
+	. "github.com/onsi/ginkgo/v2" //nolint:all
+	//lint:ignore ST1001 "This is a common practice in Gomega tests for readability."
+	. "github.com/onsi/gomega" //nolint:all
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	GitImageRepo = "127.0.0.1:30000"
+	GitImageName = "git-http"
+	GitImageTag  = "latest"
+	Name         = "e2e-repository"
+)
+
+// createLocalGitRepoDeployment creates a Deployment for a local git repository server
+// used in E2E tests. The deployment runs a git-http container that serves git repositories
+// over HTTP on ports 8080 (unauthenticated) and 8081 (authenticated).
+func createLocalGitRepoDeployment(ctx context.Context, k8sClient client.Client, namespace string) {
+	By("creating local git repo Deployment")
+
+	depl := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      Name,
+			Namespace: namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app":       Name,
+					"component": namespace,
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app":       Name,
+						"component": namespace,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:            GitImageName,
+							Image:           fmt.Sprintf("%s/%s:%s", GitImageRepo, GitImageName, GitImageTag), //"127.0.0.1:30000/git-http:latest",
+							ImagePullPolicy: corev1.PullAlways,
+							Ports: []corev1.ContainerPort{
+								{
+									ContainerPort: 8080,
+								},
+								{
+									ContainerPort: 8081,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	Expect(k8sClient.Create(ctx, depl)).To(Succeed())
+}
+
+// createLocalGitRepoService creates a NodePort Service for the local git repository server.
+// The service exposes ports 8080 (unauthenticated) and 8081 (authenticated) allowing external access to the git server.
+func createLocalGitRepoService(ctx context.Context, k8sClient client.Client, namespace string) {
+	By("creating local git repo Service")
+
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      Name,
+			Namespace: namespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeNodePort,
+			Selector: map[string]string{
+				"app":       Name,
+				"component": namespace,
+			},
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "unauth",
+					Protocol:   corev1.ProtocolTCP,
+					Port:       8080,
+					TargetPort: intstr.FromInt32(8080),
+				},
+				{
+					Name:       "auth",
+					Protocol:   corev1.ProtocolTCP,
+					Port:       8081,
+					TargetPort: intstr.FromInt32(8081),
+				},
+			},
+		},
+	}
+	Expect(k8sClient.Create(ctx, service)).To(Succeed())
+}
+
+// createLocalGitRepoSecret creates a Kubernetes Secret with ArgoCD repository credentials
+// for the local git repository. The secret is labeled with "argocd.argoproj.io/secret-type: repository"
+// so that ArgoCD can discover and use it for git operations.
+func createLocalGitRepoSecret(ctx context.Context, k8sClient client.Client, namespace string) {
+	By("creating local git repo Secret")
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      Name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"argocd.argoproj.io/secret-type": "repository",
+				"component":                      namespace,
+			},
+		},
+		StringData: map[string]string{
+			"url":      fmt.Sprintf("https://%s.%s.svc.cluster.local:8081/testdata.git", Name, namespace), //"https://e2e-repository.argocd-operator-system.svc.cluster.local:8081/testdata.git",
+			"type":     "git",
+			"password": "git",
+			"username": "git",
+			"insecure": "true",
+		},
+	}
+	Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+}
+
+// CreateLocalGitRepo creates a complete local git repository setup for E2E tests.
+// It creates a Deployment (git server), Service (NodePort for external access), and Secret
+// (ArgoCD repository credentials). This provides an isolated git repository that can be used
+// for testing git write-back functionality without requiring external git services.
+func CreateLocalGitRepo(ctx context.Context, k8sClient client.Client, namespace string) {
+	By("creating local git repo")
+	createLocalGitRepoDeployment(ctx, k8sClient, namespace)
+	createLocalGitRepoService(ctx, k8sClient, namespace)
+	createLocalGitRepoSecret(ctx, k8sClient, namespace)
+}
+
+// TriggerArgoCDRefresh periodically sets the refresh annotation on an ArgoCD Application
+// to force immediate git checks, bypassing ArgoCD's default 3-minute polling interval.
+// This function returns a function that can be used in Eventually() loops.
+// The refresh annotation is set every other call (every ~10 seconds when polling every 5s).
+// app should be a pointer to an Application object that will be updated in place.
+func TriggerArgoCDRefresh(ctx context.Context, k8sClient client.Client, app client.Object) func() {
+	refreshCounter := 0
+	return func() {
+		refreshCounter++
+		if refreshCounter%2 == 0 { // Every other call (every ~10 seconds when polling every 5s)
+			// Re-fetch to get latest resource version
+			if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(app), app); err != nil {
+				GinkgoWriter.Println("TriggerArgoCDRefresh: failed to get app:", err)
+				return
+			}
+			// Set refresh annotation to "hard" to force immediate git check and cache invalidation
+			// ArgoCD removes the annotation after processing, so we need to keep setting it
+			annotations := app.GetAnnotations()
+			if annotations == nil {
+				annotations = make(map[string]string)
+			}
+			annotations["argocd.argoproj.io/refresh"] = "hard"
+			app.SetAnnotations(annotations)
+			if err := k8sClient.Update(ctx, app); err != nil {
+				GinkgoWriter.Println("TriggerArgoCDRefresh: failed to update app:", err)
+			}
+		}
+	}
+}

--- a/test/ginkgo/fixture/os/fixture.go
+++ b/test/ginkgo/fixture/os/fixture.go
@@ -9,15 +9,18 @@ import (
 )
 
 func ExecCommand(cmdArgs ...string) (string, error) {
-	return ExecCommandWithOutputParam(true, cmdArgs...)
+	return ExecCommandWithOutputParam(true, true, cmdArgs...)
 }
 
-// You probably want to use ExecCommand, unless you need to supress the output of sensitive data (for example, openssl CLI output)
-func ExecCommandWithOutputParam(printOutput bool, cmdArgs ...string) (string, error) {
+// ExecCommandWithOutputParam You probably want to use ExecCommand, unless you need to suppress the output of sensitive data (for example, openssl CLI output)
+func ExecCommandWithOutputParam(printOutput bool, printCommand bool, cmdArgs ...string) (string, error) {
 	if len(cmdArgs) == 0 {
-		return "", fmt.Errorf("ExecCommandWithOutputParam requires at least one argument")
+		return "", fmt.Errorf("no command arguments provided")
 	}
-	GinkgoWriter.Println("executing command:", cmdArgs)
+
+	if printCommand {
+		GinkgoWriter.Println("executing command:", cmdArgs)
+	}
 
 	// #nosec G204
 	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...)

--- a/test/ginkgo/parallel/1-002-git-write-back-target-test.go
+++ b/test/ginkgo/parallel/1-002-git-write-back-target-test.go
@@ -1,0 +1,229 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package parallel
+
+import (
+	"context"
+	"fmt"
+
+	applicationFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/application"
+	appv1alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/gitops-engine/pkg/health"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	imageUpdaterApi "github.com/argoproj-labs/argocd-image-updater/api/v1alpha1"
+
+	"github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture"
+	argocdFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/argocd"
+	deplFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/deployment"
+	iuFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/imageupdater"
+	k8sFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/k8s"
+	ssFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/statefulset"
+	fixtureUtils "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/utils"
+	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
+)
+
+var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
+
+	Context("1-002-git-write-back-target-test", func() {
+
+		var (
+			k8sClient    client.Client
+			ctx          context.Context
+			ns           *corev1.Namespace
+			cleanupFunc  func()
+			imageUpdater *imageUpdaterApi.ImageUpdater
+			argoCD       *argov1beta1api.ArgoCD
+		)
+
+		BeforeEach(func() {
+			fixture.EnsureParallelCleanSlate()
+
+			k8sClient, _ = fixtureUtils.GetE2ETestKubeClient()
+			ctx = context.Background()
+		})
+
+		AfterEach(func() {
+			// Cleanup is best-effort. Issue deletes and give some time for controllers
+			// to process, but don't fail the test if cleanup takes too long.
+
+			if imageUpdater != nil {
+				By("deleting ImageUpdater CR")
+				_ = k8sClient.Delete(ctx, imageUpdater)
+			}
+
+			if argoCD != nil {
+				By("deleting ArgoCD CR")
+				_ = k8sClient.Delete(ctx, argoCD)
+			}
+
+			if cleanupFunc != nil {
+				cleanupFunc()
+			}
+
+			fixture.OutputDebugOnFail(ns)
+
+		})
+
+		It("ensures that Image Updater will update Argo CD Application using git write-back policy", func() {
+
+			By("creating simple namespace-scoped Argo CD instance with image updater enabled")
+			ns, cleanupFunc = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
+
+			By("Creating local git repo")
+			iuFixture.CreateLocalGitRepo(ctx, k8sClient, ns.Name)
+
+			By("waiting for local git repo to be ready")
+			gitDepl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: iuFixture.Name, Namespace: ns.Name}}
+			Eventually(gitDepl).Should(k8sFixture.ExistByName())
+			Eventually(gitDepl, "2m", "3s").Should(deplFixture.HaveReadyReplicas(1), "git repo server was not ready")
+
+			argoCD = &argov1beta1api.ArgoCD{
+				ObjectMeta: metav1.ObjectMeta{Name: "argocd", Namespace: ns.Name},
+				Spec: argov1beta1api.ArgoCDSpec{
+					ImageUpdater: argov1beta1api.ArgoCDImageUpdaterSpec{
+						Env: []corev1.EnvVar{
+							{
+								Name:  "IMAGE_UPDATER_LOGLEVEL",
+								Value: "trace",
+							},
+							{
+								Name:  "IMAGE_UPDATER_INTERVAL",
+								Value: "0",
+							},
+						},
+						Enabled: true},
+				},
+			}
+			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
+
+			By("waiting for ArgoCD CR to be reconciled and the instance to be ready")
+			Eventually(argoCD, "5m", "3s").Should(argocdFixture.BeAvailable())
+
+			By("verifying all workloads are started")
+			deploymentsShouldExist := []string{"argocd-redis", "argocd-server", "argocd-repo-server", "argocd-argocd-image-updater-controller"}
+			for _, depl := range deploymentsShouldExist {
+				depl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: depl, Namespace: ns.Name}}
+				Eventually(depl).Should(k8sFixture.ExistByName())
+				Eventually(depl).Should(deplFixture.HaveReplicas(1))
+				Eventually(depl, "3m", "3s").Should(deplFixture.HaveReadyReplicas(1), depl.Name+" was not ready")
+			}
+
+			statefulSet := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "argocd-application-controller", Namespace: ns.Name}}
+			Eventually(statefulSet).Should(k8sFixture.ExistByName())
+			Eventually(statefulSet).Should(ssFixture.HaveReplicas(1))
+			Eventually(statefulSet, "3m", "3s").Should(ssFixture.HaveReadyReplicas(1))
+
+			By("creating Application")
+			app := &appv1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "app-01",
+					Namespace: ns.Name,
+				},
+				Spec: appv1alpha1.ApplicationSpec{
+					Project: "default",
+					Source: &appv1alpha1.ApplicationSource{
+						RepoURL:        fmt.Sprintf("https://%s.%s.svc.cluster.local:8081/testdata.git", iuFixture.Name, ns.Name),
+						Path:           "1-002-git-write-back-target-test",
+						TargetRevision: "HEAD",
+					},
+					Destination: appv1alpha1.ApplicationDestination{
+						Server:    "https://kubernetes.default.svc",
+						Namespace: ns.Name,
+					},
+					SyncPolicy: &appv1alpha1.SyncPolicy{
+						Automated: &appv1alpha1.SyncPolicyAutomated{
+							Prune: true, // Automatically delete old resources (pods) that are no longer in git
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+
+			By("verifying deploying the Application succeeded")
+			Eventually(app, "4m", "3s").Should(applicationFixture.HaveHealthStatusCode(health.HealthStatusHealthy))
+			Eventually(app, "4m", "3s").Should(applicationFixture.HaveSyncStatusCode(appv1alpha1.SyncStatusCodeSynced))
+
+			By("creating ImageUpdater CR")
+			updateStrategy := "semver"
+			forceUpdate := false
+			method := fmt.Sprintf("git:secret:%s/%s", ns.Name, iuFixture.Name)
+			branch := "master"
+			repository := fmt.Sprintf("https://%s.%s.svc.cluster.local:8081/testdata.git", iuFixture.Name, ns.Name)
+
+			imageUpdater = &imageUpdaterApi.ImageUpdater{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "image-updater",
+					Namespace: ns.Name,
+				},
+				Spec: imageUpdaterApi.ImageUpdaterSpec{
+					Namespace: ns.Name,
+					CommonUpdateSettings: &imageUpdaterApi.CommonUpdateSettings{
+						UpdateStrategy: &updateStrategy,
+						ForceUpdate:    &forceUpdate,
+					},
+					WriteBackConfig: &imageUpdaterApi.WriteBackConfig{
+						Method: &method,
+						GitConfig: &imageUpdaterApi.GitConfig{
+							Branch:     &branch,
+							Repository: &repository,
+						},
+					},
+					ApplicationRefs: []imageUpdaterApi.ApplicationRef{
+						{
+							NamePattern: "app*",
+							Images: []imageUpdaterApi.ImageConfig{
+								{
+									Alias:     "test",
+									ImageName: "quay.io/dkarpele/my-guestbook:29437546.X",
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, imageUpdater)).To(Succeed())
+
+			By("ensuring that the Application image has `29437546.0` version after update")
+			triggerRefresh := iuFixture.TriggerArgoCDRefresh(ctx, k8sClient, app)
+			Eventually(func() string {
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(app), app)
+
+				if err != nil {
+					return "" // Let Eventually retry on error
+				}
+
+				// Trigger ArgoCD refresh periodically to force immediate git check
+				triggerRefresh()
+
+				// For git write-back method, the image updater writes changes to git, and ArgoCD syncs from git.
+				// The image appears in Status.Summary.Images (not in Spec.Source.Kustomize.Images like argocd write-back).
+				if len(app.Status.Summary.Images) > 0 {
+					return string(app.Status.Summary.Images[0])
+				}
+
+				// Return an empty string to signify the condition is not yet met.
+				return ""
+			}, "5m", "3s").Should(Equal("quay.io/dkarpele/my-guestbook:29437546.0"))
+		})
+	})
+})

--- a/test/ginkgo/prereqs/assets/configure-docker-daemon.sh
+++ b/test/ginkgo/prereqs/assets/configure-docker-daemon.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# Assisted-by: Claude AI model
+
+set -e
+
+REGISTRY="127.0.0.1:30000"
+DAEMON_JSON="/etc/docker/daemon.json"
+SUDO_CMD=""
+
+# Check if we're in CI (GitHub Actions) - always configure in CI
+IS_CI="${CI:-false}"
+if [ "$GITHUB_ACTIONS" = "true" ] || [ "$IS_CI" = "true" ]; then
+	IS_CI="true"
+fi
+
+# For local testing: check if registry is already configured and skip if so
+if [ "$IS_CI" != "true" ]; then
+	# Try to find daemon.json in common locations
+	CHECK_DAEMON_JSON=""
+	if [ -f "/etc/docker/daemon.json" ]; then
+		CHECK_DAEMON_JSON="/etc/docker/daemon.json"
+		CHECK_SUDO="sudo"
+	elif [ -f "$HOME/.docker/daemon.json" ]; then
+		CHECK_DAEMON_JSON="$HOME/.docker/daemon.json"
+		CHECK_SUDO=""
+	fi
+	
+	# If daemon.json exists, check if registry is already configured
+	if [ -n "$CHECK_DAEMON_JSON" ] && [ -f "$CHECK_DAEMON_JSON" ]; then
+		if command -v jq >/dev/null 2>&1; then
+			EXISTING_REGISTRIES=$(${CHECK_SUDO} cat "$CHECK_DAEMON_JSON" 2>/dev/null | jq -r '.["insecure-registries"] // [] | .[]' 2>/dev/null || echo "")
+			if echo "$EXISTING_REGISTRIES" | grep -q "^${REGISTRY}$"; then
+				echo "Registry ${REGISTRY} is already configured in ${CHECK_DAEMON_JSON}"
+				echo "Skipping Docker daemon configuration (local testing only)"
+				exit 0
+			fi
+		fi
+	fi
+fi
+
+# Detect OS and set daemon.json path
+if [ "$(uname)" = "Darwin" ]; then
+	echo "Detected macOS with Docker Desktop"
+	echo "Note: Docker Desktop on macOS uses its own settings UI."
+	echo "Please manually configure insecure registry in Docker Desktop:"
+	echo "  1. Open Docker Desktop"
+	echo "  2. Go to Settings > Docker Engine"
+	echo "  3. Add \"insecure-registries\": [\"127.0.0.1:30000\"] to the JSON config"
+	echo "  4. Click Apply & Restart"
+	echo ""
+	echo "Alternatively, if you have Docker running via Colima or similar, the script will attempt to configure it."
+	# Try common macOS Docker daemon.json locations
+	if [ -f "/etc/docker/daemon.json" ]; then
+		DAEMON_JSON="/etc/docker/daemon.json"
+		SUDO_CMD="sudo"
+	elif [ -f "$HOME/.docker/daemon.json" ]; then
+		DAEMON_JSON="$HOME/.docker/daemon.json"
+	fi
+else
+	echo "Detected Linux, using system daemon.json: $DAEMON_JSON"
+	# Always use sudo for /etc/docker on Linux (system directory)
+	# Also check if file exists and is not writable, or directory is not writable
+	if [ "$(dirname "$DAEMON_JSON")" = "/etc/docker" ] || \
+	   ([ -f "$DAEMON_JSON" ] && [ ! -w "$DAEMON_JSON" ]) || \
+	   [ ! -w "$(dirname "$DAEMON_JSON")" ] 2>/dev/null; then
+		SUDO_CMD="sudo"
+	fi
+	if [ ! -d "$(dirname "$DAEMON_JSON")" ]; then
+		${SUDO_CMD} mkdir -p "$(dirname "$DAEMON_JSON")"
+	fi
+fi
+
+# Check if we can proceed with file-based configuration
+if [ "$(uname)" = "Darwin" ] && [ ! -f "$DAEMON_JSON" ] && [ ! -w "/etc/docker" ]; then
+	echo "Skipping file-based configuration on macOS (Docker Desktop requires manual configuration)"
+	exit 0
+fi
+
+# Create backup if file exists
+if [ -f "$DAEMON_JSON" ]; then
+	echo "Backing up existing daemon.json to $DAEMON_JSON.backup"
+	${SUDO_CMD} cp "$DAEMON_JSON" "$DAEMON_JSON.backup" || true
+fi
+
+# Read existing config or create empty object
+if [ -f "$DAEMON_JSON" ]; then
+	EXISTING_CONFIG=$(${SUDO_CMD} cat "$DAEMON_JSON" 2>/dev/null || echo "{}")
+else
+	EXISTING_CONFIG="{}"
+fi
+
+# Use jq to merge insecure-registries (jq is lightweight and commonly available)
+if command -v jq >/dev/null 2>&1; then
+	NEW_CONFIG=$(echo "$EXISTING_CONFIG" | jq --arg reg "$REGISTRY" 'if .["insecure-registries"] == null then .["insecure-registries"] = [] else . end | if (.["insecure-registries"] | index($reg)) == null then .["insecure-registries"] += [$reg] else . end')
+else
+	echo "Error: jq is required for JSON manipulation but was not found."
+	exit 1
+fi
+
+# Write new config
+echo "$NEW_CONFIG" | ${SUDO_CMD} tee "$DAEMON_JSON" > /dev/null
+echo "Successfully updated $DAEMON_JSON"
+
+# Restart Docker if on Linux and we have systemd
+if [ "$(uname)" != "Darwin" ] && command -v systemctl >/dev/null 2>&1; then
+	echo "Restarting Docker daemon..."
+	${SUDO_CMD} systemctl restart docker || echo "Warning: Could not restart Docker. Please restart manually."
+	sleep 2
+	docker info > /dev/null 2>&1 || echo "Warning: Docker may need a moment to restart"
+elif [ "$(uname)" = "Darwin" ] && [ -f "$DAEMON_JSON" ]; then
+	echo "On macOS, please restart Docker Desktop manually for the changes to take effect:"
+	echo "  1. Click the Docker icon in the menu bar"
+	echo "  2. Select 'Restart' from the dropdown menu"
+	echo "  Or restart Docker Desktop from the Applications folder"
+fi
+

--- a/test/ginkgo/prereqs/assets/generate-registry-tls-secrets.sh
+++ b/test/ginkgo/prereqs/assets/generate-registry-tls-secrets.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Assisted-by: Claude AI model
+# Generate TLS certificates and create Kubernetes secrets for registry deployments
+# This script generates self-signed certificates and creates kubernetes.io/tls secrets
+
+set -e
+
+NAMESPACE="${NAMESPACE:-argocd-operator-system}"
+CERT_VALIDITY_DAYS="${CERT_VALIDITY_DAYS:-365}"
+CN="${CN:-e2e-registry}"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Check if required tools are available
+if ! command -v openssl &> /dev/null; then
+  echo -e "${RED}Error: openssl is not installed or not in PATH${NC}" >&2
+  exit 1
+fi
+
+if ! command -v kubectl &> /dev/null; then
+  echo -e "${RED}Error: kubectl is not installed or not in PATH${NC}" >&2
+  exit 1
+fi
+
+echo -e "${GREEN}Generating TLS certificates for registry deployments...${NC}"
+
+# Create temporary directory for certificates
+TMP_DIR=$(mktemp -d)
+trap "rm -rf $TMP_DIR" EXIT
+
+# Function to generate certificate and create secret
+generate_secret() {
+  local SECRET_NAME=$1
+  local CERT_FILE="$TMP_DIR/${SECRET_NAME}.crt"
+  local KEY_FILE="$TMP_DIR/${SECRET_NAME}.key"
+
+  echo -e "${YELLOW}Generating certificate for ${SECRET_NAME}...${NC}"
+  
+  # Generate private key
+  openssl genrsa -out "$KEY_FILE" 2048 2>/dev/null
+  
+  # Generate certificate signing request
+  openssl req -new -key "$KEY_FILE" -out "$TMP_DIR/${SECRET_NAME}.csr" \
+    -subj "/C=US/ST=State/L=City/O=Organization/CN=${CN}" 2>/dev/null
+  
+  # Generate self-signed certificate
+  openssl x509 -req -days "$CERT_VALIDITY_DAYS" -in "$TMP_DIR/${SECRET_NAME}.csr" \
+    -signkey "$KEY_FILE" -out "$CERT_FILE" 2>/dev/null
+  
+  # Create or update Kubernetes secret
+  echo -e "${YELLOW}Creating Kubernetes secret ${SECRET_NAME} in namespace ${NAMESPACE}...${NC}"
+  
+  # Check if namespace exists, create if it doesn't
+  if ! kubectl get namespace "$NAMESPACE" &>/dev/null; then
+    echo -e "${YELLOW}Namespace ${NAMESPACE} does not exist, creating it...${NC}"
+    kubectl create namespace "$NAMESPACE"
+  fi
+  
+  # Create secret using kubectl create secret tls
+  kubectl create secret tls "$SECRET_NAME" \
+    --cert="$CERT_FILE" \
+    --key="$KEY_FILE" \
+    --namespace="$NAMESPACE" \
+    --dry-run=client -o yaml | kubectl apply -f -
+  
+  echo -e "${GREEN}Secret ${SECRET_NAME} created/updated successfully${NC}"
+}
+
+# Generate secrets for both registries
+generate_secret "e2e-registry-public-tls"
+generate_secret "e2e-registry-private-tls"
+
+echo -e "${GREEN}All TLS secrets generated and applied successfully!${NC}"
+

--- a/test/ginkgo/prereqs/assets/registries.yaml
+++ b/test/ginkgo/prereqs/assets/registries.yaml
@@ -1,0 +1,4 @@
+configs:
+  "127.0.0.1:30000":
+    tls:
+      insecure_skip_verify: true

--- a/test/ginkgo/prereqs/assets/registry.yaml
+++ b/test/ginkgo/prereqs/assets/registry.yaml
@@ -1,0 +1,161 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: e2e-registry-public
+  labels:
+    app: registry
+    type: public
+    component: argocd-operator-system
+data:
+  registry.conf: |
+    version: 0.1
+    storage:
+      filesystem:
+        rootdirectory: /var/lib/storage
+        maxthreads: 100
+    http:
+      addr: 0.0.0.0:5000
+      tls:
+        certificate: /tmp/tls/tls.crt
+        key: /tmp/tls/tls.key
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: e2e-registry-public
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: registry
+      type: public
+      component: argocd-operator-system
+  template:
+    metadata:
+      labels:
+        app: registry
+        type: public
+        component: argocd-operator-system
+    spec:
+      containers:
+      - name: registry
+        command:
+        - registry
+        - serve
+        - /tmp/config/registry.conf
+        image: registry
+        ports:
+          - containerPort: 5000
+        volumeMounts:
+        - name: config
+          mountPath: /tmp/config
+        - name: tls
+          mountPath: /tmp/tls
+          readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: e2e-registry-public
+            items:
+            - key: registry.conf
+              path: registry.conf
+        - name: tls
+          secret:
+            secretName: e2e-registry-public-tls
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: e2e-registry-public
+spec:
+  type: NodePort
+  selector:
+    app: registry
+    type: public
+  ports:
+    - protocol: TCP
+      port: 443
+      targetPort: 5000
+      nodePort: 30000
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: e2e-registry-private
+  labels:
+    app: registry
+    type: private
+    component: argocd-operator-system
+data:
+  registry.conf: |
+    version: 0.1
+    storage:
+      filesystem:
+        rootdirectory: /var/lib/storage
+        maxthreads: 100
+    http:
+      addr: 0.0.0.0:5000
+      tls:
+        certificate: /tmp/tls/tls.crt
+        key: /tmp/tls/tls.key
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: e2e-registry-private
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: registry
+      type: private
+      component: argocd-operator-system
+  template:
+    metadata:
+      labels:
+        app: registry
+        type: private
+        component: argocd-operator-system
+    spec:
+      containers:
+      - name: registry
+        command:
+        - registry
+        - serve
+        - /tmp/config/registry.conf
+        image: registry
+        ports:
+          - containerPort: 5000
+        volumeMounts:
+        - name: config
+          mountPath: /tmp/config
+        - name: tls
+          mountPath: /tmp/tls
+          readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: e2e-registry-private
+            items:
+            - key: registry.conf
+              path: registry.conf
+        - name: tls
+          secret:
+            secretName: e2e-registry-private-tls
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: e2e-registry-private
+spec:
+  type: NodePort
+  selector:
+    app: registry
+    type: private
+  ports:
+    - protocol: TCP
+      port: 443
+      targetPort: 5000
+      nodePort: 30001
+---
+

--- a/test/ginkgo/prereqs/assets/wait-utils.sh
+++ b/test/ginkgo/prereqs/assets/wait-utils.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Assisted-by: Claude AI model
+# Utility functions for waiting on cluster and registry readiness
+
+# wait_for_cluster_ready waits for the Kubernetes cluster to be ready
+# Usage: wait_for_cluster_ready [timeout_seconds] [kubectl_command]
+wait_for_cluster_ready() {
+	local timeout=${1:-120}
+	local kubectl=${2:-kubectl}
+	local elapsed=0
+
+	echo "--- Waiting for k3d cluster to be ready ---"
+	while [ $elapsed -lt $timeout ]; do
+		if $kubectl get nodes >/dev/null 2>&1 && $kubectl get namespaces >/dev/null 2>&1; then
+			echo "Cluster is ready"
+			return 0
+		fi
+		printf "."
+		sleep 2
+		elapsed=$((elapsed + 2))
+	done
+	echo ""
+	echo "Error: Cluster did not become ready within $timeout seconds" >&2
+	return 1
+}
+
+# wait_for_registry_ready waits for the registry service to be accessible
+# Usage: wait_for_registry_ready [timeout_seconds] [registry_url]
+wait_for_registry_ready() {
+	local timeout=${1:-60}
+	local registry_url=${2:-https://127.0.0.1:30000/v2/}
+	local elapsed=0
+
+	echo "Waiting for registry service to be accessible at 127.0.0.1:30000..."
+	while [ $elapsed -lt $timeout ]; do
+		if curl -k -s -o /dev/null -w "%{http_code}" "$registry_url" 2>/dev/null | grep -q "200\|401\|404"; then
+			echo "Registry is accessible"
+			return 0
+		fi
+		printf "."
+		sleep 1
+		elapsed=$((elapsed + 1))
+	done
+	echo ""
+	echo "Warning: Registry may not be fully ready, but attempting push anyway..."
+	return 1
+}
+
+# If script is called directly (not sourced), execute the function
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+	"$@"
+fi
+

--- a/test/ginkgo/prereqs/containers/git/Dockerfile
+++ b/test/ginkgo/prereqs/containers/git/Dockerfile
@@ -1,0 +1,21 @@
+FROM nginx:alpine-slim
+
+RUN set -x && \
+  apk --update upgrade                                  &&  \
+  apk add git git-daemon bash fcgiwrap spawn-fcgi wget openssl apache2-utils  &&  \
+  adduser git -h /var/lib/git -D                        &&  \
+  addgroup nginx git                                     &&  \
+  git config --system http.receivepack true             &&  \
+  git config --system http.uploadpack true              &&  \
+  git config --system user.email "gitserver@git.com"    &&  \
+  git config --system user.name "Git Server"            &&  \
+  ln -sf /dev/stdout /var/log/nginx/access.log          &&  \
+  ln -sf /dev/stderr /var/log/nginx/error.log
+
+COPY ./etc /etc
+COPY ./entrypoint.sh /usr/local/bin/entrypoint
+
+ENTRYPOINT [ "entrypoint" ]
+CMD [ "-start" ]
+
+COPY ./testdata /var/lib/initial/testdata

--- a/test/ginkgo/prereqs/containers/git/entrypoint.sh
+++ b/test/ginkgo/prereqs/containers/git/entrypoint.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+# Initializes Nginx and the git cgi scripts
+# for git http-backend through fcgiwrap.
+#
+# Usage:
+#   entrypoint <commands>
+
+set -o errexit
+set -o pipefail
+
+readonly GIT_PROJECT_ROOT="/var/lib/git"
+readonly GIT_INITIAL_ROOT="/var/lib/initial"
+export GIT_HTTP_EXPORT_ALL="true"
+readonly GIT_USER="git"
+readonly GIT_GROUP="git"
+
+readonly FCGIPROGRAM="/usr/bin/fcgiwrap"
+readonly USERID="nginx"
+readonly SOCKUSERID="$USERID"
+readonly FCGISOCKET="/var/run/fcgiwrap.socket"
+readonly SSL_CERT_PATH="/etc/nginx/localhost.crt"
+readonly SSL_KEY_PATH="/etc/nginx/localhost.key"
+readonly HTPASSWD_PATH="/etc/nginx/htpasswd"
+readonly GIT_USERNAME="git"
+readonly GIT_PASSWORD="git"
+
+main() {
+  mkdir -p "$GIT_PROJECT_ROOT"
+
+  # Generate self-signed certificate if it doesn't exist
+  generate_ssl_certificate
+
+  # Generate htpasswd file if it doesn't exist
+  generate_htpasswd
+
+  # Checks if $GIT_INITIAL_ROOT has files
+  if [[ $(ls -A "${GIT_INITIAL_ROOT}") ]]; then
+    initialize_initial_repositories
+  fi
+  initialize_services
+}
+
+generate_ssl_certificate() {
+  # Generate self-signed certificate if it doesn't exist
+  if [[ ! -f "$SSL_CERT_PATH" ]] || [[ ! -f "$SSL_KEY_PATH" ]]; then
+    echo "Generating self-signed SSL certificate..."
+    openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+      -keyout "$SSL_KEY_PATH" \
+      -out "$SSL_CERT_PATH" \
+      -subj "/C=US/ST=State/L=City/O=Organization/CN=localhost" \
+      2>/dev/null
+    chmod 600 "$SSL_KEY_PATH"
+    chmod 644 "$SSL_CERT_PATH"
+    echo "Self-signed SSL certificate generated at $SSL_CERT_PATH"
+  fi
+}
+
+generate_htpasswd() {
+  # Generate htpasswd file if it doesn't exist
+  if [[ ! -f "$HTPASSWD_PATH" ]]; then
+    echo "Generating htpasswd file..."
+    htpasswd -b -c "$HTPASSWD_PATH" "$GIT_USERNAME" "$GIT_PASSWORD" 2>/dev/null
+    chmod 644 "$HTPASSWD_PATH"
+    echo "htpasswd file generated at $HTPASSWD_PATH for user $GIT_USERNAME"
+  fi
+}
+
+initialize_services() {
+  # Check permissions on $GIT_PROJECT_ROOT
+  chown -R nginx:git "$GIT_PROJECT_ROOT"
+  chmod -R 775 "$GIT_PROJECT_ROOT"
+
+  /usr/bin/spawn-fcgi \
+    -s "$FCGISOCKET" \
+    -F 4 \
+    -u "$USERID" \
+    -g "$USERID" \
+    -U "$USERID" \
+    -G "$GIT_GROUP" -- \
+    "$FCGIPROGRAM"
+  exec nginx
+}
+
+initialize_initial_repositories() {
+  cd "$GIT_INITIAL_ROOT"
+  find . -type d -maxdepth 1 -mindepth 1 -print0 | while IFS= read -r -d '' dir; do
+    echo "Initializing repository $dir"
+    init_and_commit "$dir"
+  done
+}
+
+init_and_commit() {
+  local dir="$1"
+  local tmp_dir
+  tmp_dir="$(mktemp -d)"
+  trap 'rm -rf "$tmp_dir"' RETURN
+  cp -r "$dir"/. "$tmp_dir"
+  pushd . >/dev/null
+  cd "$tmp_dir"
+  if [[ -d "./.git" ]]; then
+    rm -rf ./.git
+  fi
+
+  git init &>/dev/null
+  git add --all . &>/dev/null
+  git commit -m "first commit" &>/dev/null
+  local repo_name="${dir#./}"
+  git clone --bare "$tmp_dir" "$GIT_PROJECT_ROOT/${repo_name}.git" &>/dev/null
+
+  popd >/dev/null
+}
+
+main "$@"

--- a/test/ginkgo/prereqs/containers/git/etc/nginx/nginx.conf
+++ b/test/ginkgo/prereqs/containers/git/etc/nginx/nginx.conf
@@ -1,0 +1,29 @@
+user                    nginx;
+worker_processes        4;
+pid                     /run/nginx.pid;
+
+events {
+	worker_connections    1024;
+}
+
+http {
+	sendfile              on;
+	tcp_nopush            on;
+	tcp_nodelay           on;
+	keepalive_timeout     65;
+	types_hash_max_size   2048;
+
+	include               /etc/nginx/mime.types;
+	default_type          application/octet-stream;
+
+	access_log            /var/log/nginx/access.log;
+	error_log             /var/log/nginx/error.log;
+
+	gzip                  on;
+	gzip_disable          "msie6";
+
+	include               /etc/nginx/sites-enabled/*;
+}
+
+
+daemon                  off;

--- a/test/ginkgo/prereqs/containers/git/etc/nginx/sites-enabled/git-http-auth
+++ b/test/ginkgo/prereqs/containers/git/etc/nginx/sites-enabled/git-http-auth
@@ -1,0 +1,36 @@
+server {
+  server_name         _;
+  listen 8081         ssl;
+  listen [::]:8081    ssl;
+
+  ssl_certificate     localhost.crt;
+  ssl_certificate_key localhost.key;
+  ssl_protocols       TLSv1.2 TLSv1.3;
+
+  auth_basic      "git";
+  auth_basic_user_file "/etc/nginx/htpasswd";
+
+  location /ping {
+    add_header Content-Type text/plain;
+    return 200 'pong';
+  }
+
+  location ~ ^.*\.git/objects/([0-9a-f]+/[0-9a-f]+|pack/pack-[0-9a-f]+.(pack|idx))$ {
+    root            /var/lib/git;
+  }
+
+  location ~ ^.*\.git/(HEAD|info/refs|objects/info/.*|git-(upload|receive)-pack)$ {
+    include         fastcgi_params;
+    fastcgi_param   SCRIPT_FILENAME /usr/libexec/git-core/git-http-backend;
+    fastcgi_param   GIT_HTTP_EXPORT_ALL "";
+    fastcgi_param   GIT_PROJECT_ROOT /var/lib/git;
+    fastcgi_param   PATH_INFO $uri;
+    fastcgi_param   REMOTE_USER $remote_user;
+    fastcgi_pass    unix:/var/run/fcgiwrap.socket;
+  }
+
+  location / {
+    try_files       $uri $uri/ =404;
+  }
+}
+

--- a/test/ginkgo/prereqs/containers/git/etc/nginx/sites-enabled/git-http-noauth
+++ b/test/ginkgo/prereqs/containers/git/etc/nginx/sites-enabled/git-http-noauth
@@ -1,0 +1,29 @@
+server {
+  server_name         _;
+  listen 8080         default_server;
+  listen [::]:8080    default_server;
+
+  location /ping {
+    add_header Content-Type text/plain;
+    return 200 'pong';
+  }
+
+  location ~ ^.*\.git/objects/([0-9a-f]+/[0-9a-f]+|pack/pack-[0-9a-f]+\.(pack|idx))$ {
+    root            /var/lib/git;
+  }
+
+  location ~ ^.*\.git/(HEAD|info/refs|objects/info/.*|git-(upload|receive)-pack)$ {
+    include         fastcgi_params;
+    fastcgi_param   SCRIPT_FILENAME /usr/libexec/git-core/git-http-backend;
+    fastcgi_param   GIT_HTTP_EXPORT_ALL "";
+    fastcgi_param   GIT_PROJECT_ROOT /var/lib/git;
+    fastcgi_param   PATH_INFO $uri;
+    fastcgi_param   REMOTE_USER $remote_user;
+    fastcgi_pass    unix:/var/run/fcgiwrap.socket;
+  }
+
+  location / {
+    try_files       $uri $uri/ =404;
+  }
+}
+

--- a/test/ginkgo/prereqs/containers/git/testdata/1-002-git-write-back-target-test/deployment.yaml
+++ b/test/ginkgo/prereqs/containers/git/testdata/1-002-git-write-back-target-test/deployment.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: 1-002-git-write-back-target-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: 1-002-git-write-back-target-test
+  template:
+    metadata:
+      labels:
+        app: 1-002-git-write-back-target-test
+    spec:
+      containers:
+      - name: test
+        image: quay.io/dkarpele/my-guestbook:1.0.0

--- a/test/ginkgo/prereqs/containers/git/testdata/1-002-git-write-back-target-test/kustomization.yaml
+++ b/test/ginkgo/prereqs/containers/git/testdata/1-002-git-write-back-target-test/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - deployment.yaml


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-cluster local Git server and local container registry support for E2E testing; container image and entrypoint for the Git server.
  * Utilities to wait for cluster/registry readiness and registry TLS generation.

* **Tests**
  * New parallel E2E test for git write‑back behavior.
  * Unified and simplified E2E orchestration and workflow; increased parallel test concurrency.

* **Documentation**
  * Updated E2E README with macOS notes and revised run sequence.

* **Chores**
  * Ignore runtime TLS/key and htpasswd artifacts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->