### PR TITLE
Sort Helm parameters alphabetically in .argocd-source-<appName>.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ handling on your side.
 ### Other changes
 
 * refactor: make argocd-image-updater-config volume mapping optional (#145)
+* enhancement: sort Helm parameters alphabetically in .argocd-source-<appName>.yaml for deterministic output
 
 ## 2020-12-06 - Release v0.8.0
 

--- a/docs/basics/update-methods.md
+++ b/docs/basics/update-methods.md
@@ -59,7 +59,8 @@ By default, Argo CD Image Updater will store the parameter in a file named
 its manifests from. This will allow Argo CD to pick up parameters in this
 file, when rendering manifests for the Application named `<appName>`. Using
 this approach will also minimize the possibility of merge conflicts, as long
-as no other party in your CI will modify this file.
+as no other party in your CI will modify this file. Helm parameters in this
+file are sorted alphabetically by name to ensure deterministic output.
 
 !!!note "A note on the application's target revision"
     Due to the nature of how Git write-back works, your application really

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -1877,14 +1877,14 @@ kustomize:
 		expected := `
 helm:
   parameters:
+  - name: bar
+    value: foo
+    forcestring: true
   - name: baz
     value: baz
     forcestring: false
   - name: foo
     value: bar
-    forcestring: true
-  - name: bar
-    value: foo
     forcestring: true
 `
 		app := v1alpha1.Application{
@@ -1940,11 +1940,11 @@ helm:
 		expected := `
 helm:
   parameters:
-  - name: foo
-    value: bar
-    forcestring: true
   - name: bar
     value: foo
+    forcestring: true
+  - name: foo
+    value: bar
     forcestring: true
 `
 		app := v1alpha1.Application{
@@ -1994,11 +1994,11 @@ helm:
 		expected := `
 helm:
   parameters:
-  - name: foo
-    value: bar
-    forcestring: true
   - name: bar
     value: foo
+    forcestring: true
+  - name: foo
+    value: bar
     forcestring: true
 `
 		app := v1alpha1.Application{
@@ -5192,14 +5192,14 @@ helm:
 		assert.YAMLEq(t, `
 helm:
   parameters:
-  - name: foo
-    value: foo
-    forcestring: true
   - name: bar
     value: bar
     forcestring: true
   - name: baz
     value: baz
+    forcestring: true
+  - name: foo
+    value: foo
     forcestring: true
 `, string(override))
 	})
@@ -5255,14 +5255,14 @@ helm:
 		assert.YAMLEq(t, `
 helm:
   parameters:
-  - name: foo
-    value: foo
-    forcestring: true
   - name: bar
     value: bar
     forcestring: true
   - name: baz
     value: baz
+    forcestring: true
+  - name: foo
+    value: foo
     forcestring: true
 `, string(override))
 	})
@@ -5318,14 +5318,14 @@ helm:
 		assert.YAMLEq(t, `
 helm:
   parameters:
-  - name: foo
-    value: foo
-    forcestring: true
   - name: bar
     value: bar
     forcestring: true
   - name: baz
     value: baz
+    forcestring: true
+  - name: foo
+    value: foo
     forcestring: true
 `, string(override))
 	})
@@ -5825,6 +5825,61 @@ func Test_mergeKustomizeOverride(t *testing.T) {
 				require.NotNil(t, existingImages.Kustomize.Images)
 				assert.ElementsMatch(t, *expectedImages.Kustomize.Images, *existingImages.Kustomize.Images)
 			}
+		})
+	}
+}
+
+func Test_sortHelmParameters(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []v1alpha1.HelmParameter
+		expected []v1alpha1.HelmParameter
+	}{
+		{
+			"unsorted",
+			[]v1alpha1.HelmParameter{
+				{Name: "charlie", Value: "3"},
+				{Name: "alpha", Value: "1"},
+				{Name: "bravo", Value: "2"},
+			}, []v1alpha1.HelmParameter{
+				{Name: "alpha", Value: "1"},
+				{Name: "bravo", Value: "2"},
+				{Name: "charlie", Value: "3"},
+			}},
+		{
+			"already sorted",
+			[]v1alpha1.HelmParameter{
+				{Name: "a", Value: "1"},
+				{Name: "b", Value: "2"},
+			}, []v1alpha1.HelmParameter{
+				{Name: "a", Value: "1"},
+				{Name: "b", Value: "2"},
+			}},
+		{
+			"empty",
+			[]v1alpha1.HelmParameter{},
+			[]v1alpha1.HelmParameter{}},
+		{
+			"single element",
+			[]v1alpha1.HelmParameter{
+				{Name: "only", Value: "1"},
+			}, []v1alpha1.HelmParameter{
+				{Name: "only", Value: "1"},
+			}},
+		{
+			"preserves all fields",
+			[]v1alpha1.HelmParameter{
+				{Name: "image.tag", Value: "v2.0.0", ForceString: true},
+				{Name: "image.name", Value: "nginx", ForceString: false},
+			}, []v1alpha1.HelmParameter{
+				{Name: "image.name", Value: "nginx", ForceString: false},
+				{Name: "image.tag", Value: "v2.0.0", ForceString: true},
+			}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sortHelmParameters(tt.input)
+			assert.Equal(t, tt.expected, tt.input)
 		})
 	}
 }


### PR DESCRIPTION
... because this results in deterministic output which plays nicely with diff based tools like `git diff` etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Helm parameter entries in application overrides are now deterministically sorted by name to prevent spurious diffs while preserving all parameter fields and flags.

* **Documentation**
  * Updated Git write-back docs to note Helm parameters are alphabetically sorted for deterministic output; changelog updated.

* **Tests**
  * Added tests verifying stable Helm parameter ordering across edge cases and preservation of all fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->