### PR TITLE
fix: limit webhook request body size to prevent resource exhaustion

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -9,6 +9,11 @@ import (
 	"github.com/argoproj-labs/argocd-image-updater/pkg/argocd"
 )
 
+// maxWebhookBodySize limits the size of webhook request bodies to prevent
+// resource exhaustion from oversized payloads. 1 MiB is generous for any
+// registry webhook JSON payload.
+const maxWebhookBodySize = 1 << 20 // 1 MiB
+
 // RegistryWebhook interface defines methods for handling registry webhooks
 type RegistryWebhook interface {
 	// Parse processes the webhook payload and returns a WebhookEvent


### PR DESCRIPTION
Fixes https://github.com/argoproj-labs/argocd-image-updater/issues/1485

All webhook handlers use unbounded `io.ReadAll(r.Body)` with no server-level request size limits. A malicious client can POST a multi-gigabyte payload and OOM the process.

Fix applies `http.MaxBytesReader` once in `handleWebhook()` rather than patching each handler individually. This matches how ArgoCD itself handles it in `util/webhook/webhook.go`. Oversized requests get HTTP 413 instead of 400.

* Chose `http.MaxBytesReader` over the `io.LimitReader` approach suggested in #1485 — MaxBytesReader returns a distinct error type, closes the connection early, and auto-protects any future handlers (like the in-flight GAR webhook in #1419) without code changes
* 1 MiB limit — registry webhook payloads are typically <10 KB. Not configurable for now, trivial to add later if needed
* GHCR's double-read pattern (Validate reads body for HMAC, resets via NopCloser, Parse reads again) works correctly — MaxBytesReader caps the first read, the reset replays capped bytes

Not in scope:
* `http.Server` has no `ReadTimeout` or `ReadHeaderTimeout` — separate Slowloris concern, separate issue
* No `Content-Length` pre-check — MaxBytesReader handles this regardless

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced a maximum webhook request body size to prevent resource exhaustion; oversized requests now receive 413 (Request Entity Too Large) and are rejected early.
* **Tests**
  * Added tests verifying behavior for both oversized and valid webhook payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->