### PR TITLE
feat: batch git commits per repository to reduce clone/push overhead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ test-results
 *.crt
 # htpasswd files (should be generated at runtime, not committed)
 **/htpasswd
+cover.out
+cover2.out

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -314,6 +314,9 @@ This enables a CRD-driven approach to automated image updates with Argo CD.
 	controllerCmd.Flags().BoolVar(&cfg.GitCommitSignOff, "git-commit-sign-off", env.GetBoolVal("GIT_COMMIT_SIGN_OFF", false), "Whether to sign-off git commits")
 	controllerCmd.Flags().StringVar(&commitMessagePath, "git-commit-message-path", common.DefaultCommitTemplatePath, "Path to a template to use for Git commit messages")
 
+	// Batch commit flag
+	controllerCmd.Flags().BoolVar(&cfg.EnableBatchCommit, "enable-batch-commit", env.GetBoolVal("ENABLE_BATCH_COMMIT", false), "Enable batching of git write-back operations per repository to reduce clone/push overhead")
+
 	// Webhook flags
 	controllerCmd.Flags().BoolVar(&cfg.EnableWebhook, "enable-webhook", env.GetBoolVal("ENABLE_WEBHOOK", false), "Enable webhook server for receiving registry events")
 	controllerCmd.Flags().IntVar(&webhookCfg.Port, "webhook-port", env.ParseNumFromEnv("WEBHOOK_PORT", 8082, 0, 65535), "Port to listen on for webhook events")

--- a/docs/install/cmd/run.md
+++ b/docs/install/cmd/run.md
@@ -53,6 +53,20 @@ Secret for validating Docker Hub webhooks.
 
 Can also be set with the `DOCKER_WEBHOOK_SECRET` environment variable.
 
+**--enable-batch-commit**
+
+Enable batching of git write-back operations per repository. When enabled,
+the controller uses a two-phase approach: first all registries are polled in
+parallel, then pending git writes are grouped by repository and branch and
+committed in a single clone/fetch/checkout/commit/push cycle per group.
+This dramatically reduces git overhead when many applications share the same
+git repository.
+
+When disabled (the default), each application clones, commits, and pushes
+individually — the original behavior.
+
+Can also be set with the `ENABLE_BATCH_COMMIT` environment variable.
+
 **--enable-http2 *disabled***
 
 If set, HTTP/2 will be enabled for the metrics and webhook servers.

--- a/internal/controller/imageupdater_controller.go
+++ b/internal/controller/imageupdater_controller.go
@@ -64,6 +64,9 @@ type ImageUpdaterConfig struct {
 	// EnableCRMetrics enables per-ImageUpdater-CR Prometheus metrics. Set false in webhook-only
 	// mode (no controller/reconcile) so metrics are not written and never orphaned on CR delete.
 	EnableCRMetrics bool
+	// EnableBatchCommit batches git write-back operations per repository+branch,
+	// reducing clone/fetch/push overhead when many apps share the same git repo.
+	EnableBatchCommit bool
 }
 
 // ImageUpdaterReconciler reconciles a ImageUpdater object

--- a/internal/controller/reconcile.go
+++ b/internal/controller/reconcile.go
@@ -16,7 +16,12 @@ import (
 	"github.com/argoproj-labs/argocd-image-updater/registry-scanner/pkg/registry"
 )
 
