### PR TITLE
Sort Helm parameters alphabetically in .argocd-source-<appName>.yaml (#1474)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ handling on your side.
 ### Other changes
 
 * refactor: make argocd-image-updater-config volume mapping optional (#145)
+* enhancement: sort Helm parameters alphabetically in .argocd-source-<appName>.yaml for deterministic output
 
 ## 2020-12-06 - Release v0.8.0
 

--- a/docs/basics/update-methods.md
+++ b/docs/basics/update-methods.md
@@ -50,7 +50,8 @@ By default, Argo CD Image Updater will store the parameter in a file named
 its manifests from. This will allow Argo CD to pick up parameters in this
 file, when rendering manifests for the Application named `<appName>`. Using
 this approach will also minimize the possibility of merge conflicts, as long
-as no other party in your CI will modify this file.
+as no other party in your CI will modify this file. Helm parameters in this
+file are sorted alphabetically by name to ensure deterministic output.
 
 !!!note "A note on the application's target revision"
     Due to the nature of how Git write-back works, your application really

--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -2,6 +2,7 @@ package argocd
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"fmt"
 	"path/filepath"
@@ -605,15 +606,18 @@ func marshalParamsOverride(app *v1alpha1.Application, originalData []byte) ([]by
 			log.WithContext().AddField("application", app).Debugf("values: '%s'", outputParams)
 
 			if len(originalData) == 0 {
+				sortHelmParameters(newParams.Helm.Parameters)
 				override, err = marshalWithIndent(newParams, defaultIndent)
 				break
 			}
 			err = yaml.Unmarshal(originalData, &params)
 			if err != nil {
+				sortHelmParameters(newParams.Helm.Parameters)
 				override, err = marshalWithIndent(newParams, defaultIndent)
 				break
 			}
 			mergeHelmOverride(&params, &newParams)
+			sortHelmParameters(params.Helm.Parameters)
 			override, err = marshalWithIndent(params, defaultIndent)
 		}
 	default:
@@ -624,6 +628,12 @@ func marshalParamsOverride(app *v1alpha1.Application, originalData []byte) ([]by
 	}
 
 	return override, nil
+}
+
+func sortHelmParameters(params []v1alpha1.HelmParameter) {
+	slices.SortFunc(params, func(a, b v1alpha1.HelmParameter) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
 }
 
 func mergeHelmOverride(t *helmOverride, o *helmOverride) {


### PR DESCRIPTION
cherry-pick from master branch PR #1474 