### PR TITLE
chore: fix manifest invalid in build-push-images workflow

### DIFF
--- a/.github/workflows/build-push-images.yaml
+++ b/.github/workflows/build-push-images.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: Create and push multi-arch manifest
         run: |
           set -ex
-          IMAGE_NAME="quay.io/dkarpele/argocd-image-updater"
+          IMAGE_NAME="quay.io/argoprojlabs/argocd-image-updater"
           VERSION_TAG="${{ steps.version-tag.outputs.version-tag }}"
 
           # Resolve each platform tag to a single-image digest reference (image@sha256:...).


### PR DESCRIPTION
Failure https://github.com/argoproj-labs/argocd-image-updater/actions/runs/22075323467/job/63789436903

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched image reference handling to use digest-based identifiers to improve reproducibility and registry compatibility.
  * Updated multi-architecture manifest creation to emit platform-specific digest references and to resolve non-list tags to their platform digests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->