### PR TITLE
doc: Update Azure registry doc to patch new deployment name

### DIFF
--- a/docs/configuration/registries.md
+++ b/docs/configuration/registries.md
@@ -389,11 +389,12 @@ and annotations:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: argocd-image-updater
+  name: argocd-image-updater-controller
   labels:
     azure.workload.identity/use: "true"
   annotations:
-    azure.workload.identity/client-id: placeholder
+    azure.workload.identity/client-id: <REPLACE ME>
+    azure.workload.identity/tenant-id: <REPLACE ME>
 ```
 
 Patch the deployment with the appropriate Azure Workload identity labels, mount
@@ -403,7 +404,7 @@ directory and `ACR_NAME` environment variable:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: argocd-image-updater
+  name: argocd-image-updater-controller
 spec:
   selector:
     matchLabels:
@@ -414,9 +415,9 @@ spec:
         azure.workload.identity/use: "true"
     spec:
       containers:
-        - name: argocd-image-updater
-          command:
-            - /usr/local/bin/argocd-image-updater
+        - name: argocd-image-updater-controller
+          args:
+            - --metrics-bind-address=:8443
             - run
             - --registries-conf-path
             - /app/config/registries.conf


### PR DESCRIPTION
In v1 the main deployment was changed from `argocd-image-updater` to `argocd-image-updater-controller`. This updates the patch in the doc to use the correct name and also patch it to use the new `manager` command instead of using the old binary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration examples to reflect revised ServiceAccount and Deployment naming conventions.
  * Enhanced Azure workload identity annotations for improved authentication setup.
  * Adjusted metrics binding configuration in deployment specifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->