### PR TITLE
chore(ci): remove push event from ci-tests and codeql to avoid post-pr-merge run; remove cron from codeql; remove pr activity types from image.yml to use defaults

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -1,14 +1,8 @@
 name: Integration tests
 on:
-  push:
-    branches:
-    - 'master'
-    - 'release-*'
-    - 'master-annotation-based'
   pull_request:
     branches:
     - 'master'
-    - 'master-annotation-based'
 
 jobs:
   check-go:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,13 +12,8 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [ master, master-annotation-based ]
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [ master, master-annotation-based ]
-  schedule:
-    - cron: '38 0 * * 5'
 
 jobs:
   analyze:

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -1,13 +1,13 @@
 name: Build and push image
 
 on:
-  push:
-    branches:
-      - master
+# restore the following push event once the automatic multi-arch image build is implemented
+#  push:
+#    branches:
+#      - master
   pull_request:
     branches:
       - master
-    types: [ labeled, unlabeled, opened, synchronize, reopened ]
 
 jobs:
   build_image:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow triggers so automated checks now run on pull requests only.
  * Disabled push- and schedule-triggered runs for CI, security scanning, and image builds; validations will no longer run on direct pushes or scheduled cron jobs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->