### PR TITLE
fix: string comparison for Harbor webhook secret

### DIFF
--- a/docs/configuration/webhook.md
+++ b/docs/configuration/webhook.md
@@ -82,7 +82,7 @@ can be found here:
 
 - [Docker Hub](https://docs.docker.com/docker-hub/repos/manage/webhooks/)
 - [GitHub Container Registry](https://docs.github.com/en/webhooks/webhook-events-and-payloads)
-- [Harbor](https://goharbor.io/docs/1.10/working-with-projects/project-configuration/configure-webhooks/)
+- [Harbor](https://goharbor.io/docs/2.2.0/working-with-projects/project-configuration/configure-webhooks/)
 - [Quay](https://docs.quay.io/guides/notifications.html)
 
 For the URL that you set for the webhook, your link should go as the following:
@@ -200,8 +200,8 @@ registries supported.
 
 - [Docker Hub](https://docs.docker.com/docker-hub/repos/manage/webhooks/#example-webhook-payload)
 - [GitHub Container Registry](https://docs.github.com/en/webhooks/webhook-events-and-payloads#example-webhook-delivery)
-- [Harbor](https://goharbor.io/docs/1.10/working-with-projects/project-configuration/configure-webhooks/)
-(View JSON Payload Format Section)
+- [Harbor](https://goharbor.io/docs/2.2.0/working-with-projects/project-configuration/configure-webhooks/)
+(View Payload Format Section)
 - [Quay](https://docs.quay.io/guides/notifications.html)
 (View Repository Push Section)
 

--- a/pkg/webhook/harbor_test.go
+++ b/pkg/webhook/harbor_test.go
@@ -2,9 +2,6 @@ package webhook
 
 import (
 	"bytes"
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/hex"
 	"io"
 	"net/http/httptest"
 	"strings"
@@ -39,20 +36,21 @@ func TestHarborWebhook_Validate(t *testing.T) {
 	webhook := NewHarborWebhook(secret)
 
 	tests := []struct {
-		name        string
-		method      string
-		contentType string
-		body        string
-		signature   string
-		noSecret    bool
-		expectError bool
+		name           string
+		method         string
+		contentType    string
+		body           string
+		authHeader     string
+		noSecret       bool
+		expectError    bool
+		expectedErrMsg string
 	}{
 		{
-			name:        "valid POST request with correct signature",
+			name:        "valid POST request with correct secret",
 			method:      "POST",
 			contentType: "application/json",
 			body:        `{"test": "data"}`,
-			signature:   generateHarborSignature(secret, `{"test": "data"}`),
+			authHeader:  secret,
 			expectError: false,
 		},
 		{
@@ -68,7 +66,7 @@ func TestHarborWebhook_Validate(t *testing.T) {
 			method:      "GET",
 			contentType: "application/json",
 			body:        `{"test": "data"}`,
-			signature:   generateHarborSignature(secret, `{"test": "data"}`),
+			authHeader:  secret,
 			expectError: true,
 		},
 		{
@@ -76,32 +74,26 @@ func TestHarborWebhook_Validate(t *testing.T) {
 			method:      "POST",
 			contentType: "text/plain",
 			body:        `{"test": "data"}`,
-			signature:   generateHarborSignature(secret, `{"test": "data"}`),
+			authHeader:  secret,
 			expectError: true,
 		},
 		{
-			name:        "missing signature when secret is configured",
-			method:      "POST",
-			contentType: "application/json",
-			body:        `{"test": "data"}`,
-			signature:   "",
-			expectError: true,
+			name:           "missing Authorization header when secret is configured",
+			method:         "POST",
+			contentType:    "application/json",
+			body:           `{"test": "data"}`,
+			authHeader:     "",
+			expectError:    true,
+			expectedErrMsg: "missing Authorization header when secret is configured",
 		},
 		{
-			name:        "invalid signature",
-			method:      "POST",
-			contentType: "application/json",
-			body:        `{"test": "data"}`,
-			signature:   "sha256=invalid",
-			expectError: true,
-		},
-		{
-			name:        "signature for different body",
-			method:      "POST",
-			contentType: "application/json",
-			body:        `{"test": "data"}`,
-			signature:   generateHarborSignature(secret, `{"different": "data"}`),
-			expectError: true,
+			name:           "incorrect secret",
+			method:         "POST",
+			contentType:    "application/json",
+			body:           `{"test": "data"}`,
+			authHeader:     "wrong-secret",
+			expectError:    true,
+			expectedErrMsg: "incorrect webhook secret",
 		},
 	}
 
@@ -114,17 +106,24 @@ func TestHarborWebhook_Validate(t *testing.T) {
 
 			req := httptest.NewRequest(tt.method, "/webhook", strings.NewReader(tt.body))
 			req.Header.Set("Content-Type", tt.contentType)
-			if tt.signature != "" {
-				req.Header.Set("Authorization", tt.signature)
+			if tt.authHeader != "" {
+				req.Header.Set("Authorization", tt.authHeader)
 			}
 
 			err := testWebhook.Validate(req)
 
-			if tt.expectError && err == nil {
-				t.Error("expected error but got none")
-			}
-			if !tt.expectError && err != nil {
-				t.Errorf("expected no error but got: %v", err)
+			if tt.expectError {
+				if err == nil {
+					t.Error("expected error but got none")
+					return
+				}
+				if tt.expectedErrMsg != "" && err.Error() != tt.expectedErrMsg {
+					t.Errorf("expected error message %q, got %q", tt.expectedErrMsg, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error but got: %v", err)
+				}
 			}
 		})
 	}
@@ -352,64 +351,6 @@ func TestHarborWebhook_Parse(t *testing.T) {
 	}
 }
 
-func TestHarborWebhook_validateSignature(t *testing.T) {
-	secret := "test-secret"
-	webhook := NewHarborWebhook(secret)
-
-	tests := []struct {
-		name      string
-		body      string
-		signature string
-		expected  bool
-	}{
-		{
-			name:      "valid signature with sha256 prefix",
-			body:      `{"test": "data"}`,
-			signature: generateHarborSignature(secret, `{"test": "data"}`),
-			expected:  true,
-		},
-		{
-			name:      "valid signature with Bearer prefix",
-			body:      `{"test": "data"}`,
-			signature: "Bearer " + generateHarborSignatureHex(secret, `{"test": "data"}`),
-			expected:  true,
-		},
-		{
-			name:      "valid signature without prefix",
-			body:      `{"test": "data"}`,
-			signature: generateHarborSignatureHex(secret, `{"test": "data"}`),
-			expected:  true,
-		},
-		{
-			name:      "invalid signature",
-			body:      `{"test": "data"}`,
-			signature: "sha256=invalid",
-			expected:  false,
-		},
-		{
-			name:      "empty signature",
-			body:      `{"test": "data"}`,
-			signature: "",
-			expected:  false,
-		},
-		{
-			name:      "signature for different body",
-			body:      `{"test": "data"}`,
-			signature: generateHarborSignature(secret, `{"different": "data"}`),
-			expected:  false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := webhook.validateSignature([]byte(tt.body), tt.signature)
-			if result != tt.expected {
-				t.Errorf("expected %v, got %v", tt.expected, result)
-			}
-		})
-	}
-}
-
 func TestHarborWebhook_ParseWithBodyReuse(t *testing.T) {
 	// Test that body can be read multiple times (e.g., after validation)
 	secret := "test-secret"
@@ -432,7 +373,7 @@ func TestHarborWebhook_ParseWithBodyReuse(t *testing.T) {
 
 	req := httptest.NewRequest("POST", "/webhook", strings.NewReader(payload))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", generateHarborSignature(secret, payload))
+	req.Header.Set("Authorization", secret)
 
 	// First, validate the request
 	err := webhook.Validate(req)
@@ -457,17 +398,6 @@ func TestHarborWebhook_ParseWithBodyReuse(t *testing.T) {
 	if event.RegistryURL != "harbor" {
 		t.Errorf("expected registry URL to be 'harbor', got %q", event.RegistryURL)
 	}
-}
-
-// Helper function to generate HMAC-SHA256 signature for Harbor testing
-func generateHarborSignature(secret, body string) string {
-	return "sha256=" + generateHarborSignatureHex(secret, body)
-}
-
-func generateHarborSignatureHex(secret, body string) string {
-	mac := hmac.New(sha256.New, []byte(secret))
-	mac.Write([]byte(body))
-	return hex.EncodeToString(mac.Sum(nil))
 }
 
 // Test helper to simulate reading request body multiple times


### PR DESCRIPTION
Closes #1402 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Harbor webhook configuration documentation to reflect current version references.

* **Improvements**
  * Updated Harbor webhook authentication validation to use Authorization header-based verification instead of previous mechanism.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->