### PR TITLE
chore(deps): bump registry-scanner to 1.1.1, and image-updater to 1.1.0 in test/ginkgo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/argoproj-labs/argocd-image-updater
 go 1.25.5
 
 require (
-	github.com/argoproj-labs/argocd-image-updater/registry-scanner v1.1.0
+	github.com/argoproj-labs/argocd-image-updater/registry-scanner v1.1.1
 	github.com/argoproj/argo-cd/v3 v3.3.0
 	github.com/argoproj/gitops-engine v0.7.1-0.20251217140045-5baed5604d2d
 	github.com/bmatcuk/doublestar/v4 v4.10.0

--- a/test/ginkgo/go.mod
+++ b/test/ginkgo/go.mod
@@ -3,7 +3,7 @@ module github.com/argoproj-labs/argocd-image-updater/test/ginkgo
 go 1.25.5
 
 require (
-	github.com/argoproj-labs/argocd-image-updater v1.0.2
+	github.com/argoproj-labs/argocd-image-updater v1.1.0
 	github.com/argoproj-labs/argocd-operator v0.17.0
 	github.com/argoproj/argo-cd/v3 v3.3.0
 	github.com/argoproj/gitops-engine v0.7.1-0.20251217140045-5baed5604d2d


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to the latest compatible versions for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->