### PR TITLE
fix: Helm Manifest Targets name/tag should not be required when spec is set

### DIFF
--- a/api/v1alpha1/imageupdater_types.go
+++ b/api/v1alpha1/imageupdater_types.go
@@ -222,18 +222,20 @@ type ManifestTarget struct {
 }
 
 // HelmTarget defines parameters for updating image references within Helm values.
-// +kubebuilder:validation:XValidation:rule="has(self.spec) ? true : (has(self.name) && has(self.tag))",message="Either spec must be set, or both name and tag must be set together"
+// +kubebuilder:validation:XValidation:rule="has(self.spec) || (has(self.name) == has(self.tag))",message="Either spec must be set, both name and tag must be set together, or neither name nor tag must be set (defaults will be used)"
 type HelmTarget struct {
 	// Name is the dot-separated path to the Helm key for the image repository/name part.
 	// Example: "image.repository", "frontend.deployment.image.name".
-	// This field is required together with tag if spec is not set.
+	// If neither spec nor name/tag are set, defaults to "image.name".
+	// This field must be set together with tag if spec is not set and you want to override defaults.
 	// If spec is set, this field is ignored.
 	// +optional
 	Name *string `json:"name,omitempty"`
 
 	// Tag is the dot-separated path to the Helm key for the image tag part.
 	// Example: "image.tag", "frontend.deployment.image.version".
-	// This field is required together with name if spec is not set.
+	// If neither spec nor name/tag are set, defaults to "image.tag".
+	// This field must be set together with name if spec is not set and you want to override defaults.
 	// If spec is set, this field is ignored.
 	// +optional
 	Tag *string `json:"tag,omitempty"`

--- a/api/v1alpha1/imageupdater_types_test.go
+++ b/api/v1alpha1/imageupdater_types_test.go
@@ -616,7 +616,7 @@ var _ = Describe("HelmTarget Validation", func() {
 
 			err := k8sClient.Create(context.Background(), cr)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("Either spec must be set, or both name and tag must be set together"))
+			Expect(err.Error()).To(ContainSubstring("Either spec must be set, both name and tag must be set together, or neither name nor tag must be set"))
 		})
 
 		It("should reject HelmTarget with only tag", func() {
@@ -648,10 +648,10 @@ var _ = Describe("HelmTarget Validation", func() {
 
 			err := k8sClient.Create(context.Background(), cr)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("Either spec must be set, or both name and tag must be set together"))
+			Expect(err.Error()).To(ContainSubstring("Either spec must be set, both name and tag must be set together, or neither name nor tag must be set"))
 		})
 
-		It("should reject HelmTarget with neither spec nor name/tag", func() {
+		It("should accept HelmTarget with neither spec nor name/tag (defaults will be used)", func() {
 			cr := &ImageUpdater{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "image-updater-helm-empty",
@@ -677,8 +677,11 @@ var _ = Describe("HelmTarget Validation", func() {
 			}
 
 			err := k8sClient.Create(context.Background(), cr)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("Either spec must be set, or both name and tag must be set together"))
+			Expect(err).NotTo(HaveOccurred())
+
+			// Cleanup
+			err = k8sClient.Delete(context.Background(), cr)
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 })

--- a/config/crd/bases/argocd-image-updater.argoproj.io_imageupdaters.yaml
+++ b/config/crd/bases/argocd-image-updater.argoproj.io_imageupdaters.yaml
@@ -182,7 +182,8 @@ spec:
                                     description: |-
                                       Name is the dot-separated path to the Helm key for the image repository/name part.
                                       Example: "image.repository", "frontend.deployment.image.name".
-                                      This field is required together with tag if spec is not set.
+                                      If neither spec nor name/tag are set, defaults to "image.name".
+                                      This field must be set together with tag if spec is not set and you want to override defaults.
                                       If spec is set, this field is ignored.
                                     type: string
                                   spec:
@@ -196,15 +197,16 @@ spec:
                                     description: |-
                                       Tag is the dot-separated path to the Helm key for the image tag part.
                                       Example: "image.tag", "frontend.deployment.image.version".
-                                      This field is required together with name if spec is not set.
+                                      If neither spec nor name/tag are set, defaults to "image.tag".
+                                      This field must be set together with name if spec is not set and you want to override defaults.
                                       If spec is set, this field is ignored.
                                     type: string
                                 type: object
                                 x-kubernetes-validations:
-                                - message: Either spec must be set, or both name and
-                                    tag must be set together
-                                  rule: 'has(self.spec) ? true : (has(self.name) &&
-                                    has(self.tag))'
+                                - message: Either spec must be set, both name and
+                                    tag must be set together, or neither name nor
+                                    tag must be set (defaults will be used)
+                                  rule: has(self.spec) || (has(self.name) == has(self.tag))
                               kustomize:
                                 description: |-
                                   Kustomize specifies update parameters if the target manifest is managed by Kustomize

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -181,7 +181,8 @@ spec:
                                     description: |-
                                       Name is the dot-separated path to the Helm key for the image repository/name part.
                                       Example: "image.repository", "frontend.deployment.image.name".
-                                      This field is required together with tag if spec is not set.
+                                      If neither spec nor name/tag are set, defaults to "image.name".
+                                      This field must be set together with tag if spec is not set and you want to override defaults.
                                       If spec is set, this field is ignored.
                                     type: string
                                   spec:
@@ -195,15 +196,16 @@ spec:
                                     description: |-
                                       Tag is the dot-separated path to the Helm key for the image tag part.
                                       Example: "image.tag", "frontend.deployment.image.version".
-                                      This field is required together with name if spec is not set.
+                                      If neither spec nor name/tag are set, defaults to "image.tag".
+                                      This field must be set together with name if spec is not set and you want to override defaults.
                                       If spec is set, this field is ignored.
                                     type: string
                                 type: object
                                 x-kubernetes-validations:
-                                - message: Either spec must be set, or both name and
-                                    tag must be set together
-                                  rule: 'has(self.spec) ? true : (has(self.name) &&
-                                    has(self.tag))'
+                                - message: Either spec must be set, both name and
+                                    tag must be set together, or neither name nor
+                                    tag must be set (defaults will be used)
+                                  rule: has(self.spec) || (has(self.name) == has(self.tag))
                               kustomize:
                                 description: |-
                                   Kustomize specifies update parameters if the target manifest is managed by Kustomize


### PR DESCRIPTION
Closes: #1446

HelmTarget is valid if:
- spec is set, OR
- Both name and tag are set, OR
- Neither name nor tag are set (defaults will be used)

The HelmTarget is invalid if:
- Only name is set (without tag and without spec)
- Only tag is set (without name and without spec)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Helm target Name and Tag are now optional; validation requires either Spec be set, or both Name and Tag together (or neither). When Spec is set, Name and Tag are ignored; defaults apply when neither path is used.
* **Documentation**
  * Updated field descriptions and CRD/install schema wording to reflect new conditional validation and defaulting behavior.
* **Tests**
  * Added validation tests covering allowed and rejected Helm target combinations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->