### PR TITLE
feat(webhook): add Aliyun Container Registry (ACR) webhook handler

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -31,6 +31,8 @@ type WebhookConfig struct {
 	QuaySecret string
 	// HarborSecret is the secret for validating Harbor webhooks
 	HarborSecret string
+	// AliyunACRSecret is the secret for validating Aliyun ACR webhooks
+	AliyunACRSecret string
 	// CloudEventsSecret is the secret for validating CloudEvents webhooks
 	CloudEventsSecret string
 	// RateLimitNumAllowedRequests is the number of allowed requests per hour for rate limiting (0 disables rate limiting)
@@ -125,6 +127,7 @@ func SetupWebhookServer(webhookCfg *WebhookConfig, reconciler *controller.ImageU
 	handler.RegisterHandler(webhook.NewGHCRWebhook(webhookCfg.GHCRSecret))
 	handler.RegisterHandler(webhook.NewHarborWebhook(webhookCfg.HarborSecret))
 	handler.RegisterHandler(webhook.NewQuayWebhook(webhookCfg.QuaySecret))
+	handler.RegisterHandler(webhook.NewAliyunACRWebhook(webhookCfg.AliyunACRSecret))
 	handler.RegisterHandler(webhook.NewCloudEventsWebhook(webhookCfg.CloudEventsSecret))
 
 	// Create webhook server

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -318,6 +318,7 @@ This enables a CRD-driven approach to automated image updates with Argo CD.
 	controllerCmd.Flags().StringVar(&webhookCfg.GHCRSecret, "ghcr-webhook-secret", env.GetStringVal("GHCR_WEBHOOK_SECRET", ""), "Secret for validating GitHub Container Registry webhooks")
 	controllerCmd.Flags().StringVar(&webhookCfg.QuaySecret, "quay-webhook-secret", env.GetStringVal("QUAY_WEBHOOK_SECRET", ""), "Secret for validating Quay webhooks")
 	controllerCmd.Flags().StringVar(&webhookCfg.HarborSecret, "harbor-webhook-secret", env.GetStringVal("HARBOR_WEBHOOK_SECRET", ""), "Secret for validating Harbor webhooks")
+	controllerCmd.Flags().StringVar(&webhookCfg.AliyunACRSecret, "aliyun-acr-webhook-secret", env.GetStringVal("ALIYUN_ACR_WEBHOOK_SECRET", ""), "Secret for validating Aliyun ACR webhooks")
 	controllerCmd.Flags().StringVar(&webhookCfg.CloudEventsSecret, "cloudevents-webhook-secret", env.GetStringVal("CLOUDEVENTS_WEBHOOK_SECRET", ""), "Secret for validating CloudEvents webhooks")
 	controllerCmd.Flags().IntVar(&webhookCfg.RateLimitNumAllowedRequests, "webhook-ratelimit-allowed", env.ParseNumFromEnv("WEBHOOK_RATELIMIT_ALLOWED", 0, 0, math.MaxInt), "The number of allowed requests in an hour for webhook rate limiting, setting to 0 disables ratelimiting")
 

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -66,6 +66,7 @@ func TestNewRunCommand(t *testing.T) {
 	asser.Equal(env.GetStringVal("QUAY_WEBHOOK_SECRET", ""), controllerCommand.Flag("quay-webhook-secret").Value.String())
 	asser.Equal(env.GetStringVal("HARBOR_WEBHOOK_SECRET", ""), controllerCommand.Flag("harbor-webhook-secret").Value.String())
 	asser.Equal(env.GetStringVal("CLOUDEVENTS_WEBHOOK_SECRET", ""), controllerCommand.Flag("cloudevents-webhook-secret").Value.String())
+	asser.Equal(env.GetStringVal("ALIYUN_ACR_WEBHOOK_SECRET", ""), controllerCommand.Flag("aliyun-acr-webhook-secret").Value.String())
 	asser.Equal(strconv.Itoa(env.ParseNumFromEnv("WEBHOOK_RATELIMIT_ALLOWED", 0, 0, math.MaxInt)), controllerCommand.Flag("webhook-ratelimit-allowed").Value.String())
 
 	asser.Nil(controllerCommand.Help())

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -42,6 +42,7 @@ Supported registries:
 - GitHub Container Registry (GHCR)
 - Quay
 - Harbor
+- Aliyun ACR
 - AWS ECR (via EventBridge CloudEvents)
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -90,6 +91,7 @@ Supported registries:
 	webhookCmd.Flags().StringVar(&webhookCfg.GHCRSecret, "ghcr-webhook-secret", env.GetStringVal("GHCR_WEBHOOK_SECRET", ""), "Secret for validating GitHub Container Registry webhooks")
 	webhookCmd.Flags().StringVar(&webhookCfg.QuaySecret, "quay-webhook-secret", env.GetStringVal("QUAY_WEBHOOK_SECRET", ""), "Secret for validating Quay webhooks")
 	webhookCmd.Flags().StringVar(&webhookCfg.HarborSecret, "harbor-webhook-secret", env.GetStringVal("HARBOR_WEBHOOK_SECRET", ""), "Secret for validating Harbor webhooks")
+	webhookCmd.Flags().StringVar(&webhookCfg.AliyunACRSecret, "aliyun-acr-webhook-secret", env.GetStringVal("ALIYUN_ACR_WEBHOOK_SECRET", ""), "Secret for validating Aliyun ACR webhooks")
 	webhookCmd.Flags().StringVar(&webhookCfg.CloudEventsSecret, "cloudevents-webhook-secret", env.GetStringVal("CLOUDEVENTS_WEBHOOK_SECRET", ""), "Secret for validating CloudEvents webhooks")
 	webhookCmd.Flags().IntVar(&webhookCfg.RateLimitNumAllowedRequests, "webhook-ratelimit-allowed", env.ParseNumFromEnv("WEBHOOK_RATELIMIT_ALLOWED", 0, 0, math.MaxInt), "The number of allowed requests in an hour for webhook rate limiting, setting to 0 disables ratelimiting")
 

--- a/cmd/webhook_test.go
+++ b/cmd/webhook_test.go
@@ -43,6 +43,7 @@ func TestNewWebhookCommand(t *testing.T) {
 	asser.Equal(env.GetStringVal("QUAY_WEBHOOK_SECRET", ""), controllerCommand.Flag("quay-webhook-secret").Value.String())
 	asser.Equal(env.GetStringVal("HARBOR_WEBHOOK_SECRET", ""), controllerCommand.Flag("harbor-webhook-secret").Value.String())
 	asser.Equal(env.GetStringVal("CLOUDEVENTS_WEBHOOK_SECRET", ""), controllerCommand.Flag("cloudevents-webhook-secret").Value.String())
+	asser.Equal(env.GetStringVal("ALIYUN_ACR_WEBHOOK_SECRET", ""), controllerCommand.Flag("aliyun-acr-webhook-secret").Value.String())
 	asser.Equal(strconv.Itoa(env.ParseNumFromEnv("WEBHOOK_RATELIMIT_ALLOWED", 0, 0, math.MaxInt)), controllerCommand.Flag("webhook-ratelimit-allowed").Value.String())
 
 	asser.Nil(controllerCommand.Help())

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -940,6 +940,12 @@ spec:
               key: webhook.harbor-secret
               name: argocd-image-updater-secret
               optional: true
+        - name: ALIYUN_ACR_WEBHOOK_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: webhook.aliyun-acr-secret
+              name: argocd-image-updater-secret
+              optional: true
         - name: CLOUDEVENTS_WEBHOOK_SECRET
           valueFrom:
             secretKeyRef:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -164,6 +164,12 @@ spec:
                 name: argocd-image-updater-secret
                 key: webhook.harbor-secret
                 optional: true
+          - name: ALIYUN_ACR_WEBHOOK_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: argocd-image-updater-secret
+                key: webhook.aliyun-acr-secret
+                optional: true
           - name: CLOUDEVENTS_WEBHOOK_SECRET
             valueFrom:
               secretKeyRef:

--- a/docs/configuration/webhook.md
+++ b/docs/configuration/webhook.md
@@ -9,6 +9,7 @@ Currently Supported Registries:
 - GitHub Container Registry
 - Harbor
 - Quay
+- Aliyun ACR
 - AWS ECR (via EventBridge CloudEvents)
 
 Using webhooks can help reduce some of the stress that is put on the 
@@ -85,6 +86,7 @@ can be found here:
 - [GitHub Container Registry](https://docs.github.com/en/webhooks/webhook-events-and-payloads)
 - [Harbor](https://goharbor.io/docs/2.2.0/working-with-projects/project-configuration/configure-webhooks/)
 - [Quay](https://docs.quay.io/guides/notifications.html)
+- [Aliyun ACR](https://www.alibabacloud.com/help/en/acr/user-guide/manage-webhooks)
 - [AWS ECR via EventBridge](#aws-ecr-via-eventbridge-cloudevents) (see below)
 
 For the URL that you set for the webhook, your link should go as the following:
@@ -96,7 +98,16 @@ https://app1.example.com/webhook?type=<YOUR_REGISTRY_TYPE>
 # GitHub Container Registry = ghcr.io
 # Harbor = harbor
 # Quay = quay.io
+# Aliyun ACR = aliyun-acr
 # AWS ECR (via CloudEvents) = cloudevents
+```
+
+### Aliyun ACR Specifics
+
+Aliyun ACR (especially Enterprise Edition) uses various registry endpoints (e.g. `<instance>-registry.cn-shanghai.cr.aliyuncs.com`). Since the webhook payload does not contain the instance name, you must provide the registry URL via the `registry_url` query parameter if it differs from the default `registry.<region>.aliyuncs.com`:
+
+```text
+https://app1.example.com/webhook?type=aliyun-acr&registry_url=my-instance-registry.cn-shanghai.cr.aliyuncs.com
 ```
 
 ### AWS ECR via EventBridge CloudEvents
@@ -211,6 +222,7 @@ stringData:
   webhook.ghcr-secret: <YOUR_SECRET>
   webhook.harbor-secret: <YOUR_SECRET>
   webhook.quay-secret: <YOUR_SECRET>
+  webhook.aliyun-acr-secret: <YOUR_SECRET>
   webhook.cloudevents-secret: <YOUR_SECRET>
 ```
 
@@ -248,6 +260,7 @@ Supported Registries That Use This:
 
 - Docker Hub
 - Quay
+- Aliyun ACR
 - AWS ECR (via CloudEvents/EventBridge)
 
 Also be aware that if the container registry has a built-in secrets method you will
@@ -289,6 +302,7 @@ environment variables. Below is the list of which variables correspond to which 
 |`GHCR_WEBHOOK_SECRET` |`--ghcr-webhook-secret`|
 |`HARBOR_WEBHOOK_SECRET` |`--harbor-webhook-secret`|
 |`QUAY_WEBHOOK_SECRET` |`--quay-webhook-secret`|
+|`ALIYUN_ACR_WEBHOOK_SECRET` |`--aliyun-acr-webhook-secret`|
 |`CLOUDEVENTS_WEBHOOK_SECRET` |`--cloudevents-webhook-secret`|
 |`WEBHOOK_RATELIMIT_ALLOWED`|`--webhook-ratelimit-allowed`|
 
@@ -311,6 +325,7 @@ registries supported.
 (View Payload Format Section)
 - [Quay](https://docs.quay.io/guides/notifications.html)
 (View Repository Push Section)
+- [Aliyun ACR](https://www.alibabacloud.com/help/en/acr/user-guide/manage-webhooks)
 - [CloudEvents](#aws-ecr-via-eventbridge-cloudevents) (AWS ECR via EventBridge)
 
 ## Troubleshooting

--- a/docs/install/cmd/run.md
+++ b/docs/install/cmd/run.md
@@ -10,6 +10,12 @@ Runs the Argo CD Image Updater in a reconciliation loop with a set of options.
 
 ### Flags
 
+**--aliyun-acr-webhook-secret *secret***
+
+Secret for validating Aliyun ACR webhooks.
+
+Can also be set with the `ALIYUN_ACR_WEBHOOK_SECRET` environment variable.
+
 **--argocd-namespace *namespace***
 
 The namespace where Argo CD is running. Required only if the Image Updater runs in a different namespace than Argo CD.

--- a/docs/install/cmd/webhook.md
+++ b/docs/install/cmd/webhook.md
@@ -14,9 +14,16 @@ Supported Registries:
 - GitHub Container Registry (GHCR)
 - Quay
 - Harbor
+- Aliyun ACR (Alibaba Cloud Container Registry)
 - AWS EventBridge (CloudEvents)
 
 ### Flags
+
+**--aliyun-acr-webhook-secret *secret***
+
+Secret for validating Aliyun ACR webhooks.
+
+Can also be set with the `ALIYUN_ACR_WEBHOOK_SECRET` environment variable.
 
 **-argocd-namespace *namespace***
 

--- a/pkg/webhook/aliyun_acr.go
+++ b/pkg/webhook/aliyun_acr.go
@@ -1,0 +1,115 @@
+package webhook
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/argoproj-labs/argocd-image-updater/pkg/argocd"
+)
+
+// AliyunACRWebhook handles Aliyun Container Registry webhook events
+type AliyunACRWebhook struct {
+	secret string
+}
+
+// NewAliyunACRWebhook creates a new Aliyun ACR webhook handler
+func NewAliyunACRWebhook(secret string) *AliyunACRWebhook {
+	return &AliyunACRWebhook{
+		secret: secret,
+	}
+}
+
+// GetRegistryType returns the registry type this handler supports
+func (a *AliyunACRWebhook) GetRegistryType() string {
+	return "aliyun-acr"
+}
+
+// Validate validates the Aliyun ACR webhook payload
+func (a *AliyunACRWebhook) Validate(r *http.Request) error {
+	if r.Method != http.MethodPost {
+		return fmt.Errorf("invalid HTTP method: %s", r.Method)
+	}
+
+	// If secret is configured, validate it from query parameter
+	if a.secret != "" {
+		secret := r.URL.Query().Get("secret")
+		if secret == "" {
+			return fmt.Errorf("missing webhook secret")
+		}
+
+		if subtle.ConstantTimeCompare([]byte(secret), []byte(a.secret)) != 1 {
+			return fmt.Errorf("invalid webhook secret")
+		}
+	}
+
+	return nil
+}
+
+// Parse processes the Aliyun ACR webhook payload and returns a WebhookEvent
+func (a *AliyunACRWebhook) Parse(r *http.Request) (*argocd.WebhookEvent, error) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read request body: %w", err)
+	}
+
+	// Aliyun ACR payload structure for push events. reference: https://www.alibabacloud.com/help/en/acr/user-guide/manage-webhooks
+	var payload struct {
+		PushData struct {
+			Digest   string `json:"digest"`
+			PushedAt string `json:"pushed_at"`
+			Tag      string `json:"tag"`
+		} `json:"push_data"`
+		Repository struct {
+			DateCreated            string `json:"date_created"`
+			Name                   string `json:"name"`
+			Namespace              string `json:"namespace"`
+			Region                 string `json:"region"`
+			RepoAuthenticationType string `json:"repo_authentication_type"`
+			RepoFullName           string `json:"repo_full_name"`
+			RepoOriginType         string `json:"repo_origin_type"`
+			RepoType               string `json:"repo_type"`
+		} `json:"repository"`
+	}
+
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, fmt.Errorf("failed to parse webhook payload: %w", err)
+	}
+
+	// Extract repository name - Aliyun ACR uses namespace/name format
+	repository := payload.Repository.RepoFullName
+	if repository == "" {
+		repository = payload.Repository.Name
+		if ns := payload.Repository.Namespace; ns != "" && repository != "" {
+			repository = ns + "/" + repository
+		}
+	}
+
+	if repository == "" {
+		return nil, fmt.Errorf("repository name not found in webhook payload")
+	}
+
+	if payload.PushData.Tag == "" {
+		return nil, fmt.Errorf("tag not found in webhook payload")
+	}
+	// ACR Enterprise Edition instance name is usually <instance-name>-registry(-vpc).<region>.cr.aliyuncs.com
+	// payload does not contain the instance name, we support override registry URL through the query parameters in the URL of the webhook
+	registryURL := ""
+	if queryRegistry := r.URL.Query().Get("registry_url"); queryRegistry != "" {
+		registryURL = queryRegistry
+
+	} else if payload.Repository.Region != "" {
+		// Aliyun ACR registry URLs usually follow: registry.<region>.aliyuncs.com
+		// Note: VPC URLs usually follow: registry-vpc.<region>.aliyuncs.com, should be overridden by the query parameters in the URL of the webhook
+		registryURL = fmt.Sprintf("registry.%s.aliyuncs.com", payload.Repository.Region)
+	}
+
+	return &argocd.WebhookEvent{
+		RegistryURL: registryURL,
+		Repository:  repository,
+		Tag:         payload.PushData.Tag,
+		Digest:      payload.PushData.Digest,
+	}, nil
+}

--- a/pkg/webhook/aliyun_acr_test.go
+++ b/pkg/webhook/aliyun_acr_test.go
@@ -1,0 +1,223 @@
+package webhook
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestNewAliyunACRWebhook(t *testing.T) {
+	secret := "test-secret"
+	webhook := NewAliyunACRWebhook(secret)
+
+	if webhook == nil {
+		t.Fatal("expected webhook to be non-nil")
+	} else if webhook.secret != secret {
+		t.Errorf("expected secret to be %q, got %q", secret, webhook.secret)
+	}
+}
+
+func TestAliyunACRWebhook_GetRegistryType(t *testing.T) {
+	webhook := NewAliyunACRWebhook("")
+	registryType := webhook.GetRegistryType()
+
+	expected := "aliyun-acr"
+	if registryType != expected {
+		t.Errorf("expected registry type to be %q, got %q", expected, registryType)
+	}
+}
+
+func TestAliyunACRWebhook_Validate(t *testing.T) {
+	secret := "test-secret"
+	webhook := NewAliyunACRWebhook(secret)
+
+	tests := []struct {
+		name        string
+		method      string
+		secret      string
+		noSecret    bool
+		expectError bool
+	}{
+		{
+			name:        "valid POST request with correct secret",
+			method:      "POST",
+			secret:      "test-secret",
+			expectError: false,
+		},
+		{
+			name:        "valid POST request without secret",
+			method:      "POST",
+			noSecret:    true,
+			expectError: false,
+		},
+		{
+			name:        "invalid HTTP method",
+			method:      "GET",
+			secret:      "test-secret",
+			expectError: true,
+		},
+		{
+			name:        "missing secret when secret is configured",
+			method:      "POST",
+			secret:      "",
+			expectError: true,
+		},
+		{
+			name:        "invalid secret",
+			method:      "POST",
+			secret:      "not-the-secret",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testWebhook := webhook
+			if tt.noSecret {
+				testWebhook = NewAliyunACRWebhook("")
+			}
+
+			req := httptest.NewRequest(tt.method, "/webhook", nil)
+			if tt.secret != "" {
+				query := req.URL.Query()
+				query.Set("secret", tt.secret)
+				req.URL.RawQuery = query.Encode()
+			}
+
+			err := testWebhook.Validate(req)
+
+			if tt.expectError && err == nil {
+				t.Error("expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("expected no error but got: %v", err)
+			}
+		})
+	}
+}
+
+func TestAliyunACRWebhook_Parse(t *testing.T) {
+	tests := []struct {
+		name                string
+		payload             string
+		queryRegistry       string
+		expectedRepo        string
+		expectedTag         string
+		expectedRegistryURL string
+		expectError         bool
+	}{
+		{
+			name: "priority: query parameter",
+			payload: `{
+				"repository": { "repo_full_name": "ns/app", "region": "cn-shanghai" },
+				"push_data": { "tag": "v1" }
+			}`,
+			queryRegistry:       "query.cr.com",
+			expectedRepo:        "ns/app",
+			expectedTag:         "v1",
+			expectedRegistryURL: "query.cr.com",
+			expectError:         false,
+		},
+		{
+			name: "priority: region-based",
+			payload: `{
+				"repository": { "repo_full_name": "ns/app", "region": "cn-beijing" },
+				"push_data": { "tag": "v1" }
+			}`,
+			expectedRepo:        "ns/app",
+			expectedTag:         "v1",
+			expectedRegistryURL: "registry.cn-beijing.aliyuncs.com",
+			expectError:         false,
+		},
+		{
+			name: "full payload from user example",
+			payload: `{
+				"push_data": {
+					"digest": "sha256:457f4aa83fc9a6663ab9d1b0a6e2dce25a12a943ed5bf2c1747c58d48bbb4917", 
+					"pushed_at": "2016-11-29 12:25:46", 
+					"tag": "latest"
+				}, 
+				"repository": {
+					"date_created": "2016-10-28 21:31:42", 
+					"name": "repoTest", 
+					"namespace": "namespace", 
+					"region": "cn-hangzhou", 
+					"repo_authentication_type": "NO_CERTIFIED", 
+					"repo_full_name": "namespace/repoTest", 
+					"repo_origin_type": "NO_CERTIFIED", 
+					"repo_type": "PUBLIC"
+				}
+			}`,
+			expectedRepo:        "namespace/repoTest",
+			expectedTag:         "latest",
+			expectedRegistryURL: "registry.cn-hangzhou.aliyuncs.com",
+			expectError:         false,
+		},
+		{
+			name: "missing region without query parameter",
+			payload: `{
+				"repository": { "repo_full_name": "ns/app" },
+				"push_data": { "tag": "v1" }
+			}`,
+			expectedRepo:        "ns/app",
+			expectedTag:         "v1",
+			expectedRegistryURL: "",
+			expectError:         false,
+		},
+		{
+			name: "missing tag",
+			payload: `{
+				"repository": {
+					"repo_full_name": "myuser/myapp"
+				},
+				"push_data": {}
+			}`,
+			expectError: true,
+		},
+		{
+			name:        "invalid JSON",
+			payload:     `{"invalid": json}`,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			webhook := NewAliyunACRWebhook("")
+			req := httptest.NewRequest("POST", "/webhook", strings.NewReader(tt.payload))
+
+			if tt.queryRegistry != "" {
+				query := req.URL.Query()
+				query.Set("registry_url", tt.queryRegistry)
+				req.URL.RawQuery = query.Encode()
+			}
+
+			event, err := webhook.Parse(req)
+
+			if tt.expectError {
+				if err == nil {
+					t.Error("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("expected no error but got: %v", err)
+				return
+			}
+
+			if event == nil {
+				t.Fatal("expected event to be non-nil")
+			}
+			if event.RegistryURL != tt.expectedRegistryURL {
+				t.Errorf("expected registry URL to be %q, got %q", tt.expectedRegistryURL, event.RegistryURL)
+			}
+			if event.Repository != tt.expectedRepo {
+				t.Errorf("expected repository to be %q, got %q", tt.expectedRepo, event.Repository)
+			}
+			if event.Tag != tt.expectedTag {
+				t.Errorf("expected tag to be %q, got %q", tt.expectedTag, event.Tag)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds webhook support for Aliyun Container Registry (ACR) trigger, see [reference](https://www.alibabacloud.com/help/en/acr/user-guide/manage-webhooks)
- Add webhook handler for Aliyun Container Registry (ACR)
- Support registry_url query parameter for Enterprise Edition
- Add secret validation via query parameter
- Update documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Aliyun ACR webhook notifications for automatic image tag detection.
  * New configuration option to set Aliyun ACR webhook secret via CLI flag or environment variable.

* **Documentation**
  * Added comprehensive Aliyun ACR webhook setup guide with configuration examples and payload format details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->