### PR TITLE
chore(deps): bump argo-cd from 3.2.3 to 3.2.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/argoproj-labs/argocd-image-updater
 
-go 1.25.0
+go 1.25.5
 
 require (
 	github.com/argoproj-labs/argocd-image-updater/registry-scanner v1.0.2
-	github.com/argoproj/argo-cd/v3 v3.2.3
+	github.com/argoproj/argo-cd/v3 v3.2.6
 	github.com/argoproj/gitops-engine v0.7.1-0.20251217140045-5baed5604d2d
 	github.com/bmatcuk/doublestar/v4 v4.9.1
 	github.com/bombsimon/logrusr/v2 v2.0.1

--- a/go.sum
+++ b/go.sum
@@ -41,8 +41,8 @@ github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuW
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
-github.com/argoproj/argo-cd/v3 v3.2.3 h1:7PLQOVhrs/+C2S9+LfDygibOHyZIytB7oMPdlFt8fio=
-github.com/argoproj/argo-cd/v3 v3.2.3/go.mod h1:aAglAkPzWVN2Q5N/K/5uYVW/+aZ/CuXtA+XZQV4IVmg=
+github.com/argoproj/argo-cd/v3 v3.2.6 h1:nDCjBnHyxUf6JFuCKjuuXHS23LFj6/TjuO/APrS1ku4=
+github.com/argoproj/argo-cd/v3 v3.2.6/go.mod h1:Wf349kOvhIwW1zo1kv82iGCwdOzBY6dp43yhvuCru54=
 github.com/argoproj/gitops-engine v0.7.1-0.20251217140045-5baed5604d2d h1:iUJYrbSvpV9n8vyl1sBt1GceM60HhHfnHxuzcm5apDg=
 github.com/argoproj/gitops-engine v0.7.1-0.20251217140045-5baed5604d2d/go.mod h1:PauXVUVcfiTgC+34lDdWzPS101g4NpsUtDAjFBnWf94=
 github.com/argoproj/pkg v0.13.7-0.20230627120311-a4dd357b057e h1:kuLQvJqwwRMQTheT4MFyKVM8Txncu21CHT4yBWUl1Mk=

--- a/registry-scanner/go.mod
+++ b/registry-scanner/go.mod
@@ -1,6 +1,6 @@
 module github.com/argoproj-labs/argocd-image-updater/registry-scanner
 
-go 1.25.0
+go 1.25.5
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0

--- a/test/ginkgo/go.mod
+++ b/test/ginkgo/go.mod
@@ -1,11 +1,11 @@
 module github.com/argoproj-labs/argocd-image-updater/test/ginkgo
 
-go 1.25.0
+go 1.25.5
 
 require (
 	github.com/argoproj-labs/argocd-image-updater v1.0.2
 	github.com/argoproj-labs/argocd-operator v0.17.0-rc1.0.20251127152419-b7f30e034efa
-	github.com/argoproj/argo-cd/v3 v3.2.3
+	github.com/argoproj/argo-cd/v3 v3.2.6
 	github.com/argoproj/gitops-engine v0.7.1-0.20251217140045-5baed5604d2d
 	github.com/onsi/ginkgo/v2 v2.27.3
 	github.com/onsi/gomega v1.38.2

--- a/test/ginkgo/go.sum
+++ b/test/ginkgo/go.sum
@@ -31,8 +31,8 @@ github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFI
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/argoproj-labs/argocd-operator v0.17.0-rc1.0.20251127152419-b7f30e034efa h1:5a4R/OOvOnJLrvQp1moOub0h0Q66Ux4XLXqmPjjuhac=
 github.com/argoproj-labs/argocd-operator v0.17.0-rc1.0.20251127152419-b7f30e034efa/go.mod h1:JUvpFGuOdBL23437e/IdBsdwUE+69J6LzKQ2Q42ycc0=
-github.com/argoproj/argo-cd/v3 v3.2.3 h1:7PLQOVhrs/+C2S9+LfDygibOHyZIytB7oMPdlFt8fio=
-github.com/argoproj/argo-cd/v3 v3.2.3/go.mod h1:aAglAkPzWVN2Q5N/K/5uYVW/+aZ/CuXtA+XZQV4IVmg=
+github.com/argoproj/argo-cd/v3 v3.2.6 h1:nDCjBnHyxUf6JFuCKjuuXHS23LFj6/TjuO/APrS1ku4=
+github.com/argoproj/argo-cd/v3 v3.2.6/go.mod h1:Wf349kOvhIwW1zo1kv82iGCwdOzBY6dp43yhvuCru54=
 github.com/argoproj/gitops-engine v0.7.1-0.20251217140045-5baed5604d2d h1:iUJYrbSvpV9n8vyl1sBt1GceM60HhHfnHxuzcm5apDg=
 github.com/argoproj/gitops-engine v0.7.1-0.20251217140045-5baed5604d2d/go.mod h1:PauXVUVcfiTgC+34lDdWzPS101g4NpsUtDAjFBnWf94=
 github.com/argoproj/pkg v0.13.7-0.20250305113207-cbc37dc61de5 h1:YBoLSjpoaJXaXAldVvBRKJuOPvIXz9UOv6S96gMJM/Q=


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain to version 1.25.5
  * Updated Argo CD dependency to version v3.2.6

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->