### PR TITLE
chore: update github.com/argoproj-labs/argocd-image-updater/registry-scanner from v1.0.0 to v1.0.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/argoproj-labs/argocd-image-updater
 go 1.24.6
 
 require (
-	github.com/argoproj-labs/argocd-image-updater/registry-scanner v1.0.0
+	github.com/argoproj-labs/argocd-image-updater/registry-scanner v1.0.2
 	github.com/argoproj/argo-cd/v3 v3.1.9
 	github.com/argoproj/gitops-engine v0.7.1-0.20250905160054-e48120133eec
 	github.com/bmatcuk/doublestar/v4 v4.9.1


### PR DESCRIPTION
For release-1.0