### PR TITLE
fix: remove command override to preserve tini entrypoint from Dockerfile

### DIFF
--- a/config/install.yaml
+++ b/config/install.yaml
@@ -830,8 +830,6 @@ spec:
       - args:
         - --metrics-bind-address=:8443
         - run
-        command:
-        - /manager
         env:
         - name: ARGOCD_NAMESPACE
           valueFrom:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -49,9 +49,7 @@ spec:
         # seccompProfile:
         #   type: RuntimeDefault
       containers:
-      - command:
-          - /manager
-        args:
+      - args:
           - run
         image: argocd-image-updater-controller:latest
         name: argocd-image-updater-controller


### PR DESCRIPTION
resolves: https://github.com/argoproj/argo-helm/issues/3752

Currently, image-updater-controller ENTRYPOINT of Dockerfile has tini process wrapping.
So it can reap git process without making zombie processes.

But current manifest has command overriding by `/manager` without tini wrapping.

By removing command overiding, we can use default ENTRYPOINT from Dockerfile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to use default container startup behavior, simplifying container initialization logic across configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->