### PR TITLE
chore(deps): bump argo-cd from 3.3.2 to 3.3.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.5
 
 require (
 	github.com/argoproj-labs/argocd-image-updater/registry-scanner v1.1.1
-	github.com/argoproj/argo-cd/v3 v3.3.2
+	github.com/argoproj/argo-cd/v3 v3.3.4
 	github.com/argoproj/gitops-engine v0.7.1-0.20251217140045-5baed5604d2d
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bombsimon/logrusr/v2 v2.0.1

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuW
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
-github.com/argoproj/argo-cd/v3 v3.3.2 h1:kVHBj5Z0Wm2D6s69l0q6lC/WH5tc4E1peXgEEOPrLLU=
-github.com/argoproj/argo-cd/v3 v3.3.2/go.mod h1:5VAfe0s/a4VY5GmAIFK76FtW6xn7zAcLmaw25bOL/2g=
+github.com/argoproj/argo-cd/v3 v3.3.4 h1:3dFCh1b8QaqHv78QZPaH59zdZnu6wRvUpQtXmklLfUY=
+github.com/argoproj/argo-cd/v3 v3.3.4/go.mod h1:RqLNOqYHufjRTFcKIpdf27c1zvrze+fS5I9VVoJJciE=
 github.com/argoproj/gitops-engine v0.7.1-0.20251217140045-5baed5604d2d h1:iUJYrbSvpV9n8vyl1sBt1GceM60HhHfnHxuzcm5apDg=
 github.com/argoproj/gitops-engine v0.7.1-0.20251217140045-5baed5604d2d/go.mod h1:PauXVUVcfiTgC+34lDdWzPS101g4NpsUtDAjFBnWf94=
 github.com/argoproj/pkg v0.13.7-0.20230627120311-a4dd357b057e h1:kuLQvJqwwRMQTheT4MFyKVM8Txncu21CHT4yBWUl1Mk=

--- a/test/ginkgo/go.mod
+++ b/test/ginkgo/go.mod
@@ -5,7 +5,7 @@ go 1.25.5
 require (
 	github.com/argoproj-labs/argocd-image-updater v1.1.1
 	github.com/argoproj-labs/argocd-operator v0.17.0
-	github.com/argoproj/argo-cd/v3 v3.3.2
+	github.com/argoproj/argo-cd/v3 v3.3.4
 	github.com/argoproj/gitops-engine v0.7.1-0.20251217140045-5baed5604d2d
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1

--- a/test/ginkgo/go.sum
+++ b/test/ginkgo/go.sum
@@ -33,8 +33,8 @@ github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFI
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/argoproj-labs/argocd-operator v0.17.0 h1:hsCjIT8F6bZhrzq3hHNjQxv7fesTh5TAWMgBsPjHFYQ=
 github.com/argoproj-labs/argocd-operator v0.17.0/go.mod h1:NQ382HBjCxWnDAvg/4nn2SXZ+RHPFhH96rglup3Wi6Y=
-github.com/argoproj/argo-cd/v3 v3.3.2 h1:kVHBj5Z0Wm2D6s69l0q6lC/WH5tc4E1peXgEEOPrLLU=
-github.com/argoproj/argo-cd/v3 v3.3.2/go.mod h1:5VAfe0s/a4VY5GmAIFK76FtW6xn7zAcLmaw25bOL/2g=
+github.com/argoproj/argo-cd/v3 v3.3.4 h1:3dFCh1b8QaqHv78QZPaH59zdZnu6wRvUpQtXmklLfUY=
+github.com/argoproj/argo-cd/v3 v3.3.4/go.mod h1:RqLNOqYHufjRTFcKIpdf27c1zvrze+fS5I9VVoJJciE=
 github.com/argoproj/gitops-engine v0.7.1-0.20251217140045-5baed5604d2d h1:iUJYrbSvpV9n8vyl1sBt1GceM60HhHfnHxuzcm5apDg=
 github.com/argoproj/gitops-engine v0.7.1-0.20251217140045-5baed5604d2d/go.mod h1:PauXVUVcfiTgC+34lDdWzPS101g4NpsUtDAjFBnWf94=
 github.com/argoproj/pkg v0.13.7-0.20250305113207-cbc37dc61de5 h1:YBoLSjpoaJXaXAldVvBRKJuOPvIXz9UOv6S96gMJM/Q=

--- a/test/ginkgo/sequential/1-008-app-in-any-ns_test.go
+++ b/test/ginkgo/sequential/1-008-app-in-any-ns_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"time"
 
-	applicationFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/application"
 	appv1alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/gitops-engine/pkg/health"
 	. "github.com/onsi/ginkgo/v2"
@@ -29,9 +28,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	applicationFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/application"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	imageUpdaterApi "github.com/argoproj-labs/argocd-image-updater/api/v1alpha1"
+
+	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 
 	"github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture"
 	argocdFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/argocd"
@@ -40,7 +43,6 @@ import (
 	k8sFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/k8s"
 	ssFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/statefulset"
 	fixtureUtils "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/utils"
-	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 )
 
 var _ = Describe("ArgoCD Image Updater Sequential E2E Tests", func() {


### PR DESCRIPTION
https://github.com/argoproj/argo-cd/releases/tag/v3.3.4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Argo CD dependency to version 3.3.4 across all modules.
  * Internal code reorganization for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->