-// RunImageUpdater is a main loop for argocd-image-controller
+// RunImageUpdater is a main loop for argocd-image-controller.
+// When EnableBatchCommit is true, it uses a two-phase approach: first polling
+// all registries in parallel, then batching git write-back operations per
+// repository to minimize clone/fetch/push overhead.
+// When EnableBatchCommit is false (the default), it uses the original per-app
+// flow where each application polls its registry and commits individually.
 func (r *ImageUpdaterReconciler) RunImageUpdater(ctx context.Context, cr *iuapi.ImageUpdater, warmUp bool, webhookEvent *argocd.WebhookEvent) (argocd.ImageUpdaterResult, error) {
 	baseLogger := log.LoggerFromContext(ctx)
 
@@ -58,8 +63,8 @@ func (r *ImageUpdaterReconciler) RunImageUpdater(ctx context.Context, cr *iuapi.
 	sem := semaphore.NewWeighted(int64(concurrency))
 
 	var wg sync.WaitGroup
-	var mu sync.Mutex
-	var allChanges []argocd.ChangeEntry
+	var pendingMu sync.Mutex
+	var pendingWrites []*argocd.PendingWrite
 	wg.Add(len(appList))
 
 	for app, curApplication := range appList {
@@ -69,7 +74,6 @@ func (r *ImageUpdaterReconciler) RunImageUpdater(ctx context.Context, cr *iuapi.
 		lockErr := sem.Acquire(ctx, 1)
 		if lockErr != nil {
 			appLogger.Errorf("Could not acquire semaphore: %v", lockErr)
-			// Release entry in wait group on error, too - we're never going to execute
 			wg.Done()
 			continue
 		}
@@ -96,22 +100,46 @@ func (r *ImageUpdaterReconciler) RunImageUpdater(ctx context.Context, cr *iuapi.
 				DisableKubeEvents:      r.Config.DisableKubeEvents,
 				GitCreds:               r.Config.GitCreds,
 			}
-			res := argocd.UpdateApplication(appCtx, upconf, syncState)
 
-			mu.Lock()
-			result.NumApplicationsProcessed += 1
-			result.NumErrors += res.NumErrors
-			result.NumImagesConsidered += res.NumImagesConsidered
-			result.NumImagesUpdated += res.NumImagesUpdated
-			result.NumSkipped += res.NumSkipped
-			allChanges = append(allChanges, res.Changes...)
-			mu.Unlock()
+			if r.Config.EnableBatchCommit {
+				// Two-phase approach: poll only, collect pending git writes for Phase 2.
+				res, pw := argocd.CheckApplicationImages(appCtx, upconf, syncState)
 
-			if !warmUp && r.Config != nil && r.Config.EnableCRMetrics && metrics.ImageUpdaterCR() != nil {
-				if !r.Config.DryRun {
-					metrics.ImageUpdaterCR().IncreaseImageUpdate(cr.Name, cr.Namespace, res.NumImagesUpdated)
+				pendingMu.Lock()
+				result.NumApplicationsProcessed += 1
+				result.NumErrors += res.NumErrors
+				result.NumImagesConsidered += res.NumImagesConsidered
+				result.NumImagesUpdated += res.NumImagesUpdated
+				result.NumSkipped += res.NumSkipped
+				if pw != nil {
+					pendingWrites = append(pendingWrites, pw)
 				}
-				metrics.ImageUpdaterCR().IncreaseUpdateErrors(cr.Name, cr.Namespace, res.NumErrors)
+				pendingMu.Unlock()
+
+				if !warmUp && r.Config != nil && r.Config.EnableCRMetrics && metrics.ImageUpdaterCR() != nil {
+					if !r.Config.DryRun {
+						metrics.ImageUpdaterCR().IncreaseImageUpdate(cr.Name, cr.Namespace, res.NumImagesUpdated)
+					}
+					metrics.ImageUpdaterCR().IncreaseUpdateErrors(cr.Name, cr.Namespace, res.NumErrors)
+				}
+			} else {
+				// Original path: poll + commit per app individually.
+				res := argocd.UpdateApplication(appCtx, upconf, syncState)
+
+				pendingMu.Lock()
+				result.NumApplicationsProcessed += 1
+				result.NumErrors += res.NumErrors
+				result.NumImagesConsidered += res.NumImagesConsidered
+				result.NumImagesUpdated += res.NumImagesUpdated
+				result.NumSkipped += res.NumSkipped
+				pendingMu.Unlock()
+
+				if !warmUp && r.Config != nil && r.Config.EnableCRMetrics && metrics.ImageUpdaterCR() != nil {
+					if !r.Config.DryRun {
+						metrics.ImageUpdaterCR().IncreaseImageUpdate(cr.Name, cr.Namespace, res.NumImagesUpdated)
+					}
+					metrics.ImageUpdaterCR().IncreaseUpdateErrors(cr.Name, cr.Namespace, res.NumErrors)
+				}
 			}
 		}(appCtx, app, curApplication)
 	}
@@ -119,14 +147,39 @@ func (r *ImageUpdaterReconciler) RunImageUpdater(ctx context.Context, cr *iuapi.
 	// Wait for all goroutines to finish
 	wg.Wait()
 
-	result.Changes = allChanges
-
-	// Set images-watched gauge once here with the CR-wide aggregate. We cannot set it inside the
-	// per-application goroutines: each goroutine would overwrite the same gauge with that app's
-	// count, so only the last app to finish would be reflected. Using result.NumImagesConsidered
-	// after wg.Wait() gives the total number of images considered for this CR.
+	// Set images-watched gauge once here with the CR-wide aggregate.
 	if !warmUp && r.Config != nil && r.Config.EnableCRMetrics && metrics.ImageUpdaterCR() != nil {
 		metrics.ImageUpdaterCR().SetNumberOfImagesWatched(cr.Name, cr.Namespace, result.NumImagesConsidered)
+	}
+
+	// Phase 2 (batch mode only): batch git write-back operations by repo+branch.
+	if r.Config.EnableBatchCommit && len(pendingWrites) > 0 {
+		baseLogger.Infof("Phase 2: batching %d pending git write(s)", len(pendingWrites))
+
+		// Group pending writes by repo+branch
+		batches := make(map[string][]*argocd.PendingWrite)
+		for _, pw := range pendingWrites {
+			key := pw.BatchKey()
+			batches[key] = append(batches[key], pw)
+		}
+
+		for batchKey, batch := range batches {
+			baseLogger.Infof("Executing batch for %s: %d app(s)", batchKey, len(batch))
+			batchErrors := argocd.BatchCommitChangesGit(ctx, batch, syncState)
+
+			// Process results: emit kube events for successful writes, count errors for failed ones
+			for _, pw := range batch {
+				if batchErr, hasBatchErr := batchErrors[pw.AppName]; hasBatchErr {
+					baseLogger.Errorf("Batch commit failed for app %s: %v", pw.AppName, batchErr)
+					result.NumErrors += 1
+					// Undo the image update count since the commit failed
+					result.NumImagesUpdated -= pw.Result.NumImagesUpdated
+				} else {
+					baseLogger.Infof("Successfully updated application %s via batch commit", pw.AppName)
+					argocd.EmitKubeEvents(ctx, pw.UpdateConf, pw.ChangeList, pw.AppName)
+				}
+			}
+		}
 	}
 
 	baseLogger.Infof("Processing results: applications=%d images_considered=%d images_skipped=%d images_updated=%d errors=%d",

--- a/internal/controller/reconcile.go
+++ b/internal/controller/reconcile.go
@@ -104,6 +104,8 @@ func (r *ImageUpdaterReconciler) RunImageUpdater(ctx context.Context, cr *iuapi.
 
 			if r.Config.EnableBatchCommit {
 				// Two-phase approach: poll only, collect pending git writes for Phase 2.
+				// Image-update success metrics are deferred to phase 2 so they
+				// reflect actual commit outcomes rather than pending writes.
 				res, pw := argocd.CheckApplicationImages(appCtx, upconf, syncState)
 
 				pendingMu.Lock()
@@ -117,10 +119,9 @@ func (r *ImageUpdaterReconciler) RunImageUpdater(ctx context.Context, cr *iuapi.
 				}
 				pendingMu.Unlock()
 
+				// Only emit error metrics in phase 1; success metrics are
+				// deferred to phase 2 after BatchCommitChangesGit confirms push.
 				if !warmUp && r.Config != nil && r.Config.EnableCRMetrics && metrics.ImageUpdaterCR() != nil {
-					if !r.Config.DryRun {
-						metrics.ImageUpdaterCR().IncreaseImageUpdate(cr.Name, cr.Namespace, res.NumImagesUpdated)
-					}
 					metrics.ImageUpdaterCR().IncreaseUpdateErrors(cr.Name, cr.Namespace, res.NumErrors)
 				}
 			} else {
@@ -167,11 +168,12 @@ func (r *ImageUpdaterReconciler) RunImageUpdater(ctx context.Context, cr *iuapi.
 			batches[key] = append(batches[key], pw)
 		}
 
-		for batchKey, batch := range batches {
-			baseLogger.Infof("Executing batch for %s: %d app(s)", batchKey, len(batch))
+		for _, batch := range batches {
+			baseLogger.Infof("Executing batch of %d app(s)", len(batch))
 			batchErrors := argocd.BatchCommitChangesGit(ctx, batch, syncState)
 
-			// Process results: emit kube events for successful writes, count errors for failed ones
+			// Process results: emit kube events and metrics for successful writes,
+			// count errors for failed ones.
 			for _, pw := range batch {
 				if batchErr, hasBatchErr := batchErrors[pw.AppName]; hasBatchErr {
 					baseLogger.Errorf("Batch commit failed for app %s: %v", pw.AppName, batchErr)
@@ -181,6 +183,10 @@ func (r *ImageUpdaterReconciler) RunImageUpdater(ctx context.Context, cr *iuapi.
 				} else {
 					baseLogger.Infof("Successfully updated application %s via batch commit", pw.AppName)
 					argocd.EmitKubeEvents(ctx, pw.UpdateConf, pw.ChangeList, pw.AppName)
+					// Emit image-update success metric now that the push succeeded.
+					if !warmUp && r.Config != nil && r.Config.EnableCRMetrics && metrics.ImageUpdaterCR() != nil && !r.Config.DryRun {
+						metrics.ImageUpdaterCR().IncreaseImageUpdate(cr.Name, cr.Namespace, pw.Result.NumImagesUpdated)
+					}
 				}
 			}
 		}

--- a/internal/controller/reconcile.go
+++ b/internal/controller/reconcile.go
@@ -104,8 +104,10 @@ func (r *ImageUpdaterReconciler) RunImageUpdater(ctx context.Context, cr *iuapi.
 
 			if r.Config.EnableBatchCommit {
 				// Two-phase approach: poll only, collect pending git writes for Phase 2.
-				// Image-update success metrics are deferred to phase 2 so they
-				// reflect actual commit outcomes rather than pending writes.
+				// CheckApplicationImages returns pw==nil in two cases:
+				//   (a) no updates needed
+				//   (b) already committed immediately (non-git, PR mode, write-branch)
+				// In case (b) we must emit success metrics and collect changes here.
 				res, pw := argocd.CheckApplicationImages(appCtx, upconf, syncState)
 
 				pendingMu.Lock()
@@ -114,15 +116,19 @@ func (r *ImageUpdaterReconciler) RunImageUpdater(ctx context.Context, cr *iuapi.
 				result.NumImagesConsidered += res.NumImagesConsidered
 				result.NumImagesUpdated += res.NumImagesUpdated
 				result.NumSkipped += res.NumSkipped
+				allChanges = append(allChanges, res.Changes...)
 				if pw != nil {
 					pendingWrites = append(pendingWrites, pw)
 				}
 				pendingMu.Unlock()
 
-				// Only emit error metrics in phase 1; success metrics are
-				// deferred to phase 2 after BatchCommitChangesGit confirms push.
 				if !warmUp && r.Config != nil && r.Config.EnableCRMetrics && metrics.ImageUpdaterCR() != nil {
 					metrics.ImageUpdaterCR().IncreaseUpdateErrors(cr.Name, cr.Namespace, res.NumErrors)
+					// For immediate commits (pw == nil), emit success metrics now.
+					// For batched writes (pw != nil), defer to phase 2.
+					if pw == nil && !r.Config.DryRun {
+						metrics.ImageUpdaterCR().IncreaseImageUpdate(cr.Name, cr.Namespace, res.NumImagesUpdated)
+					}
 				}
 			} else {
 				// Original path: poll + commit per app individually.

--- a/internal/controller/reconcile.go
+++ b/internal/controller/reconcile.go
@@ -65,6 +65,7 @@ func (r *ImageUpdaterReconciler) RunImageUpdater(ctx context.Context, cr *iuapi.
 	var wg sync.WaitGroup
 	var pendingMu sync.Mutex
 	var pendingWrites []*argocd.PendingWrite
+	var allChanges []argocd.ChangeEntry
 	wg.Add(len(appList))
 
 	for app, curApplication := range appList {
@@ -132,6 +133,7 @@ func (r *ImageUpdaterReconciler) RunImageUpdater(ctx context.Context, cr *iuapi.
 				result.NumImagesConsidered += res.NumImagesConsidered
 				result.NumImagesUpdated += res.NumImagesUpdated
 				result.NumSkipped += res.NumSkipped
+				allChanges = append(allChanges, res.Changes...)
 				pendingMu.Unlock()
 
 				if !warmUp && r.Config != nil && r.Config.EnableCRMetrics && metrics.ImageUpdaterCR() != nil {
@@ -146,6 +148,8 @@ func (r *ImageUpdaterReconciler) RunImageUpdater(ctx context.Context, cr *iuapi.
 
 	// Wait for all goroutines to finish
 	wg.Wait()
+
+	result.Changes = allChanges
 
 	// Set images-watched gauge once here with the CR-wide aggregate.
 	if !warmUp && r.Config != nil && r.Config.EnableCRMetrics && metrics.ImageUpdaterCR() != nil {

--- a/pkg/argocd/git.go
+++ b/pkg/argocd/git.go
@@ -396,13 +396,9 @@ func BatchCommitChangesGit(ctx context.Context, pendingWrites []*PendingWrite, s
 		return batchErrs
 	}
 
-	// Determine the checkout branch from the first app's config
-	var checkOutBranch string
-	if firstWBC.GitBranch != "" {
-		checkOutBranch = firstWBC.GitBranch
-	} else {
-		checkOutBranch = getWriteBackBranch(ctx, &firstApp, firstWBC)
-	}
+	// Determine the checkout branch from the pre-resolved branch.
+	// All writes in this batch share the same resolved branch (guaranteed by BatchKey).
+	checkOutBranch := pendingWrites[0].ResolvedBranch
 	if checkOutBranch == "" || checkOutBranch == "HEAD" {
 		checkOutBranch, err = gitC.SymRefToBranch(ctx, checkOutBranch)
 		logCtx.Infof("resolved remote default branch to '%s' and using that for operations", checkOutBranch)

--- a/pkg/argocd/git.go
+++ b/pkg/argocd/git.go
@@ -336,10 +336,10 @@ func commitChangesGit(ctx context.Context, applicationImages *ApplicationImages,
 // Returns a map of app names to errors for any individual write failures.
 func BatchCommitChangesGit(ctx context.Context, pendingWrites []*PendingWrite, state *SyncIterationState) map[string]error {
 	logCtx := log.LoggerFromContext(ctx)
-	errors := make(map[string]error)
+	batchErrs := make(map[string]error)
 
 	if len(pendingWrites) == 0 {
-		return errors
+		return batchErrs
 	}
 
 	// Use the first write's config as representative for repo/branch/creds.
@@ -357,9 +357,9 @@ func BatchCommitChangesGit(ctx context.Context, pendingWrites []*PendingWrite, s
 	creds, err := firstWBC.GetCreds(&firstApp)
 	if err != nil {
 		for _, pw := range pendingWrites {
-			errors[pw.AppName] = fmt.Errorf("could not get creds for repo '%s': %v", firstWBC.GitRepo, err)
+			batchErrs[pw.AppName] = fmt.Errorf("could not get creds for repo '%s': %v", firstWBC.GitRepo, err)
 		}
-		return errors
+		return batchErrs
 	}
 
 	// Create a single temp directory and git client for the entire batch
@@ -371,9 +371,9 @@ func BatchCommitChangesGit(ctx context.Context, pendingWrites []*PendingWrite, s
 		tempRoot, err := os.MkdirTemp(os.TempDir(), "git-batch")
 		if err != nil {
 			for _, pw := range pendingWrites {
-				errors[pw.AppName] = err
+				batchErrs[pw.AppName] = err
 			}
-			return errors
+			return batchErrs
 		}
 		defer func() {
 			if removeErr := os.RemoveAll(tempRoot); removeErr != nil {
@@ -384,16 +384,16 @@ func BatchCommitChangesGit(ctx context.Context, pendingWrites []*PendingWrite, s
 		gitC, err = git.NewClientExt(firstWBC.GitRepo, tempRoot, creds, false, false, "")
 		if err != nil {
 			for _, pw := range pendingWrites {
-				errors[pw.AppName] = err
+				batchErrs[pw.AppName] = err
 			}
-			return errors
+			return batchErrs
 		}
 	}
 	if err = gitC.Init(ctx); err != nil {
 		for _, pw := range pendingWrites {
-			errors[pw.AppName] = err
+			batchErrs[pw.AppName] = err
 		}
-		return errors
+		return batchErrs
 	}
 
 	// Determine the checkout branch from the first app's config
@@ -408,24 +408,24 @@ func BatchCommitChangesGit(ctx context.Context, pendingWrites []*PendingWrite, s
 		logCtx.Infof("resolved remote default branch to '%s' and using that for operations", checkOutBranch)
 		if err != nil {
 			for _, pw := range pendingWrites {
-				errors[pw.AppName] = err
+				batchErrs[pw.AppName] = err
 			}
-			return errors
+			return batchErrs
 		}
 	}
 
 	// Single fetch + checkout for the entire batch
 	if err = gitC.ShallowFetch(ctx, checkOutBranch, 1); err != nil {
 		for _, pw := range pendingWrites {
-			errors[pw.AppName] = err
+			batchErrs[pw.AppName] = err
 		}
-		return errors
+		return batchErrs
 	}
 	if err = gitC.Checkout(ctx, checkOutBranch, false); err != nil {
 		for _, pw := range pendingWrites {
-			errors[pw.AppName] = err
+			batchErrs[pw.AppName] = err
 		}
-		return errors
+		return batchErrs
 	}
 
 	logCtx.Infof("Batch writing %d application(s) in a single git transaction", len(pendingWrites))
@@ -444,7 +444,7 @@ func BatchCommitChangesGit(ctx context.Context, pendingWrites []*PendingWrite, s
 		appCtx := log.ContextWithLogger(ctx, logCtx.WithField("application", pw.AppName))
 		if writeErr, skip := write(appCtx, pw.App, gitC); writeErr != nil {
 			logCtx.Errorf("Error writing changes for app %s: %v", pw.AppName, writeErr)
-			errors[pw.AppName] = writeErr
+			batchErrs[pw.AppName] = writeErr
 		} else if !skip {
 			appsWithChanges = append(appsWithChanges, pw)
 		} else {
@@ -454,7 +454,7 @@ func BatchCommitChangesGit(ctx context.Context, pendingWrites []*PendingWrite, s
 
 	if len(appsWithChanges) == 0 {
 		logCtx.Infof("Batch: all %d app file(s) already up-to-date, nothing to commit", len(pendingWrites))
-		return errors
+		return batchErrs
 	}
 
 	// Build a combined commit message
@@ -464,9 +464,9 @@ func BatchCommitChangesGit(ctx context.Context, pendingWrites []*PendingWrite, s
 	if firstWBC.GitCommitUser != "" && firstWBC.GitCommitEmail != "" {
 		if err = gitC.Config(ctx, firstWBC.GitCommitUser, firstWBC.GitCommitEmail); err != nil {
 			for _, pw := range appsWithChanges {
-				errors[pw.AppName] = err
+				batchErrs[pw.AppName] = err
 			}
-			return errors
+			return batchErrs
 		}
 	}
 
@@ -476,16 +476,16 @@ func BatchCommitChangesGit(ctx context.Context, pendingWrites []*PendingWrite, s
 	cm, err := os.CreateTemp("", "image-updater-batch-commit-msg")
 	if err != nil {
 		for _, pw := range appsWithChanges {
-			errors[pw.AppName] = fmt.Errorf("could not create temp file: %v", err)
+			batchErrs[pw.AppName] = fmt.Errorf("could not create temp file: %v", err)
 		}
-		return errors
+		return batchErrs
 	}
 	if err = os.WriteFile(cm.Name(), []byte(commitMsg), 0600); err != nil {
 		_ = cm.Close()
 		for _, pw := range appsWithChanges {
-			errors[pw.AppName] = fmt.Errorf("could not write commit message: %v", err)
+			batchErrs[pw.AppName] = fmt.Errorf("could not write commit message: %v", err)
 		}
-		return errors
+		return batchErrs
 	}
 	commitOpts.CommitMessagePath = cm.Name()
 	_ = cm.Close()
@@ -500,19 +500,19 @@ func BatchCommitChangesGit(ctx context.Context, pendingWrites []*PendingWrite, s
 	// Single commit + push for all changes
 	if err = gitC.Commit(ctx, "", commitOpts); err != nil {
 		for _, pw := range appsWithChanges {
-			errors[pw.AppName] = fmt.Errorf("git commit failed: %v", err)
+			batchErrs[pw.AppName] = fmt.Errorf("git commit failed: %v", err)
 		}
-		return errors
+		return batchErrs
 	}
 	if err = gitC.Push(ctx, "origin", checkOutBranch, false); err != nil {
 		for _, pw := range appsWithChanges {
-			errors[pw.AppName] = fmt.Errorf("git push failed: %v", err)
+			batchErrs[pw.AppName] = fmt.Errorf("git push failed: %v", err)
 		}
-		return errors
+		return batchErrs
 	}
 
 	logCtx.Infof("Batch: successfully committed and pushed %d app update(s) in a single transaction", len(appsWithChanges))
-	return errors
+	return batchErrs
 }
 
 // buildBatchCommitMessage creates a commit message summarizing all batched updates.

--- a/pkg/argocd/git.go
+++ b/pkg/argocd/git.go
@@ -343,7 +343,10 @@ func BatchCommitChangesGit(ctx context.Context, pendingWrites []*PendingWrite, s
 	}
 
 	// Use the first write's config as representative for repo/branch/creds.
-	// All writes in this batch must share the same repo+branch.
+	// All writes in this batch must share the same repo+branch (guaranteed by BatchKey).
+	// NOTE: git credentials, commit user/email, and signing config are taken from the
+	// first app. If apps sharing the same repo have different credentials configured,
+	// only the first app's credentials are used for the batch push.
 	firstWBC := pendingWrites[0].App.WriteBackConfig
 	firstApp := pendingWrites[0].App.Application
 
@@ -476,6 +479,7 @@ func BatchCommitChangesGit(ctx context.Context, pendingWrites []*PendingWrite, s
 		}
 		return batchErrs
 	}
+	defer os.Remove(cm.Name())
 	if err = os.WriteFile(cm.Name(), []byte(commitMsg), 0600); err != nil {
 		_ = cm.Close()
 		for _, pw := range appsWithChanges {
@@ -485,7 +489,6 @@ func BatchCommitChangesGit(ctx context.Context, pendingWrites []*PendingWrite, s
 	}
 	commitOpts.CommitMessagePath = cm.Name()
 	_ = cm.Close()
-	defer os.Remove(cm.Name())
 
 	if firstWBC.GitCommitSigningKey != "" {
 		commitOpts.SigningKey = firstWBC.GitCommitSigningKey

--- a/pkg/argocd/git.go
+++ b/pkg/argocd/git.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"text/template"
 
 	"sigs.k8s.io/kustomize/api/konfig"
@@ -324,6 +325,215 @@ func commitChangesGit(ctx context.Context, applicationImages *ApplicationImages,
 	}
 
 	return nil
+}
+
+// BatchCommitChangesGit performs git write-back for multiple applications in a single
+// git transaction. Instead of each app doing its own clone→fetch→checkout→write→commit→push
+// cycle, it does a single clone→fetch→checkout, writes all files, then one commit→push.
+// For N apps sharing the same repo+branch, this reduces N round-trips to 1.
+//
+// All pending writes must target the same git repository and branch.
+// Returns a map of app names to errors for any individual write failures.
+func BatchCommitChangesGit(ctx context.Context, pendingWrites []*PendingWrite, state *SyncIterationState) map[string]error {
+	logCtx := log.LoggerFromContext(ctx)
+	errors := make(map[string]error)
+
+	if len(pendingWrites) == 0 {
+		return errors
+	}
+
+	// Use the first write's config as representative for repo/branch/creds.
+	// All writes in this batch must share the same repo+branch.
+	firstWBC := pendingWrites[0].App.WriteBackConfig
+	firstApp := pendingWrites[0].App.Application
+
+	// Acquire the repo lock once for the entire batch
+	if firstWBC.RequiresLocking() {
+		lock := state.GetRepositoryLock(firstWBC.GitRepo)
+		lock.Lock()
+		defer lock.Unlock()
+	}
+
+	creds, err := firstWBC.GetCreds(&firstApp)
+	if err != nil {
+		for _, pw := range pendingWrites {
+			errors[pw.AppName] = fmt.Errorf("could not get creds for repo '%s': %v", firstWBC.GitRepo, err)
+		}
+		return errors
+	}
+
+	// Create a single temp directory and git client for the entire batch
+	var gitC git.Client
+	if firstWBC.GitClient != nil {
+		// Use injected git client (e.g. for testing)
+		gitC = firstWBC.GitClient
+	} else {
+		tempRoot, err := os.MkdirTemp(os.TempDir(), "git-batch")
+		if err != nil {
+			for _, pw := range pendingWrites {
+				errors[pw.AppName] = err
+			}
+			return errors
+		}
+		defer func() {
+			if removeErr := os.RemoveAll(tempRoot); removeErr != nil {
+				logCtx.Errorf("could not remove temp dir: %v", removeErr)
+			}
+		}()
+
+		gitC, err = git.NewClientExt(firstWBC.GitRepo, tempRoot, creds, false, false, "")
+		if err != nil {
+			for _, pw := range pendingWrites {
+				errors[pw.AppName] = err
+			}
+			return errors
+		}
+	}
+	if err = gitC.Init(ctx); err != nil {
+		for _, pw := range pendingWrites {
+			errors[pw.AppName] = err
+		}
+		return errors
+	}
+
+	// Determine the checkout branch from the first app's config
+	var checkOutBranch string
+	if firstWBC.GitBranch != "" {
+		checkOutBranch = firstWBC.GitBranch
+	} else {
+		checkOutBranch = getWriteBackBranch(ctx, &firstApp, firstWBC)
+	}
+	if checkOutBranch == "" || checkOutBranch == "HEAD" {
+		checkOutBranch, err = gitC.SymRefToBranch(ctx, checkOutBranch)
+		logCtx.Infof("resolved remote default branch to '%s' and using that for operations", checkOutBranch)
+		if err != nil {
+			for _, pw := range pendingWrites {
+				errors[pw.AppName] = err
+			}
+			return errors
+		}
+	}
+
+	// Single fetch + checkout for the entire batch
+	if err = gitC.ShallowFetch(ctx, checkOutBranch, 1); err != nil {
+		for _, pw := range pendingWrites {
+			errors[pw.AppName] = err
+		}
+		return errors
+	}
+	if err = gitC.Checkout(ctx, checkOutBranch, false); err != nil {
+		for _, pw := range pendingWrites {
+			errors[pw.AppName] = err
+		}
+		return errors
+	}
+
+	logCtx.Infof("Batch writing %d application(s) in a single git transaction", len(pendingWrites))
+
+	// Phase: Write all files. Track which apps had actual changes.
+	var appsWithChanges []*PendingWrite
+	for _, pw := range pendingWrites {
+		wbc := pw.App.WriteBackConfig
+		var write changeWriter
+		if wbc.KustomizeBase != "" {
+			write = writeKustomization
+		} else {
+			write = writeOverrides
+		}
+
+		appCtx := log.ContextWithLogger(ctx, logCtx.WithField("application", pw.AppName))
+		if writeErr, skip := write(appCtx, pw.App, gitC); writeErr != nil {
+			logCtx.Errorf("Error writing changes for app %s: %v", pw.AppName, writeErr)
+			errors[pw.AppName] = writeErr
+		} else if !skip {
+			appsWithChanges = append(appsWithChanges, pw)
+		} else {
+			logCtx.Debugf("App %s: file already up-to-date, skipping", pw.AppName)
+		}
+	}
+
+	if len(appsWithChanges) == 0 {
+		logCtx.Infof("Batch: all %d app file(s) already up-to-date, nothing to commit", len(pendingWrites))
+		return errors
+	}
+
+	// Build a combined commit message
+	commitMsg := buildBatchCommitMessage(appsWithChanges)
+
+	// Use git config from the first app (they should all share the same user/email)
+	if firstWBC.GitCommitUser != "" && firstWBC.GitCommitEmail != "" {
+		if err = gitC.Config(ctx, firstWBC.GitCommitUser, firstWBC.GitCommitEmail); err != nil {
+			for _, pw := range appsWithChanges {
+				errors[pw.AppName] = err
+			}
+			return errors
+		}
+	}
+
+	commitOpts := &git.CommitOptions{}
+
+	// Write commit message to temp file
+	cm, err := os.CreateTemp("", "image-updater-batch-commit-msg")
+	if err != nil {
+		for _, pw := range appsWithChanges {
+			errors[pw.AppName] = fmt.Errorf("could not create temp file: %v", err)
+		}
+		return errors
+	}
+	if err = os.WriteFile(cm.Name(), []byte(commitMsg), 0600); err != nil {
+		_ = cm.Close()
+		for _, pw := range appsWithChanges {
+			errors[pw.AppName] = fmt.Errorf("could not write commit message: %v", err)
+		}
+		return errors
+	}
+	commitOpts.CommitMessagePath = cm.Name()
+	_ = cm.Close()
+	defer os.Remove(cm.Name())
+
+	if firstWBC.GitCommitSigningKey != "" {
+		commitOpts.SigningKey = firstWBC.GitCommitSigningKey
+	}
+	commitOpts.SigningMethod = firstWBC.GitCommitSigningMethod
+	commitOpts.SignOff = firstWBC.GitCommitSignOff
+
+	// Single commit + push for all changes
+	if err = gitC.Commit(ctx, "", commitOpts); err != nil {
+		for _, pw := range appsWithChanges {
+			errors[pw.AppName] = fmt.Errorf("git commit failed: %v", err)
+		}
+		return errors
+	}
+	if err = gitC.Push(ctx, "origin", checkOutBranch, false); err != nil {
+		for _, pw := range appsWithChanges {
+			errors[pw.AppName] = fmt.Errorf("git push failed: %v", err)
+		}
+		return errors
+	}
+
+	logCtx.Infof("Batch: successfully committed and pushed %d app update(s) in a single transaction", len(appsWithChanges))
+	return errors
+}
+
+// buildBatchCommitMessage creates a commit message summarizing all batched updates.
+func buildBatchCommitMessage(writes []*PendingWrite) string {
+	if len(writes) == 1 {
+		// For a single app, use the app's own commit message if available
+		if msg := writes[0].App.WriteBackConfig.GitCommitMessage; msg != "" {
+			return msg
+		}
+	}
+
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("build: batch update of %d application(s)\n\n", len(writes)))
+	for _, pw := range writes {
+		b.WriteString(fmt.Sprintf("- %s:", pw.AppName))
+		for _, c := range pw.ChangeList {
+			b.WriteString(fmt.Sprintf(" %s %s→%s", c.Image.ImageName, c.OldTag.String(), c.NewTag.String()))
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
 }
 
 func writeOverrides(ctx context.Context, applicationImages *ApplicationImages, gitC git.Client) (err error, skip bool) {

--- a/pkg/argocd/git.go
+++ b/pkg/argocd/git.go
@@ -343,10 +343,10 @@ func BatchCommitChangesGit(ctx context.Context, pendingWrites []*PendingWrite, s
 	}
 
 	// Use the first write's config as representative for repo/branch/creds.
-	// All writes in this batch must share the same repo+branch (guaranteed by BatchKey).
-	// NOTE: git credentials, commit user/email, and signing config are taken from the
-	// first app. If apps sharing the same repo have different credentials configured,
-	// only the first app's credentials are used for the batch push.
+	// All writes in this batch share the same repo+branch+credential source
+	// (guaranteed by BatchKey, which includes GitCredsID).
+	// Commit user/email and signing config are taken from the first app;
+	// this is safe because these settings are typically global, not per-app.
 	firstWBC := pendingWrites[0].App.WriteBackConfig
 	firstApp := pendingWrites[0].App.Application
 

--- a/pkg/argocd/types.go
+++ b/pkg/argocd/types.go
@@ -196,6 +196,33 @@ func (list ImageList) ToContainerImageList() image.ContainerImageList {
 	return cil
 }
 
+// PendingWrite represents a deferred git write-back operation for a single application.
+// It is produced by the registry polling phase and consumed by the batched git write phase.
+type PendingWrite struct {
+	// AppName is the namespaced name of the application (e.g. "namespace/appname")
+	AppName string
+	// App holds the application and its write-back configuration
+	App *ApplicationImages
+	// ChangeList records which images were changed
+	ChangeList []ChangeEntry
+	// Result holds the polling-phase result for this application
+	Result ImageUpdaterResult
+	// UpdateConf holds the full update config needed for kube events etc.
+	UpdateConf *UpdateConfiguration
+}
+
+// BatchKey returns the grouping key for batching git operations.
+// Operations targeting the same repository and branch can share a single
+// clone/fetch/checkout cycle.
+func (pw *PendingWrite) BatchKey() string {
+	wbc := pw.App.WriteBackConfig
+	branch := wbc.GitBranch
+	if branch == "" {
+		branch = "_default_"
+	}
+	return wbc.GitRepo + "::" + branch
+}
+
 // WebhookEvent represents a generic webhook payload
 type WebhookEvent struct {
 	// RegistryURL is the URL of the registry that sent the webhook

--- a/pkg/argocd/types.go
+++ b/pkg/argocd/types.go
@@ -83,6 +83,9 @@ type WriteBackConfig struct {
 	GitCreds               git.CredsStore
 	PRProvider             PRProvider
 	PullRequest            *PullRequest
+	// GitCredsID identifies the credential source (e.g. "repocreds" or "secret:ns/name").
+	// Used by BatchKey() to ensure only apps sharing the same credential source are batched.
+	GitCredsID string
 }
 
 // RequiresLocking returns true if write-back method requires repository locking
@@ -215,15 +218,20 @@ type PendingWrite struct {
 }
 
 // BatchKey returns the grouping key for batching git operations.
-// Operations targeting the same repository and branch can share a single
-// clone/fetch/checkout cycle.
+// Operations targeting the same repository, branch, and credential source
+// can share a single clone/fetch/checkout cycle. Including the credential
+// source ensures apps with different git credentials are never batched.
 func (pw *PendingWrite) BatchKey() string {
 	wbc := pw.App.WriteBackConfig
 	branch := pw.ResolvedBranch
 	if branch == "" {
 		branch = "_default_"
 	}
-	return wbc.GitRepo + "::" + branch
+	credsKey := wbc.GitCredsID
+	if credsKey == "" {
+		credsKey = "_unknown_"
+	}
+	return wbc.GitRepo + "::" + branch + "::" + credsKey
 }
 
 // WebhookEvent represents a generic webhook payload

--- a/pkg/argocd/types.go
+++ b/pkg/argocd/types.go
@@ -209,6 +209,9 @@ type PendingWrite struct {
 	Result ImageUpdaterResult
 	// UpdateConf holds the full update config needed for kube events etc.
 	UpdateConf *UpdateConfiguration
+	// ResolvedBranch is the effective target branch resolved at polling time
+	// from the app's targetRevision or explicit annotation.
+	ResolvedBranch string
 }
 
 // BatchKey returns the grouping key for batching git operations.
@@ -216,7 +219,7 @@ type PendingWrite struct {
 // clone/fetch/checkout cycle.
 func (pw *PendingWrite) BatchKey() string {
 	wbc := pw.App.WriteBackConfig
-	branch := wbc.GitBranch
+	branch := pw.ResolvedBranch
 	if branch == "" {
 		branch = "_default_"
 	}

--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -303,6 +303,7 @@ func CheckApplicationImages(ctx context.Context, updateConf *UpdateConfiguration
 	var needUpdate bool = false
 	result := ImageUpdaterResult{}
 	app := updateConf.UpdateApp.Application.GetName()
+	appNs := updateConf.UpdateApp.Application.GetNamespace()
 	changeList := make([]ChangeEntry, 0)
 
 	applicationImages := GetImagesFromApplication(updateConf.UpdateApp)
@@ -483,11 +484,13 @@ func CheckApplicationImages(ctx context.Context, updateConf *UpdateConfiguration
 	}
 
 	if !needUpdate {
+		result.Changes = changeList
 		return result, nil
 	}
 
 	if updateConf.DryRun {
 		baseLogger.Infof("Dry run - not committing %d changes to application", result.NumImagesUpdated)
+		result.Changes = changeList
 		return result, nil
 	}
 
@@ -503,6 +506,7 @@ func CheckApplicationImages(ctx context.Context, updateConf *UpdateConfiguration
 			baseLogger.Infof("Successfully updated the live application spec")
 			EmitKubeEvents(ctx, updateConf, changeList, app)
 		}
+		result.Changes = changeList
 		return result, nil
 	}
 
@@ -520,13 +524,20 @@ func CheckApplicationImages(ctx context.Context, updateConf *UpdateConfiguration
 			baseLogger.Infof("Successfully updated the live application spec")
 			EmitKubeEvents(ctx, updateConf, changeList, app)
 		}
+		result.Changes = changeList
 		return result, nil
 	}
 
-	// For git write-back to the base branch, return a PendingWrite for batching
-	baseLogger.Infof("Preparing batched write for application %s (%d image update(s))", app, result.NumImagesUpdated)
+	// For git write-back to the base branch, return a PendingWrite for batching.
+	// Use namespace/name as AppName to avoid collisions across namespaces.
+	appKey := app
+	if appNs != "" {
+		appKey = appNs + "/" + app
+	}
+	baseLogger.Infof("Preparing batched write for application %s (%d image update(s))", appKey, result.NumImagesUpdated)
+	result.Changes = changeList
 	pw := &PendingWrite{
-		AppName:    app,
+		AppName:    appKey,
 		App:        updateConf.UpdateApp,
 		ChangeList: changeList,
 		Result:     result,

--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -292,6 +292,251 @@ func UpdateApplication(ctx context.Context, updateConf *UpdateConfiguration, sta
 	return result
 }
 
+// CheckApplicationImages performs the registry polling phase for a single application.
+// It checks for newer image versions and prepares a PendingWrite if updates are needed,
+// but does NOT commit to git. The PendingWrite can be batched with other writes later.
+// For non-git write-back methods (e.g., WriteBackApplication), the commit is performed
+// immediately since those don't benefit from batching.
+func CheckApplicationImages(ctx context.Context, updateConf *UpdateConfiguration, state *SyncIterationState) (ImageUpdaterResult, *PendingWrite) {
+	baseLogger := log.LoggerFromContext(ctx)
+
+	var needUpdate bool = false
+	result := ImageUpdaterResult{}
+	app := updateConf.UpdateApp.Application.GetName()
+	changeList := make([]ChangeEntry, 0)
+
+	applicationImages := GetImagesFromApplication(updateConf.UpdateApp)
+	result.NumApplicationsProcessed += 1
+
+	for _, applicationImage := range updateConf.UpdateApp.Images {
+		updateableImage := applicationImages.ContainsImage(applicationImage.ContainerImage, false)
+		if updateableImage == nil {
+			baseLogger.Debugf("Image '%s' seems not to be live in this application, skipping", applicationImage.ImageName)
+			result.NumSkipped += 1
+			continue
+		}
+
+		if updateableImage.ImageTag == nil {
+			updateableImage.ImageTag = tag.NewImageTag("", time.Unix(0, 0), "")
+		}
+
+		result.NumImagesConsidered += 1
+
+		fields := updateableImage.GetLogFields(applicationImage.ImageAlias)
+		imgCtx := baseLogger.WithFields(fields)
+		imageOpCtx := log.ContextWithLogger(ctx, imgCtx)
+
+		if updateableImage.KustomizeImage != nil {
+			imgCtx = imgCtx.WithField("kustomize_image", updateableImage.KustomizeImage)
+		}
+
+		imgCtx.Debugf("Considering this image for update")
+
+		rep, err := registry.GetRegistryEndpoint(imageOpCtx, applicationImage.ContainerImage)
+		if err != nil {
+			imgCtx.Errorf("Could not get registry endpoint from configuration: %v", err)
+			result.NumErrors += 1
+			continue
+		}
+
+		var vc image.VersionConstraint
+		if applicationImage.ImageTag != nil {
+			vc.Constraint = applicationImage.ImageTag.TagName
+		}
+
+		vc.Strategy = applicationImage.UpdateStrategy
+		vc.MatchFunc, vc.MatchArgs = applicationImage.ParseMatch(imageOpCtx, applicationImage.AllowTags)
+		vc.IgnoreList = applicationImage.IgnoreTags
+		vc.Options = applicationImage.
+			GetPlatformOptions(imageOpCtx, updateConf.IgnorePlatforms, applicationImage.Platforms).
+			WithMetadata(vc.Strategy.NeedsMetadata())
+
+		if rep.TagListSort > registry.TagListSortUnsorted && vc.Strategy.NeedsMetadata() {
+			imgCtx.Infof("taglistsort is set to '%s' but update strategy '%s' requires metadata. Results may not be what you expect.", rep.TagListSort.String(), vc.Strategy.String())
+		}
+
+		// retrieves an image's pull secret credentials
+		secretVal := applicationImage.PullSecret
+		if secretVal == "" {
+			imgCtx.Tracef("No pull secret configured for this image")
+		}
+		// The endpoint can provide default credentials for pulling images
+		creds, err := rep.SetEndpointCredentials(imageOpCtx, updateConf.KubeClient.KubeClient, secretVal)
+		if err != nil {
+			imgCtx.Errorf("Could not set registry endpoint credentials: %v", err)
+			result.NumErrors += 1
+			continue
+		}
+
+		regClient, err := updateConf.NewRegFN(rep, creds.Username, creds.Password)
+		if err != nil {
+			imgCtx.Errorf("Could not create registry client: %v", err)
+			result.NumErrors += 1
+			continue
+		}
+
+		// Get list of available image tags from the repository
+		// Load creds, create registry client, fetch tags (retry once on 401/403)
+		tags, err := rep.GetTags(imageOpCtx, applicationImage.ContainerImage, regClient, &vc, secretVal == "")
+		if err != nil {
+			// Retry once on 401/403
+			if errors.Is(err, registry.ErrCredentialsInvalid) {
+				imgCtx.Infof("credentials invalid (401/403), refetching and retrying once")
+				creds, err = rep.SetEndpointCredentials(imageOpCtx, updateConf.KubeClient.KubeClient, secretVal)
+				if err != nil {
+					imgCtx.Errorf("Could not set registry endpoint credentials: %v", err)
+					result.NumErrors += 1
+					continue
+				}
+
+				regClient, err = updateConf.NewRegFN(rep, creds.Username, creds.Password)
+				if err != nil {
+					imgCtx.Errorf("Could not create registry client: %v", err)
+					result.NumErrors += 1
+					continue
+				}
+				tags, err = rep.GetTags(imageOpCtx, applicationImage.ContainerImage, regClient, &vc, secretVal == "")
+			}
+			if err != nil {
+				imgCtx.Errorf("Could not get tags from registry: %v", err)
+				result.NumErrors += 1
+				continue
+			}
+		}
+
+		imgCtx.Tracef("List of available tags found: %v", tags.Tags())
+
+		latest, err := updateableImage.GetNewestVersionFromTags(imageOpCtx, &vc, tags)
+		if err != nil {
+			imgCtx.Errorf("Unable to find newest version from available tags: %v", err)
+			result.NumErrors += 1
+			continue
+		}
+
+		if latest == nil {
+			imgCtx.Debugf("No suitable image tag for upgrade found in list of available tags.")
+			result.NumSkipped += 1
+			continue
+		}
+
+		if needsUpdate(updateableImage, applicationImage.ContainerImage, latest, vc.Strategy) {
+			appImageWithTag := applicationImage.WithTag(latest)
+			appImageFullNameWithTag := appImageWithTag.GetFullNameWithTag()
+
+			appImageSpec, err := getAppImage(imageOpCtx, &updateConf.UpdateApp.Application, updateConf.UpdateApp.WriteBackConfig, applicationImage)
+			if err != nil {
+				continue
+			}
+			if appImageSpec == appImageFullNameWithTag {
+				imgCtx.Infof("New image %s already set in spec", appImageFullNameWithTag)
+				continue
+			}
+
+			needUpdate = true
+			imgCtx.Infof("Setting new image to %s", appImageFullNameWithTag)
+
+			err = setAppImage(imageOpCtx, &updateConf.UpdateApp.Application, appImageWithTag, updateConf.UpdateApp.WriteBackConfig, applicationImage)
+			if err != nil {
+				imgCtx.Errorf("Error while trying to update image: %v", err)
+				result.NumErrors += 1
+				continue
+			} else {
+				imgCtx.Infof("Successfully updated image '%s' to '%s', but pending spec update (dry run=%v)", updateableImage.GetFullNameWithTag(), appImageFullNameWithTag, updateConf.DryRun)
+				changeList = append(changeList, ChangeEntry{appImageWithTag, updateableImage.ImageTag, appImageWithTag.ImageTag})
+				result.NumImagesUpdated += 1
+			}
+		} else {
+			err = setAppImage(imageOpCtx, &updateConf.UpdateApp.Application, applicationImage.WithTag(updateableImage.ImageTag), updateConf.UpdateApp.WriteBackConfig, applicationImage)
+			if err != nil {
+				imgCtx.Errorf("Error while trying to update image: %v", err)
+				result.NumErrors += 1
+			}
+			imgCtx.Debugf("Image '%s' already on latest allowed version", updateableImage.GetFullNameWithTag())
+		}
+	}
+
+	// Prepare the write-back config
+	wbc := updateConf.UpdateApp.WriteBackConfig
+	wbc.ArgoClient = updateConf.ArgoClient
+
+	if updateConf.GitCreds == nil {
+		wbc.GitCreds = git.NoopCredsStore{}
+	} else {
+		wbc.GitCreds = updateConf.GitCreds
+	}
+
+	if wbc.Method == WriteBackGit {
+		if updateConf.GitCommitUser != "" {
+			wbc.GitCommitUser = updateConf.GitCommitUser
+		}
+		if updateConf.GitCommitEmail != "" {
+			wbc.GitCommitEmail = updateConf.GitCommitEmail
+		}
+		if len(changeList) > 0 && updateConf.GitCommitMessage != nil {
+			wbc.GitCommitMessage = TemplateCommitMessage(ctx, updateConf.GitCommitMessage, updateConf.UpdateApp.Application.Name, changeList)
+		}
+		if updateConf.GitCommitSigningKey != "" {
+			wbc.GitCommitSigningKey = updateConf.GitCommitSigningKey
+		}
+		wbc.GitCommitSigningMethod = updateConf.GitCommitSigningMethod
+		wbc.GitCommitSignOff = updateConf.GitCommitSignOff
+	}
+
+	if !needUpdate {
+		return result, nil
+	}
+
+	if updateConf.DryRun {
+		baseLogger.Infof("Dry run - not committing %d changes to application", result.NumImagesUpdated)
+		return result, nil
+	}
+
+	// For non-git methods, commit immediately (no batching benefit)
+	if wbc.Method != WriteBackGit {
+		baseLogger.Infof("Committing %d parameter update(s) for application %s", result.NumImagesUpdated, app)
+		err := commitChangesLocked(ctx, updateConf.UpdateApp, state, changeList)
+		if err != nil {
+			baseLogger.Errorf("Could not update application spec: %v", err)
+			result.NumErrors += 1
+			result.NumImagesUpdated = 0
+		} else {
+			baseLogger.Infof("Successfully updated the live application spec")
+			EmitKubeEvents(ctx, updateConf, changeList, app)
+		}
+		return result, nil
+	}
+
+	// For git write-back, return a PendingWrite for batching
+	baseLogger.Infof("Preparing batched write for application %s (%d image update(s))", app, result.NumImagesUpdated)
+	pw := &PendingWrite{
+		AppName:    app,
+		App:        updateConf.UpdateApp,
+		ChangeList: changeList,
+		Result:     result,
+		UpdateConf: updateConf,
+	}
+	return result, pw
+}
+
+// EmitKubeEvents sends Kubernetes events for image updates if configured.
+func EmitKubeEvents(ctx context.Context, updateConf *UpdateConfiguration, changeList []ChangeEntry, app string) {
+	baseLogger := log.LoggerFromContext(ctx)
+	if !updateConf.DisableKubeEvents && updateConf.KubeClient != nil {
+		annotations := map[string]string{}
+		for i, c := range changeList {
+			annotations[fmt.Sprintf("argocd-image-updater.image-%d/full-image-name", i)] = c.Image.GetFullNameWithoutTag()
+			annotations[fmt.Sprintf("argocd-image-updater.image-%d/image-name", i)] = c.Image.ImageName
+			annotations[fmt.Sprintf("argocd-image-updater.image-%d/old-tag", i)] = c.OldTag.String()
+			annotations[fmt.Sprintf("argocd-image-updater.image-%d/new-tag", i)] = c.NewTag.String()
+		}
+		message := fmt.Sprintf("Successfully updated application '%s'", app)
+		_, err := updateConf.KubeClient.CreateApplicationEvent(&updateConf.UpdateApp.Application, "ImagesUpdated", message, annotations)
+		if err != nil {
+			baseLogger.Warnf("Event could not be sent: %v", err)
+		}
+	}
+}
+
 // needsUpdate determines if an image needs to be updated based on the provided
 // updateableImage, applicationImage, latest available tag, and update strategy.
 // It considers digest strategy, tag equality, and Kustomize image differences.

--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -534,14 +534,23 @@ func CheckApplicationImages(ctx context.Context, updateConf *UpdateConfiguration
 	if appNs != "" {
 		appKey = appNs + "/" + app
 	}
-	baseLogger.Infof("Preparing batched write for application %s (%d image update(s))", appKey, result.NumImagesUpdated)
+
+	// Resolve the effective target branch now so BatchKey groups correctly.
+	// This mirrors the logic in commitChangesGit / BatchCommitChangesGit.
+	resolvedBranch := wbc.GitBranch
+	if resolvedBranch == "" {
+		resolvedBranch = getWriteBackBranch(ctx, &updateConf.UpdateApp.Application, wbc)
+	}
+
+	baseLogger.Infof("Preparing batched write for application %s (%d image update(s), branch=%s)", appKey, result.NumImagesUpdated, resolvedBranch)
 	result.Changes = changeList
 	pw := &PendingWrite{
-		AppName:    appKey,
-		App:        updateConf.UpdateApp,
-		ChangeList: changeList,
-		Result:     result,
-		UpdateConf: updateConf,
+		AppName:        appKey,
+		App:            updateConf.UpdateApp,
+		ChangeList:     changeList,
+		Result:         result,
+		UpdateConf:     updateConf,
+		ResolvedBranch: resolvedBranch,
 	}
 	return result, pw
 }

--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -1151,6 +1151,7 @@ func parseGitConfig(ctx context.Context, app *v1alpha1.Application, kubeClient *
 		return fmt.Errorf("invalid git credentials source: %v", err)
 	}
 	wbc.GetCreds = credsSource
+	wbc.GitCredsID = creds
 	return nil
 }
 

--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -506,7 +506,24 @@ func CheckApplicationImages(ctx context.Context, updateConf *UpdateConfiguration
 		return result, nil
 	}
 
-	// For git write-back, return a PendingWrite for batching
+	// Apps using PR mode or a custom write-branch template push to per-app
+	// branches and cannot be batched. Commit them immediately via the
+	// original per-app git path.
+	if wbc.PRProvider > 0 || wbc.GitWriteBranch != "" {
+		baseLogger.Infof("Committing %d parameter update(s) for application %s (write-branch/PR mode, not batchable)", result.NumImagesUpdated, app)
+		err := commitChangesLocked(ctx, updateConf.UpdateApp, state, changeList)
+		if err != nil {
+			baseLogger.Errorf("Could not update application spec: %v", err)
+			result.NumErrors += 1
+			result.NumImagesUpdated = 0
+		} else {
+			baseLogger.Infof("Successfully updated the live application spec")
+			EmitKubeEvents(ctx, updateConf, changeList, app)
+		}
+		return result, nil
+	}
+
+	// For git write-back to the base branch, return a PendingWrite for batching
 	baseLogger.Infof("Preparing batched write for application %s (%d image update(s))", app, result.NumImagesUpdated)
 	pw := &PendingWrite{
 		AppName:    app,

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -6742,8 +6742,9 @@ func Test_PendingWrite_BatchKey(t *testing.T) {
 			ResolvedBranch: "main",
 			App: &ApplicationImages{
 				WriteBackConfig: &WriteBackConfig{
-					GitRepo:   "https://github.com/example/repo.git",
-					GitBranch: "main",
+					GitRepo:    "https://github.com/example/repo.git",
+					GitBranch:  "main",
+					GitCredsID: "repocreds",
 				},
 			},
 		}
@@ -6751,8 +6752,9 @@ func Test_PendingWrite_BatchKey(t *testing.T) {
 			ResolvedBranch: "main",
 			App: &ApplicationImages{
 				WriteBackConfig: &WriteBackConfig{
-					GitRepo:   "https://github.com/example/repo.git",
-					GitBranch: "main",
+					GitRepo:    "https://github.com/example/repo.git",
+					GitBranch:  "main",
+					GitCredsID: "repocreds",
 				},
 			},
 		}
@@ -6760,8 +6762,9 @@ func Test_PendingWrite_BatchKey(t *testing.T) {
 			ResolvedBranch: "staging",
 			App: &ApplicationImages{
 				WriteBackConfig: &WriteBackConfig{
-					GitRepo:   "https://github.com/example/repo.git",
-					GitBranch: "staging",
+					GitRepo:    "https://github.com/example/repo.git",
+					GitBranch:  "staging",
+					GitCredsID: "repocreds",
 				},
 			},
 		}
@@ -6769,13 +6772,14 @@ func Test_PendingWrite_BatchKey(t *testing.T) {
 			ResolvedBranch: "main",
 			App: &ApplicationImages{
 				WriteBackConfig: &WriteBackConfig{
-					GitRepo:   "https://github.com/other/repo.git",
-					GitBranch: "main",
+					GitRepo:    "https://github.com/other/repo.git",
+					GitBranch:  "main",
+					GitCredsID: "repocreds",
 				},
 			},
 		}
 
-		assert.Equal(t, pw1.BatchKey(), pw2.BatchKey(), "Same repo+branch should have same key")
+		assert.Equal(t, pw1.BatchKey(), pw2.BatchKey(), "Same repo+branch+creds should have same key")
 		assert.NotEqual(t, pw1.BatchKey(), pw3.BatchKey(), "Different branches should have different keys")
 		assert.NotEqual(t, pw1.BatchKey(), pw4.BatchKey(), "Different repos should have different keys")
 	})
@@ -6785,8 +6789,9 @@ func Test_PendingWrite_BatchKey(t *testing.T) {
 			ResolvedBranch: "",
 			App: &ApplicationImages{
 				WriteBackConfig: &WriteBackConfig{
-					GitRepo:   "https://github.com/example/repo.git",
-					GitBranch: "",
+					GitRepo:    "https://github.com/example/repo.git",
+					GitBranch:  "",
+					GitCredsID: "repocreds",
 				},
 			},
 		}
@@ -6799,7 +6804,8 @@ func Test_PendingWrite_BatchKey(t *testing.T) {
 			ResolvedBranch: "master",
 			App: &ApplicationImages{
 				WriteBackConfig: &WriteBackConfig{
-					GitRepo: "https://github.com/example/repo.git",
+					GitRepo:    "https://github.com/example/repo.git",
+					GitCredsID: "repocreds",
 				},
 			},
 		}
@@ -6807,7 +6813,8 @@ func Test_PendingWrite_BatchKey(t *testing.T) {
 			ResolvedBranch: "feature/my-branch",
 			App: &ApplicationImages{
 				WriteBackConfig: &WriteBackConfig{
-					GitRepo: "https://github.com/example/repo.git",
+					GitRepo:    "https://github.com/example/repo.git",
+					GitCredsID: "repocreds",
 				},
 			},
 		}
@@ -6815,6 +6822,40 @@ func Test_PendingWrite_BatchKey(t *testing.T) {
 			"Apps with different resolved branches must NOT be batched together")
 		assert.Contains(t, pwMaster.BatchKey(), "master")
 		assert.Contains(t, pwFeature.BatchKey(), "feature/my-branch")
+	})
+
+	t.Run("Separates by credential source", func(t *testing.T) {
+		pwRepocreds := &PendingWrite{
+			ResolvedBranch: "main",
+			App: &ApplicationImages{
+				WriteBackConfig: &WriteBackConfig{
+					GitRepo:    "https://github.com/example/repo.git",
+					GitCredsID: "repocreds",
+				},
+			},
+		}
+		pwSecret := &PendingWrite{
+			ResolvedBranch: "main",
+			App: &ApplicationImages{
+				WriteBackConfig: &WriteBackConfig{
+					GitRepo:    "https://github.com/example/repo.git",
+					GitCredsID: "secret:myns/my-git-secret",
+				},
+			},
+		}
+		pwSecretSame := &PendingWrite{
+			ResolvedBranch: "main",
+			App: &ApplicationImages{
+				WriteBackConfig: &WriteBackConfig{
+					GitRepo:    "https://github.com/example/repo.git",
+					GitCredsID: "secret:myns/my-git-secret",
+				},
+			},
+		}
+		assert.NotEqual(t, pwRepocreds.BatchKey(), pwSecret.BatchKey(),
+			"Apps with different credential sources must NOT be batched together")
+		assert.Equal(t, pwSecret.BatchKey(), pwSecretSame.BatchKey(),
+			"Apps with same credential source should be batched together")
 	})
 }
 

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -6563,6 +6563,76 @@ func Test_CheckApplicationImages(t *testing.T) {
 		assert.Equal(t, 1, res.NumImagesUpdated)
 		assert.Nil(t, pw, "PendingWrite should be nil in dry-run mode")
 	})
+
+	t.Run("Commits immediately for git write-branch mode (not batchable)", func(t *testing.T) {
+		mockClientFn := func(endpoint *registry.RegistryEndpoint, username, password string) (registry.RegistryClient, error) {
+			regClient := regmock.RegistryClient{}
+			regClient.On("NewRepository", mock.Anything).Return(nil)
+			regClient.On("Tags", mock.Anything).Return([]string{"1.0.1", "1.0.2"}, nil)
+			regClient.On("ManifestForTag", mock.Anything, mock.Anything).Return(&schema1.SignedManifest{}, nil)
+			return &regClient, nil
+		}
+
+		argoClient := argomock.ArgoCD{}
+		argoClient.On("UpdateSpec", mock.Anything, mock.Anything).Return(nil, nil)
+
+		kubeClient := kube.ImageUpdaterKubernetesClient{
+			KubeClient: &registryKube.KubernetesClient{
+				Clientset: fake.NewFakeKubeClient(),
+			},
+		}
+
+		imageList := ImageList{
+			NewImage(image.NewFromIdentifier("foobar=gcr.io/jannfis/foobar:>=1.0.1")),
+		}
+
+		appImages := &ApplicationImages{
+			Application: v1alpha1.Application{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "guestbook",
+					Namespace: "guestbook",
+				},
+				Spec: v1alpha1.ApplicationSpec{
+					Source: &v1alpha1.ApplicationSource{
+						RepoURL:        "https://github.com/example/repo.git",
+						TargetRevision: "main",
+						Kustomize: &v1alpha1.ApplicationSourceKustomize{
+							Images: v1alpha1.KustomizeImages{"jannfis/foobar:1.0.1"},
+						},
+					},
+				},
+				Status: v1alpha1.ApplicationStatus{
+					SourceType: v1alpha1.ApplicationSourceTypeKustomize,
+					Summary: v1alpha1.ApplicationSummary{
+						Images: []string{"gcr.io/jannfis/foobar:1.0.1"},
+					},
+				},
+			},
+			WriteBackConfig: &WriteBackConfig{
+				Method:         WriteBackGit,
+				GitRepo:        "https://github.com/example/repo.git",
+				GitWriteBranch: "image-updates-{{.SHA256}}",
+				GetCreds: func(app *v1alpha1.Application) (git.Creds, error) {
+					return git.NopCreds{}, nil
+				},
+			},
+			Images: imageList,
+		}
+
+		res, pw := CheckApplicationImages(context.Background(), &UpdateConfiguration{
+			NewRegFN:   mockClientFn,
+			ArgoClient: &argoClient,
+			KubeClient: &kubeClient,
+			UpdateApp:  appImages,
+			DryRun:     false,
+		}, NewSyncIterationState())
+
+		assert.Nil(t, pw, "PendingWrite should be nil for write-branch mode (commits immediately)")
+		// The immediate commit fails (no real git repo), which resets NumImagesUpdated to 0
+		// and increments NumErrors. The key assertion is pw == nil (correct routing).
+		assert.Equal(t, 0, res.NumImagesUpdated)
+		assert.Equal(t, 1, res.NumErrors)
+	})
 }
 
 func Test_BatchCommitChangesGit(t *testing.T) {

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -6666,14 +6666,16 @@ func Test_BatchCommitChangesGit(t *testing.T) {
 
 		pendingWrites := []*PendingWrite{
 			{
-				AppName: "app1",
+				AppName:        "app1",
+				ResolvedBranch: "main",
 				App: &ApplicationImages{
 					Application:     app1,
 					WriteBackConfig: wbc,
 				},
 			},
 			{
-				AppName: "app2",
+				AppName:        "app2",
+				ResolvedBranch: "main",
 				App: &ApplicationImages{
 					Application:     *app2,
 					WriteBackConfig: wbc,
@@ -6709,7 +6711,8 @@ func Test_BatchCommitChangesGit(t *testing.T) {
 
 		pendingWrites := []*PendingWrite{
 			{
-				AppName: "app1",
+				AppName:        "app1",
+				ResolvedBranch: "main",
 				App: &ApplicationImages{
 					Application:     app1,
 					WriteBackConfig: wbc,
@@ -6736,6 +6739,7 @@ func Test_BatchCommitChangesGit(t *testing.T) {
 func Test_PendingWrite_BatchKey(t *testing.T) {
 	t.Run("Groups by repo and branch", func(t *testing.T) {
 		pw1 := &PendingWrite{
+			ResolvedBranch: "main",
 			App: &ApplicationImages{
 				WriteBackConfig: &WriteBackConfig{
 					GitRepo:   "https://github.com/example/repo.git",
@@ -6744,6 +6748,7 @@ func Test_PendingWrite_BatchKey(t *testing.T) {
 			},
 		}
 		pw2 := &PendingWrite{
+			ResolvedBranch: "main",
 			App: &ApplicationImages{
 				WriteBackConfig: &WriteBackConfig{
 					GitRepo:   "https://github.com/example/repo.git",
@@ -6752,6 +6757,7 @@ func Test_PendingWrite_BatchKey(t *testing.T) {
 			},
 		}
 		pw3 := &PendingWrite{
+			ResolvedBranch: "staging",
 			App: &ApplicationImages{
 				WriteBackConfig: &WriteBackConfig{
 					GitRepo:   "https://github.com/example/repo.git",
@@ -6760,6 +6766,7 @@ func Test_PendingWrite_BatchKey(t *testing.T) {
 			},
 		}
 		pw4 := &PendingWrite{
+			ResolvedBranch: "main",
 			App: &ApplicationImages{
 				WriteBackConfig: &WriteBackConfig{
 					GitRepo:   "https://github.com/other/repo.git",
@@ -6775,6 +6782,7 @@ func Test_PendingWrite_BatchKey(t *testing.T) {
 
 	t.Run("Uses default branch placeholder when empty", func(t *testing.T) {
 		pw := &PendingWrite{
+			ResolvedBranch: "",
 			App: &ApplicationImages{
 				WriteBackConfig: &WriteBackConfig{
 					GitRepo:   "https://github.com/example/repo.git",
@@ -6783,6 +6791,30 @@ func Test_PendingWrite_BatchKey(t *testing.T) {
 			},
 		}
 		assert.Contains(t, pw.BatchKey(), "_default_")
+	})
+
+	t.Run("Groups by resolved branch not annotation branch", func(t *testing.T) {
+		// Two apps pointing at same repo, no annotation branch, but different targetRevisions
+		pwMaster := &PendingWrite{
+			ResolvedBranch: "master",
+			App: &ApplicationImages{
+				WriteBackConfig: &WriteBackConfig{
+					GitRepo: "https://github.com/example/repo.git",
+				},
+			},
+		}
+		pwFeature := &PendingWrite{
+			ResolvedBranch: "feature/my-branch",
+			App: &ApplicationImages{
+				WriteBackConfig: &WriteBackConfig{
+					GitRepo: "https://github.com/example/repo.git",
+				},
+			},
+		}
+		assert.NotEqual(t, pwMaster.BatchKey(), pwFeature.BatchKey(),
+			"Apps with different resolved branches must NOT be batched together")
+		assert.Contains(t, pwMaster.BatchKey(), "master")
+		assert.Contains(t, pwFeature.BatchKey(), "feature/my-branch")
 	})
 }
 

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -6320,3 +6320,453 @@ func Test_sortHelmParameters(t *testing.T) {
 func stringPtr(s string) *string {
 	return &s
 }
+
+func Test_CheckApplicationImages(t *testing.T) {
+	t.Run("Returns PendingWrite for git write-back when update needed", func(t *testing.T) {
+		mockClientFn := func(endpoint *registry.RegistryEndpoint, username, password string) (registry.RegistryClient, error) {
+			regMock := regmock.RegistryClient{}
+			regMock.On("NewRepository", mock.Anything).Return(nil)
+			regMock.On("Tags", mock.Anything).Return([]string{"1.0.2", "1.0.3"}, nil)
+			return &regMock, nil
+		}
+
+		argoClient := argomock.ArgoCD{}
+		kubeClient := kube.ImageUpdaterKubernetesClient{
+			KubeClient: &registryKube.KubernetesClient{
+				Clientset: fake.NewFakeKubeClient(),
+			},
+		}
+
+		imageList := ImageList{
+			NewImage(image.NewFromIdentifier("foobar=gcr.io/jannfis/foobar:>=1.0.1")),
+		}
+
+		appImages := &ApplicationImages{
+			Application: v1alpha1.Application{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "guestbook",
+					Namespace: "guestbook",
+				},
+				Spec: v1alpha1.ApplicationSpec{
+					Source: &v1alpha1.ApplicationSource{
+						RepoURL: "https://github.com/example/repo.git",
+						Kustomize: &v1alpha1.ApplicationSourceKustomize{
+							Images: v1alpha1.KustomizeImages{
+								"jannfis/foobar:1.0.1",
+							},
+						},
+					},
+				},
+				Status: v1alpha1.ApplicationStatus{
+					SourceType: v1alpha1.ApplicationSourceTypeKustomize,
+					Summary: v1alpha1.ApplicationSummary{
+						Images: []string{"gcr.io/jannfis/foobar:1.0.1"},
+					},
+				},
+			},
+			WriteBackConfig: &WriteBackConfig{
+				Method:  WriteBackGit,
+				GitRepo: "https://github.com/example/repo.git",
+			},
+			Images: imageList,
+		}
+
+		res, pw := CheckApplicationImages(context.Background(), &UpdateConfiguration{
+			NewRegFN:   mockClientFn,
+			ArgoClient: &argoClient,
+			KubeClient: &kubeClient,
+			UpdateApp:  appImages,
+			DryRun:     false,
+		}, NewSyncIterationState())
+
+		assert.Equal(t, 0, res.NumErrors)
+		assert.Equal(t, 1, res.NumImagesUpdated)
+		assert.NotNil(t, pw, "PendingWrite should be returned for git write-back")
+		assert.Equal(t, 1, len(pw.ChangeList))
+		assert.Equal(t, "1.0.3", pw.ChangeList[0].NewTag.TagName)
+	})
+
+	t.Run("Returns nil PendingWrite when no update needed", func(t *testing.T) {
+		mockClientFn := func(endpoint *registry.RegistryEndpoint, username, password string) (registry.RegistryClient, error) {
+			regMock := regmock.RegistryClient{}
+			regMock.On("NewRepository", mock.Anything).Return(nil)
+			regMock.On("Tags", mock.Anything).Return([]string{"1.0.1"}, nil)
+			return &regMock, nil
+		}
+
+		argoClient := argomock.ArgoCD{}
+		kubeClient := kube.ImageUpdaterKubernetesClient{
+			KubeClient: &registryKube.KubernetesClient{
+				Clientset: fake.NewFakeKubeClient(),
+			},
+		}
+
+		imageList := ImageList{
+			NewImage(image.NewFromIdentifier("foobar=gcr.io/jannfis/foobar:>=1.0.1")),
+		}
+
+		appImages := &ApplicationImages{
+			Application: v1alpha1.Application{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "guestbook",
+					Namespace: "guestbook",
+				},
+				Spec: v1alpha1.ApplicationSpec{
+					Source: &v1alpha1.ApplicationSource{
+						Kustomize: &v1alpha1.ApplicationSourceKustomize{
+							Images: v1alpha1.KustomizeImages{"jannfis/foobar:1.0.1"},
+						},
+					},
+				},
+				Status: v1alpha1.ApplicationStatus{
+					SourceType: v1alpha1.ApplicationSourceTypeKustomize,
+					Summary: v1alpha1.ApplicationSummary{
+						Images: []string{"gcr.io/jannfis/foobar:1.0.1"},
+					},
+				},
+			},
+			WriteBackConfig: &WriteBackConfig{
+				Method:  WriteBackGit,
+				GitRepo: "https://github.com/example/repo.git",
+			},
+			Images: imageList,
+		}
+
+		res, pw := CheckApplicationImages(context.Background(), &UpdateConfiguration{
+			NewRegFN:   mockClientFn,
+			ArgoClient: &argoClient,
+			KubeClient: &kubeClient,
+			UpdateApp:  appImages,
+			DryRun:     false,
+		}, NewSyncIterationState())
+
+		assert.Equal(t, 0, res.NumErrors)
+		assert.Equal(t, 0, res.NumImagesUpdated)
+		assert.Nil(t, pw, "PendingWrite should be nil when no update needed")
+	})
+
+	t.Run("Commits immediately for argocd write-back method", func(t *testing.T) {
+		mockClientFn := func(endpoint *registry.RegistryEndpoint, username, password string) (registry.RegistryClient, error) {
+			regMock := regmock.RegistryClient{}
+			regMock.On("NewRepository", mock.Anything).Return(nil)
+			regMock.On("Tags", mock.Anything).Return([]string{"1.0.2"}, nil)
+			return &regMock, nil
+		}
+
+		argoClient := argomock.ArgoCD{}
+		argoClient.On("UpdateSpec", mock.Anything, mock.Anything).Return(nil, nil)
+
+		kubeClient := kube.ImageUpdaterKubernetesClient{
+			KubeClient: &registryKube.KubernetesClient{
+				Clientset: fake.NewFakeKubeClient(),
+			},
+		}
+
+		imageList := ImageList{
+			NewImage(image.NewFromIdentifier("foobar=gcr.io/jannfis/foobar:>=1.0.1")),
+		}
+
+		appImages := &ApplicationImages{
+			Application: v1alpha1.Application{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "guestbook",
+					Namespace: "guestbook",
+				},
+				Spec: v1alpha1.ApplicationSpec{
+					Source: &v1alpha1.ApplicationSource{
+						Kustomize: &v1alpha1.ApplicationSourceKustomize{
+							Images: v1alpha1.KustomizeImages{"jannfis/foobar:1.0.1"},
+						},
+					},
+				},
+				Status: v1alpha1.ApplicationStatus{
+					SourceType: v1alpha1.ApplicationSourceTypeKustomize,
+					Summary: v1alpha1.ApplicationSummary{
+						Images: []string{"gcr.io/jannfis/foobar:1.0.1"},
+					},
+				},
+			},
+			WriteBackConfig: &WriteBackConfig{
+				Method: WriteBackApplication,
+			},
+			Images: imageList,
+		}
+
+		res, pw := CheckApplicationImages(context.Background(), &UpdateConfiguration{
+			NewRegFN:   mockClientFn,
+			ArgoClient: &argoClient,
+			KubeClient: &kubeClient,
+			UpdateApp:  appImages,
+			DryRun:     false,
+		}, NewSyncIterationState())
+
+		assert.Equal(t, 0, res.NumErrors)
+		assert.Equal(t, 1, res.NumImagesUpdated)
+		assert.Nil(t, pw, "PendingWrite should be nil for argocd write-back (committed immediately)")
+	})
+
+	t.Run("Returns nil PendingWrite in dry-run mode", func(t *testing.T) {
+		mockClientFn := func(endpoint *registry.RegistryEndpoint, username, password string) (registry.RegistryClient, error) {
+			regMock := regmock.RegistryClient{}
+			regMock.On("NewRepository", mock.Anything).Return(nil)
+			regMock.On("Tags", mock.Anything).Return([]string{"1.0.2"}, nil)
+			return &regMock, nil
+		}
+
+		argoClient := argomock.ArgoCD{}
+		kubeClient := kube.ImageUpdaterKubernetesClient{
+			KubeClient: &registryKube.KubernetesClient{
+				Clientset: fake.NewFakeKubeClient(),
+			},
+		}
+
+		imageList := ImageList{
+			NewImage(image.NewFromIdentifier("foobar=gcr.io/jannfis/foobar:>=1.0.1")),
+		}
+
+		appImages := &ApplicationImages{
+			Application: v1alpha1.Application{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "guestbook",
+					Namespace: "guestbook",
+				},
+				Spec: v1alpha1.ApplicationSpec{
+					Source: &v1alpha1.ApplicationSource{
+						Kustomize: &v1alpha1.ApplicationSourceKustomize{
+							Images: v1alpha1.KustomizeImages{"jannfis/foobar:1.0.1"},
+						},
+					},
+				},
+				Status: v1alpha1.ApplicationStatus{
+					SourceType: v1alpha1.ApplicationSourceTypeKustomize,
+					Summary: v1alpha1.ApplicationSummary{
+						Images: []string{"gcr.io/jannfis/foobar:1.0.1"},
+					},
+				},
+			},
+			WriteBackConfig: &WriteBackConfig{
+				Method:  WriteBackGit,
+				GitRepo: "https://github.com/example/repo.git",
+			},
+			Images: imageList,
+		}
+
+		res, pw := CheckApplicationImages(context.Background(), &UpdateConfiguration{
+			NewRegFN:   mockClientFn,
+			ArgoClient: &argoClient,
+			KubeClient: &kubeClient,
+			UpdateApp:  appImages,
+			DryRun:     true,
+		}, NewSyncIterationState())
+
+		assert.Equal(t, 0, res.NumErrors)
+		assert.Equal(t, 1, res.NumImagesUpdated)
+		assert.Nil(t, pw, "PendingWrite should be nil in dry-run mode")
+	})
+}
+
+func Test_BatchCommitChangesGit(t *testing.T) {
+	t.Run("Empty pending writes returns empty errors", func(t *testing.T) {
+		state := NewSyncIterationState()
+		errs := BatchCommitChangesGit(context.Background(), []*PendingWrite{}, state)
+		assert.Empty(t, errs)
+	})
+
+	t.Run("Creds error fails all apps in batch", func(t *testing.T) {
+		state := NewSyncIterationState()
+		wbc := &WriteBackConfig{
+			GitRepo:   "https://github.com/example/repo.git",
+			GitBranch: "main",
+			Method:    WriteBackGit,
+			GetCreds: func(app *v1alpha1.Application) (git.Creds, error) {
+				return nil, fmt.Errorf("creds unavailable")
+			},
+		}
+		app1 := v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{Name: "app1"},
+			Spec: v1alpha1.ApplicationSpec{
+				Source: &v1alpha1.ApplicationSource{
+					RepoURL:        "https://github.com/example/repo.git",
+					TargetRevision: "main",
+				},
+			},
+		}
+		app2 := app1.DeepCopy()
+		app2.Name = "app2"
+
+		pendingWrites := []*PendingWrite{
+			{
+				AppName: "app1",
+				App: &ApplicationImages{
+					Application:     app1,
+					WriteBackConfig: wbc,
+				},
+			},
+			{
+				AppName: "app2",
+				App: &ApplicationImages{
+					Application:     *app2,
+					WriteBackConfig: wbc,
+				},
+			},
+		}
+
+		errs := BatchCommitChangesGit(context.Background(), pendingWrites, state)
+		assert.Len(t, errs, 2)
+		assert.Contains(t, errs["app1"].Error(), "creds unavailable")
+		assert.Contains(t, errs["app2"].Error(), "creds unavailable")
+	})
+
+	t.Run("Acquires repo lock and releases on error", func(t *testing.T) {
+		state := NewSyncIterationState()
+		wbc := &WriteBackConfig{
+			GitRepo:   "/nonexistent/repo.git",
+			GitBranch: "main",
+			Method:    WriteBackGit,
+			GetCreds: func(app *v1alpha1.Application) (git.Creds, error) {
+				return git.NopCreds{}, nil
+			},
+		}
+		app1 := v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{Name: "app1"},
+			Spec: v1alpha1.ApplicationSpec{
+				Source: &v1alpha1.ApplicationSource{
+					RepoURL:        "/nonexistent/repo.git",
+					TargetRevision: "main",
+				},
+			},
+		}
+
+		pendingWrites := []*PendingWrite{
+			{
+				AppName: "app1",
+				App: &ApplicationImages{
+					Application:     app1,
+					WriteBackConfig: wbc,
+				},
+			},
+		}
+
+		errs := BatchCommitChangesGit(context.Background(), pendingWrites, state)
+		// Should fail (no valid git repo) but not panic or deadlock
+		assert.NotEmpty(t, errs)
+		assert.Contains(t, errs, "app1")
+
+		// Verify the lock is not held (we can acquire it)
+		lock := state.GetRepositoryLock("/nonexistent/repo.git")
+		assert.NotNil(t, lock)
+		locked := lock.TryLock()
+		assert.True(t, locked, "Lock should be released after BatchCommitChangesGit returns")
+		if locked {
+			lock.Unlock()
+		}
+	})
+}
+
+func Test_PendingWrite_BatchKey(t *testing.T) {
+	t.Run("Groups by repo and branch", func(t *testing.T) {
+		pw1 := &PendingWrite{
+			App: &ApplicationImages{
+				WriteBackConfig: &WriteBackConfig{
+					GitRepo:   "https://github.com/example/repo.git",
+					GitBranch: "main",
+				},
+			},
+		}
+		pw2 := &PendingWrite{
+			App: &ApplicationImages{
+				WriteBackConfig: &WriteBackConfig{
+					GitRepo:   "https://github.com/example/repo.git",
+					GitBranch: "main",
+				},
+			},
+		}
+		pw3 := &PendingWrite{
+			App: &ApplicationImages{
+				WriteBackConfig: &WriteBackConfig{
+					GitRepo:   "https://github.com/example/repo.git",
+					GitBranch: "staging",
+				},
+			},
+		}
+		pw4 := &PendingWrite{
+			App: &ApplicationImages{
+				WriteBackConfig: &WriteBackConfig{
+					GitRepo:   "https://github.com/other/repo.git",
+					GitBranch: "main",
+				},
+			},
+		}
+
+		assert.Equal(t, pw1.BatchKey(), pw2.BatchKey(), "Same repo+branch should have same key")
+		assert.NotEqual(t, pw1.BatchKey(), pw3.BatchKey(), "Different branches should have different keys")
+		assert.NotEqual(t, pw1.BatchKey(), pw4.BatchKey(), "Different repos should have different keys")
+	})
+
+	t.Run("Uses default branch placeholder when empty", func(t *testing.T) {
+		pw := &PendingWrite{
+			App: &ApplicationImages{
+				WriteBackConfig: &WriteBackConfig{
+					GitRepo:   "https://github.com/example/repo.git",
+					GitBranch: "",
+				},
+			},
+		}
+		assert.Contains(t, pw.BatchKey(), "_default_")
+	})
+}
+
+func Test_buildBatchCommitMessage(t *testing.T) {
+	t.Run("Single app uses app's own message", func(t *testing.T) {
+		writes := []*PendingWrite{
+			{
+				AppName: "ns/myapp",
+				App: &ApplicationImages{
+					WriteBackConfig: &WriteBackConfig{
+						GitCommitMessage: "build: update myapp",
+					},
+				},
+				ChangeList: []ChangeEntry{},
+			},
+		}
+		msg := buildBatchCommitMessage(writes)
+		assert.Equal(t, "build: update myapp", msg)
+	})
+
+	t.Run("Multiple apps get combined message", func(t *testing.T) {
+		writes := []*PendingWrite{
+			{
+				AppName: "ns/app1",
+				App: &ApplicationImages{
+					WriteBackConfig: &WriteBackConfig{},
+				},
+				ChangeList: []ChangeEntry{
+					{
+						Image:  image.NewFromIdentifier("nginx"),
+						OldTag: tag.NewImageTag("1.0", time.Now(), ""),
+						NewTag: tag.NewImageTag("1.1", time.Now(), ""),
+					},
+				},
+			},
+			{
+				AppName: "ns/app2",
+				App: &ApplicationImages{
+					WriteBackConfig: &WriteBackConfig{},
+				},
+				ChangeList: []ChangeEntry{
+					{
+						Image:  image.NewFromIdentifier("redis"),
+						OldTag: tag.NewImageTag("6.0", time.Now(), ""),
+						NewTag: tag.NewImageTag("7.0", time.Now(), ""),
+					},
+				},
+			},
+		}
+		msg := buildBatchCommitMessage(writes)
+		assert.Contains(t, msg, "batch update of 2 application(s)")
+		assert.Contains(t, msg, "ns/app1")
+		assert.Contains(t, msg, "ns/app2")
+		assert.Contains(t, msg, "nginx")
+		assert.Contains(t, msg, "redis")
+	})
+}

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -6569,7 +6569,7 @@ func Test_CheckApplicationImages(t *testing.T) {
 			regClient := regmock.RegistryClient{}
 			regClient.On("NewRepository", mock.Anything).Return(nil)
 			regClient.On("Tags", mock.Anything).Return([]string{"1.0.1", "1.0.2"}, nil)
-			regClient.On("ManifestForTag", mock.Anything, mock.Anything).Return(&schema1.SignedManifest{}, nil)
+			regClient.On("ManifestForTag", mock.Anything, mock.Anything).Return(&schema1.SignedManifest{}, nil) //nolint:staticcheck
 			return &regClient, nil
 		}
 


### PR DESCRIPTION
Instead of each application performing its own clone→fetch→checkout→write→commit→push cycle while holding the per-repo mutex, this change introduces a two-phase approach:

Phase 1 (parallel): All applications poll their registries concurrently via CheckApplicationImages(), which returns a PendingWrite describing what needs to be written to git, without actually touching git.

Phase 2 (batched): PendingWrites are grouped by BatchKey (repo + branch). For each group, BatchCommitChangesGit() acquires the repo lock once, does a single clone/fetch/checkout, applies all file writes (kustomization or parameter overrides), builds a combined commit message, and does a single commit + push.

For N apps sharing the same repo, this reduces git operations from N separate clone→push cycles to 1. In a monorepo setup with 300+ applications where each git cycle takes several seconds, the serialized queue can take minutes. Batching reduces this to a single round-trip regardless of the number of apps with pending updates.

- Add PendingWrite type with BatchKey() method (types.go)
- Add CheckApplicationImages() splitting registry poll from git write (update.go)
- Add BatchCommitChangesGit() and buildBatchCommitMessage() (git.go)
- Rewrite RunImageUpdater() as two-phase batched pipeline (reconcile.go)
- Add unit tests for CheckApplicationImages, PendingWrite.BatchKey, BatchCommitChangesGit, buildBatchCommitMessage (update_test.go)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --enable-batch-commit / ENABLE_BATCH_COMMIT (default: false) to enable batched git write-backs: registry polling remains per-application, then updates are grouped by repository+branch to perform a single clone/commit/push per group; kube events are emitted after successful batched writes.

* **Documentation**
  * Documented the new flag/env var and the batched vs per-application behaviors.

* **Tests**
  * Added unit tests covering polling, pending-write creation, batching, commit grouping, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->