### PR TITLE
fix: implement git command process cleanup and use context-aware git command execution

### DIFF
--- a/ext/git/writer.go
+++ b/ext/git/writer.go
@@ -159,7 +159,7 @@ func (m *nativeGitClient) runCredentialedCmdWithOutput(ctx context.Context, args
 		}
 	}
 
-	cmd := exec.Command("git", args...)
+	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Env = append(cmd.Env, environ...)
 	return m.runCmdOutput(ctx, cmd, runOpts{})
 }


### PR DESCRIPTION
Fixes https://github.com/argoproj-labs/argocd-image-updater/issues/1445

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Git commands now honor cancellation requests, reducing hangs and improving timeout handling.
  * Improved cleanup of subprocesses by ensuring entire command groups are terminated to prevent orphaned processes and PID buildup.
  * Credential-invoked Git operations also support context-aware cancellation for more reliable remote interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->