### PR TITLE
chore(ci): change legacy branch ci images.yaml workflow to build latest-annotation-based image on pr merge only; change the default tag to latest-annotation-based in Makefile

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -1,29 +1,9 @@
 name: Build and push image
 
 on:
-  # push:
-  #   branches:
-  #     - master-annotation-based
-  # pull_request:
-  #   branches:
-  #     - master-annotation-based
-  #   types: [ labeled, unlabeled, opened, synchronize, reopened ]
-  #
-  # make it a manual trigger to disable automatic pushing of legacy images with `latest` tag
-  # to quay.io/argoprojlabs, and to prevent overwriting the current `latest` tag built from master branch.
-  #
-  workflow_dispatch:
-    inputs:
-      push:
-        description: 'Push image to registry'
-        required: false
-        default: false
-        type: boolean
-      multiarch:
-        description: 'Build multi-architecture image'
-        required: false
-        default: false
-        type: boolean
+  push:
+    branches:
+      - master-annotation-based
 
 jobs:
   build_image:
@@ -41,29 +21,8 @@ jobs:
       - name: Build and possibly push image
         run: |
           set -ex
-          MULTIARCH=no
-          PUSH=no
-          if [[ "${{ github.event_name }}" == "push" ]]; then
-            MULTIARCH=yes
-            PUSH=yes
-          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            if [[ "${{ inputs.push }}" == "true" ]]; then
-              PUSH=yes
-            fi
-            if [[ "${{ inputs.multiarch }}" == "true" ]]; then
-              MULTIARCH=yes
-            fi
-          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'test-arm-image') }}" == "true" ]]; then
-            MULTIARCH=yes
-          fi
-          if [[ "${PUSH}" == "yes" ]]; then
-            docker login --username "${DOCKER_USERNAME}" --password "${DOCKER_PASSWORD}" quay.io
-          fi
-          if [[ "${MULTIARCH}" = "yes" ]]; then
-            IMAGE_TAG=latest-annotation-based IMAGE_PUSH=${PUSH} make multiarch-image
-          else
-            IMAGE_TAG=latest-annotation-based make image
-          fi
+          docker login --username "${DOCKER_USERNAME}" --password "${DOCKER_PASSWORD}" quay.io
+          IMAGE_PUSH=yes make multiarch-image
         working-directory: argocd-image-updater
         env:
           DOCKER_USERNAME: ${{ secrets.QUAY_USERNAME }}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 IMAGE_NAMESPACE?=quay.io/argoprojlabs
 IMAGE_NAME=argocd-image-updater
-IMAGE_TAG?=latest
+IMAGE_TAG?=latest-annotation-based
 ifdef IMAGE_NAMESPACE
 IMAGE_PREFIX=${IMAGE_NAMESPACE}/
 else

--- a/hack/generate-manifests.sh
+++ b/hack/generate-manifests.sh
@@ -20,9 +20,9 @@ if [ "$IMAGE_TAG" = "" ]; then
     IMAGE_TAG=v$(cat $SRCROOT/VERSION)
   fi
 fi
-# otherwise, use latest
+# otherwise, use latest-annotation-based
 if [ "$IMAGE_TAG" = "" ]; then
-  IMAGE_TAG=latest
+  IMAGE_TAG=latest-annotation-based
 fi
 
 cd ${SRCROOT}/manifests/base && ${KUSTOMIZE} edit set image ${IMAGE_NAMESPACE}/argocd-image-updater:${IMAGE_TAG}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default container image tag identifier to reflect annotation-based versioning
  * Streamlined build pipeline to standardize multi-architecture image generation for consistency

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->