### PR TITLE
docs: fix callout indents

### DIFF
--- a/docs/configuration/images.md
+++ b/docs/configuration/images.md
@@ -65,13 +65,11 @@ in the
 of the [Semver library](https://github.com/Masterminds/semver) we're using.
 
 !!!note
-If you use an
-[update strategy](#update-strategies)
-other than `semver` or `digest`, the `version_constraint` will not have any effect
-and all tags returned from the registry will be considered for update. If
-you need to further restrict the list of tags to consider, see
-[filtering tags](#filtering-tags)
-below.
+    If you use an [update strategy](#update-strategies) other than `semver` or
+    `digest`, the `version_constraint` will not have any effect and all tags
+    returned from the registry will be considered for update. If you need to
+    further restrict the list of tags to consider, see [filtering tags](#filtering-tags)
+    below.
 
 ### Forcing Image Updates
 
@@ -136,16 +134,18 @@ If no update strategy is given, or an invalid value is used, the default
 strategy `semver` will be used.
 
 !!!warning "Renamed image update strategies"
-The `latest` strategy has been renamed to `newest-build`, and `name` strategy has been renamed to `alphabetical`.
-Please switch to the new convention as support for the old naming convention will be removed in future releases.
+    The `latest` strategy has been renamed to `newest-build`, and `name`
+    strategy has been renamed to `alphabetical`. Please switch to the new
+    convention as support for the old naming convention will be removed in
+    future releases.
 
 !!!warning
-As of November 2020, Docker Hub has introduced pull limits for accounts on
-the free plan and unauthenticated requests. The `latest/newest-build` update strategy
-will perform manifest pulls for determining the most recently pushed tags,
-and these will count into your pull limits. So unless you are not affected
-by these pull limits, it is **not recommended** to use the `latest/newest-build` update
-strategy with images hosted on Docker Hub.
+    As of November 2020, Docker Hub has introduced pull limits for accounts on
+    the free plan and unauthenticated requests. The `latest/newest-build` update
+    strategy will perform manifest pulls for determining the most recently
+    pushed tags, and these will count into your pull limits. So unless you are
+    not affected by these pull limits, it is **not recommended** to use the
+    `latest/newest-build` update strategy with images hosted on Docker Hub.
 
 ## Filtering tags
 
@@ -244,10 +244,10 @@ images:
 The correct image to execute will be chosen by Kubernetes.
 
 !!!note
-The `platforms` field only has effect for images that use an update
-strategy that fetches meta-data. Currently, these are the `latest` and
-`digest` strategies. For `semver` and `name` strategies, the `platforms`
-setting has no effect.
+    The `platforms` field only has effect for images that use an update
+    strategy that fetches meta-data. Currently, these are the `latest` and
+    `digest` strategies. For `semver` and `name` strategies, the `platforms`
+    setting has no effect.
 
 ## <a name="pull-secrets"></a>Specifying pull secrets
 

--- a/docs/install/installation.md
+++ b/docs/install/installation.md
@@ -186,13 +186,13 @@ The following metric is currently available and populated with data:
     temporarily disabled. They may not appear on the `/metrics` endpoint or may
     always report a value of `0`.
 
-*   `argocd_image_updater_images_watched_total`
-*   `argocd_image_updater_images_updated_total`
-*   `argocd_image_updater_images_errors_total`
-*   `argocd_image_updater_k8s_api_requests_total`
-*   `argocd_image_updater_k8s_api_errors_total`
-*   `argocd_image_updater_registry_requests_total`
-*   `argocd_image_updater_registry_requests_failed_total`
+    *   `argocd_image_updater_images_watched_total`
+    *   `argocd_image_updater_images_updated_total`
+    *   `argocd_image_updater_images_errors_total`
+    *   `argocd_image_updater_k8s_api_requests_total`
+    *   `argocd_image_updater_k8s_api_errors_total`
+    *   `argocd_image_updater_registry_requests_total`
+    *   `argocd_image_updater_registry_requests_failed_total`
 
 A (very) rudimentary example dashboard definition for Grafana is provided
 [here](https://github.com/argoproj-labs/argocd-image-updater/tree/master/config)


### PR DESCRIPTION
Some call-outs ([Admonition](https://squidfunk.github.io/mkdocs-material/reference/admonitions/) in mkdocs) are not indented so not correctly rendered.

Also modified bit to make width under 80 chars
(I think there's no written rule for this, but just tried to match with other docs)


### As-is

<img width="1804" height="550" alt="95372" src="https://github.com/user-attachments/assets/2ba6c6b7-dfdf-4024-b12a-fd24eea5f517" />

### To-be

<img width="1570" height="362" alt="71422" src="https://github.com/user-attachments/assets/f2f87334-b2b8-451b-aab4-1c5729d4fa84" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting and layout in installation and configuration guides for enhanced readability and presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->