### PR TITLE
fix: remove validation for HelmTarget params

### DIFF
--- a/api/v1alpha1/imageupdater_types.go
+++ b/api/v1alpha1/imageupdater_types.go
@@ -222,12 +222,10 @@ type ManifestTarget struct {
 }
 
 // HelmTarget defines parameters for updating image references within Helm values.
-// +kubebuilder:validation:XValidation:rule="has(self.spec) || (has(self.name) == has(self.tag))",message="Either spec must be set, both name and tag must be set together, or neither name nor tag must be set (defaults will be used)"
 type HelmTarget struct {
 	// Name is the dot-separated path to the Helm key for the image repository/name part.
 	// Example: "image.repository", "frontend.deployment.image.name".
 	// If neither spec nor name/tag are set, defaults to "image.name".
-	// This field must be set together with tag if spec is not set and you want to override defaults.
 	// If spec is set, this field is ignored.
 	// +optional
 	Name *string `json:"name,omitempty"`
@@ -235,7 +233,6 @@ type HelmTarget struct {
 	// Tag is the dot-separated path to the Helm key for the image tag part.
 	// Example: "image.tag", "frontend.deployment.image.version".
 	// If neither spec nor name/tag are set, defaults to "image.tag".
-	// This field must be set together with name if spec is not set and you want to override defaults.
 	// If spec is set, this field is ignored.
 	// +optional
 	Tag *string `json:"tag,omitempty"`

--- a/api/v1alpha1/imageupdater_types_test.go
+++ b/api/v1alpha1/imageupdater_types_test.go
@@ -587,7 +587,7 @@ var _ = Describe("HelmTarget Validation", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("should reject HelmTarget with only name", func() {
+		It("should accept HelmTarget with only name", func() {
 			cr := &ImageUpdater{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "image-updater-helm-name-only",
@@ -615,11 +615,14 @@ var _ = Describe("HelmTarget Validation", func() {
 			}
 
 			err := k8sClient.Create(context.Background(), cr)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("Either spec must be set, both name and tag must be set together, or neither name nor tag must be set"))
+			Expect(err).NotTo(HaveOccurred())
+
+			// Cleanup
+			err = k8sClient.Delete(context.Background(), cr)
+			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("should reject HelmTarget with only tag", func() {
+		It("should accept HelmTarget with only tag", func() {
 			cr := &ImageUpdater{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "image-updater-helm-tag-only",
@@ -647,8 +650,11 @@ var _ = Describe("HelmTarget Validation", func() {
 			}
 
 			err := k8sClient.Create(context.Background(), cr)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("Either spec must be set, both name and tag must be set together, or neither name nor tag must be set"))
+			Expect(err).NotTo(HaveOccurred())
+
+			// Cleanup
+			err = k8sClient.Delete(context.Background(), cr)
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should accept HelmTarget with neither spec nor name/tag (defaults will be used)", func() {

--- a/config/crd/bases/argocd-image-updater.argoproj.io_imageupdaters.yaml
+++ b/config/crd/bases/argocd-image-updater.argoproj.io_imageupdaters.yaml
@@ -183,7 +183,6 @@ spec:
                                       Name is the dot-separated path to the Helm key for the image repository/name part.
                                       Example: "image.repository", "frontend.deployment.image.name".
                                       If neither spec nor name/tag are set, defaults to "image.name".
-                                      This field must be set together with tag if spec is not set and you want to override defaults.
                                       If spec is set, this field is ignored.
                                     type: string
                                   spec:
@@ -198,15 +197,9 @@ spec:
                                       Tag is the dot-separated path to the Helm key for the image tag part.
                                       Example: "image.tag", "frontend.deployment.image.version".
                                       If neither spec nor name/tag are set, defaults to "image.tag".
-                                      This field must be set together with name if spec is not set and you want to override defaults.
                                       If spec is set, this field is ignored.
                                     type: string
                                 type: object
-                                x-kubernetes-validations:
-                                - message: Either spec must be set, both name and
-                                    tag must be set together, or neither name nor
-                                    tag must be set (defaults will be used)
-                                  rule: has(self.spec) || (has(self.name) == has(self.tag))
                               kustomize:
                                 description: |-
                                   Kustomize specifies update parameters if the target manifest is managed by Kustomize

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -182,7 +182,6 @@ spec:
                                       Name is the dot-separated path to the Helm key for the image repository/name part.
                                       Example: "image.repository", "frontend.deployment.image.name".
                                       If neither spec nor name/tag are set, defaults to "image.name".
-                                      This field must be set together with tag if spec is not set and you want to override defaults.
                                       If spec is set, this field is ignored.
                                     type: string
                                   spec:
@@ -197,15 +196,9 @@ spec:
                                       Tag is the dot-separated path to the Helm key for the image tag part.
                                       Example: "image.tag", "frontend.deployment.image.version".
                                       If neither spec nor name/tag are set, defaults to "image.tag".
-                                      This field must be set together with name if spec is not set and you want to override defaults.
                                       If spec is set, this field is ignored.
                                     type: string
                                 type: object
-                                x-kubernetes-validations:
-                                - message: Either spec must be set, both name and
-                                    tag must be set together, or neither name nor
-                                    tag must be set (defaults will be used)
-                                  rule: has(self.spec) || (has(self.name) == has(self.tag))
                               kustomize:
                                 description: |-
                                   Kustomize specifies update parameters if the target manifest is managed by Kustomize


### PR DESCRIPTION
Closes #1465


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Relaxed schema validation for Helm manifest targets. Name and tag are no longer required as a pair, and spec/name/tag can be provided independently, enabling more flexible configurations.

- Tests
  - Updated validation tests to accept name-only and tag-only Helm targets and added cleanup steps after successful runs.

- Documentation
  - Removed schema guidance that previously implied coupling between Helm name/tag/spec to reflect the relaxed validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->