### PR TITLE
fix: string comparison for Harbor webhook secret

### DIFF
--- a/docs/configuration/webhook.md
+++ b/docs/configuration/webhook.md
@@ -83,7 +83,7 @@ can be found here:
 
 - [Docker Hub](https://docs.docker.com/docker-hub/repos/manage/webhooks/)
 - [GitHub Container Registry](https://docs.github.com/en/webhooks/webhook-events-and-payloads)
-- [Harbor](https://goharbor.io/docs/1.10/working-with-projects/project-configuration/configure-webhooks/)
+- [Harbor](https://goharbor.io/docs/2.2.0/working-with-projects/project-configuration/configure-webhooks/)
 - [Quay](https://docs.quay.io/guides/notifications.html)
 - [AWS ECR via EventBridge](#aws-ecr-via-eventbridge-cloudevents) (see below)
 
@@ -307,8 +307,8 @@ registries supported.
 
 - [Docker Hub](https://docs.docker.com/docker-hub/repos/manage/webhooks/#example-webhook-payload)
 - [GitHub Container Registry](https://docs.github.com/en/webhooks/webhook-events-and-payloads#example-webhook-delivery)
-- [Harbor](https://goharbor.io/docs/1.10/working-with-projects/project-configuration/configure-webhooks/)
-(View JSON Payload Format Section)
+- [Harbor](https://goharbor.io/docs/2.2.0/working-with-projects/project-configuration/configure-webhooks/)
+(View Payload Format Section)
 - [Quay](https://docs.quay.io/guides/notifications.html)
 (View Repository Push Section)
 - [CloudEvents](#aws-ecr-via-eventbridge-cloudevents) (AWS ECR via EventBridge)

--- a/pkg/webhook/harbor.go
+++ b/pkg/webhook/harbor.go
@@ -1,9 +1,7 @@
 package webhook
 
 import (
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/hex"
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -43,23 +41,17 @@ func (h *HarborWebhook) Validate(r *http.Request) error {
 		return fmt.Errorf("invalid content type: %s", eventType)
 	}
 
-	// If secret is configured, validate the signature
+	// If secret is configured, validate the secret
+	// See: https://github.com/akuity/kargo/blob/main/pkg/webhook/external/harbor.go
 	if h.secret != "" {
-		signature := r.Header.Get("Authorization")
-		if signature == "" {
-			return fmt.Errorf("missing webhook signature")
+		authHeader := r.Header.Get("Authorization")
+		if authHeader == "" {
+			return fmt.Errorf("missing Authorization header when secret is configured")
 		}
 
-		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			return fmt.Errorf("failed to read request body: %w", err)
-		}
-
-		// Reset body for later reading
-		r.Body = io.NopCloser(strings.NewReader(string(body)))
-
-		if !h.validateSignature(body, signature) {
-			return fmt.Errorf("invalid webhook signature")
+		// Harbor sends plain secret value directly in Authorization header for external webhooks
+		if subtle.ConstantTimeCompare([]byte(authHeader), []byte(h.secret)) != 1 {
+			return fmt.Errorf("incorrect webhook secret")
 		}
 	}
 
@@ -156,24 +148,4 @@ func (h *HarborWebhook) Parse(r *http.Request) (*argocd.WebhookEvent, error) {
 		Tag:         resource.Tag,
 		Digest:      resource.Digest,
 	}, nil
-}
-
-// validateSignature validates the webhook signature using HMAC-SHA256
-func (h *HarborWebhook) validateSignature(body []byte, signature string) bool {
-	// Harbor signature format can vary, commonly uses sha256=<hex> in Authorization header
-	var expectedSig string
-
-	if strings.HasPrefix(signature, "sha256=") {
-		expectedSig = signature[7:] // Remove "sha256=" prefix
-	} else if strings.HasPrefix(signature, "Bearer ") {
-		expectedSig = signature[7:] // Remove "Bearer " prefix
-	} else {
-		expectedSig = signature
-	}
-
-	mac := hmac.New(sha256.New, []byte(h.secret))
-	mac.Write(body)
-	calculatedSig := hex.EncodeToString(mac.Sum(nil))
-
-	return hmac.Equal([]byte(expectedSig), []byte(calculatedSig))
 }


### PR DESCRIPTION
Closes #1402 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Harbor webhook links and example payload anchor to reference version 2.2.0 and the revised payload section label.

* **Refactor**
  * Simplified Harbor webhook authentication to rely on the Authorization header and clarified error messages for missing or incorrect credentials.

* **Tests**
  * Updated tests to reflect Authorization header-based authentication and adjusted expectations for success and error cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->