### PR TITLE
chore: bump registry-scanner version to v1.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/argoproj-labs/argocd-image-updater
 go 1.25.5
 
 require (
-	github.com/argoproj-labs/argocd-image-updater/registry-scanner v1.0.2
+	github.com/argoproj-labs/argocd-image-updater/registry-scanner v1.1.0
 	github.com/argoproj/argo-cd/v3 v3.3.0
 	github.com/argoproj/gitops-engine v0.7.1-0.20251217140045-5baed5604d2d
 	github.com/bmatcuk/doublestar/v4 v4.10.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated registry-scanner dependency to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->