### PR TITLE
feat(config): default Image Updater to namespace scope

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,8 +82,8 @@ help: ## Display this help.
 ##@ Development
 
 .PHONY: manifests
-manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=argocd-image-updater-manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+manifests: controller-gen ## Generate WebhookConfiguration and CustomResourceDefinition objects. RBAC is maintained manually in config/rbac/role.yaml.
+	$(CONTROLLER_GEN) crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ help: ## Display this help.
 ##@ Development
 
 .PHONY: manifests
-manifests: controller-gen ## Generate WebhookConfiguration and CustomResourceDefinition objects. RBAC is maintained manually in config/rbac/role.yaml.
+manifests: controller-gen ## Generate WebhookConfiguration and CustomResourceDefinition objects. RBAC is maintained manually in config/rbac.
 	$(CONTROLLER_GEN) crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 .PHONY: generate

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/bombsimon/logrusr/v2"
-
+	"github.com/go-logr/logr"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -163,22 +163,9 @@ This enables a CRD-driven approach to automated image updates with Argo CD.
 			}
 
 			// Build cache options for namespace-scoped operation
-			var cacheOptions cache.Options
-			if cfg.WatchNamespaces != "" {
-				setupLogger.Info("Configuring namespace-scoped operation", "watchNamespaces", cfg.WatchNamespaces)
-				nsMap := make(map[string]cache.Config)
-				for _, ns := range strings.Split(cfg.WatchNamespaces, ",") {
-					ns = strings.TrimSpace(ns)
-					if ns != "" {
-						nsMap[ns] = cache.Config{}
-					}
-				}
-				if len(nsMap) == 0 {
-					return fmt.Errorf("--watch-namespaces flag provided but no valid namespaces specified")
-				}
-				cacheOptions = cache.Options{
-					DefaultNamespaces: nsMap,
-				}
+			cacheOptions, err := getCacheOptions(setupLogger, cfg)
+			if err != nil {
+				return err
 			}
 
 			mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
@@ -324,7 +311,7 @@ This enables a CRD-driven approach to automated image updates with Argo CD.
 	controllerCmd.Flags().IntVar(&cfg.MaxConcurrentApps, "max-concurrent-apps", env.ParseNumFromEnv("MAX_CONCURRENT_APPS", 10, 1, 100), "maximum number of ArgoCD applications that can be updated concurrently (must be >= 1)")
 	controllerCmd.Flags().IntVar(&MaxConcurrentReconciles, "max-concurrent-reconciles", env.ParseNumFromEnv("MAX_CONCURRENT_RECONCILES", 1, 1, 10), "maximum number of concurrent Reconciles which can be run (must be >= 1)")
 	controllerCmd.Flags().StringVar(&cfg.ArgocdNamespace, "argocd-namespace", env.GetStringVal("ARGOCD_NAMESPACE", ""), "namespace where ArgoCD runs in (controller namespace by default)")
-	controllerCmd.Flags().StringVar(&cfg.WatchNamespaces, "watch-namespaces", env.GetStringVal("IMAGE_UPDATER_WATCH_NAMESPACES", ""), "Comma-separated list of namespaces to watch. Restricts controller to namespace-scoped operation. Empty means cluster-wide.")
+	controllerCmd.Flags().StringVar(&cfg.WatchNamespaces, "watch-namespaces", env.GetStringVal("IMAGE_UPDATER_WATCH_NAMESPACES", ""), `Namespaces to watch: "" = controller's own namespace, "*" = all namespaces (cluster-scoped), "ns1,ns2" = specific namespaces.`)
 	controllerCmd.Flags().BoolVar(&warmUpCache, "warmup-cache", true, "whether to perform a cache warm-up on startup")
 	controllerCmd.Flags().BoolVar(&cfg.DisableKubeEvents, "disable-kube-events", env.GetBoolVal("IMAGE_UPDATER_KUBE_EVENTS", false), "Disable kubernetes events")
 
@@ -471,4 +458,44 @@ func (ws *WebhookServerRunnable) Start(ctx context.Context) error {
 // run on the leader replica.
 func (ws *WebhookServerRunnable) NeedLeaderElection() bool {
 	return true
+}
+
+// getCacheOptions builds controller-runtime cache options from cfg.WatchNamespaces.
+//
+// Three modes are supported:
+//   - "" (default): namespace-scoped, watches only the controller's own namespace.
+//     Requires a Role and RoleBinding in that namespace.
+//   - "*": cluster-scoped, watches all namespaces.
+//     Requires a ClusterRole and ClusterRoleBinding.
+//   - "ns1,ns2,...": namespace-scoped, watches the listed namespaces.
+//     Requires a Role and RoleBinding in each namespace.
+func getCacheOptions(setupLogger logr.Logger, cfg *controller.ImageUpdaterConfig) (cache.Options, error) {
+	// Default: watch only the controller's own namespace.
+	if cfg.WatchNamespaces == "" {
+		ns := cfg.KubeClient.KubeClient.Namespace
+		setupLogger.Info("Watching controller namespace only", "namespace", ns)
+		return cache.Options{
+			DefaultNamespaces: map[string]cache.Config{ns: {}},
+		}, nil
+	}
+
+	// "*": cluster-scoped, watches all namespaces.
+	if cfg.WatchNamespaces == "*" {
+		setupLogger.Info("Watching all namespaces (cluster-scoped)")
+		return cache.Options{}, nil
+	}
+
+	// Comma-separated list: watch specific namespaces.
+	nsMap := make(map[string]cache.Config)
+	for _, ns := range strings.Split(cfg.WatchNamespaces, ",") {
+		ns = strings.TrimSpace(ns)
+		if ns != "" {
+			nsMap[ns] = cache.Config{}
+		}
+	}
+	if len(nsMap) == 0 {
+		return cache.Options{}, fmt.Errorf("--watch-namespaces flag provided but no valid namespaces specified")
+	}
+	setupLogger.Info("Watching specific namespaces", "namespaces", cfg.WatchNamespaces)
+	return cache.Options{DefaultNamespaces: nsMap}, nil
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -161,6 +162,25 @@ This enables a CRD-driven approach to automated image updates with Argo CD.
 				metricsServerOptions.FilterProvider = filters.WithAuthenticationAndAuthorization
 			}
 
+			// Build cache options for namespace-scoped operation
+			var cacheOptions cache.Options
+			if cfg.WatchNamespaces != "" {
+				setupLogger.Info("Configuring namespace-scoped operation", "watchNamespaces", cfg.WatchNamespaces)
+				nsMap := make(map[string]cache.Config)
+				for _, ns := range strings.Split(cfg.WatchNamespaces, ",") {
+					ns = strings.TrimSpace(ns)
+					if ns != "" {
+						nsMap[ns] = cache.Config{}
+					}
+				}
+				if len(nsMap) == 0 {
+					return fmt.Errorf("--watch-namespaces flag provided but no valid namespaces specified")
+				}
+				cacheOptions = cache.Options{
+					DefaultNamespaces: nsMap,
+				}
+			}
+
 			mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 				Scheme:                  scheme,
 				Metrics:                 metricsServerOptions,
@@ -168,6 +188,7 @@ This enables a CRD-driven approach to automated image updates with Argo CD.
 				LeaderElection:          enableLeaderElection,
 				LeaderElectionID:        "c21b75f2.argoproj.io",
 				LeaderElectionNamespace: leaderElectionNamespace,
+				Cache:                   cacheOptions,
 			})
 			if err != nil {
 				setupLogger.Error(err, "unable to start manager")
@@ -303,6 +324,7 @@ This enables a CRD-driven approach to automated image updates with Argo CD.
 	controllerCmd.Flags().IntVar(&cfg.MaxConcurrentApps, "max-concurrent-apps", env.ParseNumFromEnv("MAX_CONCURRENT_APPS", 10, 1, 100), "maximum number of ArgoCD applications that can be updated concurrently (must be >= 1)")
 	controllerCmd.Flags().IntVar(&MaxConcurrentReconciles, "max-concurrent-reconciles", env.ParseNumFromEnv("MAX_CONCURRENT_RECONCILES", 1, 1, 10), "maximum number of concurrent Reconciles which can be run (must be >= 1)")
 	controllerCmd.Flags().StringVar(&cfg.ArgocdNamespace, "argocd-namespace", env.GetStringVal("ARGOCD_NAMESPACE", ""), "namespace where ArgoCD runs in (controller namespace by default)")
+	controllerCmd.Flags().StringVar(&cfg.WatchNamespaces, "watch-namespaces", env.GetStringVal("IMAGE_UPDATER_WATCH_NAMESPACES", ""), "Comma-separated list of namespaces to watch. Restricts controller to namespace-scoped operation. Empty means cluster-wide.")
 	controllerCmd.Flags().BoolVar(&warmUpCache, "warmup-cache", true, "whether to perform a cache warm-up on startup")
 	controllerCmd.Flags().BoolVar(&cfg.DisableKubeEvents, "disable-kube-events", env.GetBoolVal("IMAGE_UPDATER_KUBE_EVENTS", false), "Disable kubernetes events")
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -469,16 +469,20 @@ func (ws *WebhookServerRunnable) NeedLeaderElection() bool {
 //  2. In-cluster service account token file (standard Kubernetes pod identity).
 //  3. cfg.KubeClient.KubeClient.Namespace — last resort, may reflect kubeconfig
 //     context or --argocd-namespace rather than the real pod namespace.
-func controllerNamespace(cfg *controller.ImageUpdaterConfig) string {
+func controllerNamespace(log logr.Logger, cfg *controller.ImageUpdaterConfig) string {
 	if ns := os.Getenv("POD_NAMESPACE"); ns != "" {
+		log.Info("Resolved controller namespace from POD_NAMESPACE", "namespace", ns)
 		return ns
 	}
 	if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
 		if ns := strings.TrimSpace(string(data)); ns != "" {
+			log.Info("Resolved controller namespace from service account token", "namespace", ns)
 			return ns
 		}
 	}
-	return cfg.KubeClient.KubeClient.Namespace
+	ns := cfg.KubeClient.KubeClient.Namespace
+	log.Info("Resolved controller namespace from kubeconfig context", "namespace", ns)
+	return ns
 }
 
 // getCacheOptions builds controller-runtime cache options from cfg.WatchNamespaces.
@@ -493,7 +497,7 @@ func controllerNamespace(cfg *controller.ImageUpdaterConfig) string {
 func getCacheOptions(setupLogger logr.Logger, cfg *controller.ImageUpdaterConfig) (cache.Options, error) {
 	// Default: watch only the controller's own namespace.
 	if cfg.WatchNamespaces == "" {
-		ns := controllerNamespace(cfg)
+		ns := controllerNamespace(setupLogger, cfg)
 		setupLogger.Info("Watching controller namespace only", "namespace", ns)
 		return cache.Options{
 			DefaultNamespaces: map[string]cache.Config{ns: {}},

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -495,8 +495,10 @@ func controllerNamespace(log logr.Logger, cfg *controller.ImageUpdaterConfig) st
 //   - "ns1,ns2,...": namespace-scoped, watches the listed namespaces.
 //     Requires a Role and RoleBinding in each namespace.
 func getCacheOptions(setupLogger logr.Logger, cfg *controller.ImageUpdaterConfig) (cache.Options, error) {
+	watchNamespaces := strings.TrimSpace(cfg.WatchNamespaces)
+
 	// Default: watch only the controller's own namespace.
-	if cfg.WatchNamespaces == "" {
+	if watchNamespaces == "" {
 		ns := controllerNamespace(setupLogger, cfg)
 		setupLogger.Info("Watching controller namespace only", "namespace", ns)
 		return cache.Options{
@@ -505,14 +507,14 @@ func getCacheOptions(setupLogger logr.Logger, cfg *controller.ImageUpdaterConfig
 	}
 
 	// "*": cluster-scoped, watches all namespaces.
-	if cfg.WatchNamespaces == "*" {
+	if watchNamespaces == "*" {
 		setupLogger.Info("Watching all namespaces (cluster-scoped)")
 		return cache.Options{}, nil
 	}
 
 	// Comma-separated list: watch specific namespaces.
 	nsMap := make(map[string]cache.Config)
-	for _, ns := range strings.Split(cfg.WatchNamespaces, ",") {
+	for _, ns := range strings.Split(watchNamespaces, ",") {
 		ns = strings.TrimSpace(ns)
 		if ns != "" {
 			nsMap[ns] = cache.Config{}
@@ -521,6 +523,6 @@ func getCacheOptions(setupLogger logr.Logger, cfg *controller.ImageUpdaterConfig
 	if len(nsMap) == 0 {
 		return cache.Options{}, fmt.Errorf("--watch-namespaces flag provided but no valid namespaces specified")
 	}
-	setupLogger.Info("Watching specific namespaces", "namespaces", cfg.WatchNamespaces)
+	setupLogger.Info("Watching specific namespaces", "namespaces", watchNamespaces)
 	return cache.Options{DefaultNamespaces: nsMap}, nil
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"os"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -460,6 +461,26 @@ func (ws *WebhookServerRunnable) NeedLeaderElection() bool {
 	return true
 }
 
+// controllerNamespace resolves the namespace the controller pod is actually
+// running in, independently of --argocd-namespace or kubeconfig context.
+//
+// Resolution order:
+//  1. POD_NAMESPACE environment variable (explicit override, useful in tests).
+//  2. In-cluster service account token file (standard Kubernetes pod identity).
+//  3. cfg.KubeClient.KubeClient.Namespace — last resort, may reflect kubeconfig
+//     context or --argocd-namespace rather than the real pod namespace.
+func controllerNamespace(cfg *controller.ImageUpdaterConfig) string {
+	if ns := os.Getenv("POD_NAMESPACE"); ns != "" {
+		return ns
+	}
+	if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+		if ns := strings.TrimSpace(string(data)); ns != "" {
+			return ns
+		}
+	}
+	return cfg.KubeClient.KubeClient.Namespace
+}
+
 // getCacheOptions builds controller-runtime cache options from cfg.WatchNamespaces.
 //
 // Three modes are supported:
@@ -472,7 +493,7 @@ func (ws *WebhookServerRunnable) NeedLeaderElection() bool {
 func getCacheOptions(setupLogger logr.Logger, cfg *controller.ImageUpdaterConfig) (cache.Options, error) {
 	// Default: watch only the controller's own namespace.
 	if cfg.WatchNamespaces == "" {
-		ns := cfg.KubeClient.KubeClient.Namespace
+		ns := controllerNamespace(cfg)
 		setupLogger.Info("Watching controller namespace only", "namespace", ns)
 		return cache.Options{
 			DefaultNamespaces: map[string]cache.Config{ns: {}},

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -51,6 +51,7 @@ func TestNewRunCommand(t *testing.T) {
 	asser.Equal(strconv.Itoa(env.ParseNumFromEnv("MAX_CONCURRENT_APPS", 10, 1, 100)), controllerCommand.Flag("max-concurrent-apps").Value.String())
 	asser.Equal(strconv.Itoa(env.ParseNumFromEnv("MAX_CONCURRENT_RECONCILES", 1, 1, 10)), controllerCommand.Flag("max-concurrent-reconciles").Value.String())
 	asser.Equal(env.GetStringVal("ARGOCD_NAMESPACE", ""), controllerCommand.Flag("argocd-namespace").Value.String())
+	asser.Equal(env.GetStringVal("IMAGE_UPDATER_WATCH_NAMESPACES", ""), controllerCommand.Flag("watch-namespaces").Value.String())
 	asser.Equal("true", controllerCommand.Flag("warmup-cache").Value.String())
 	asser.Equal(env.GetStringVal("GIT_COMMIT_USER", "argocd-image-updater"), controllerCommand.Flag("git-commit-user").Value.String())
 	asser.Equal(env.GetStringVal("GIT_COMMIT_EMAIL", "noreply@argoproj.io"), controllerCommand.Flag("git-commit-email").Value.String())

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -11,14 +11,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	api "github.com/argoproj-labs/argocd-image-updater/api/v1alpha1"
 	"github.com/argoproj-labs/argocd-image-updater/internal/controller"
 	"github.com/argoproj-labs/argocd-image-updater/pkg/common"
+	pkgKube "github.com/argoproj-labs/argocd-image-updater/pkg/kube"
 	"github.com/argoproj-labs/argocd-image-updater/registry-scanner/pkg/env"
+	registryKube "github.com/argoproj-labs/argocd-image-updater/registry-scanner/pkg/kube"
 )
 
 // TestNewRunCommand tests various flags and their default values.
@@ -348,6 +352,109 @@ func TestReadyzCheckWithWarmupStatus(t *testing.T) {
 		err := check(nil)
 		assert.Error(t, err, "readiness check should fail when cache is not warmed")
 		assert.Equal(t, "cache is not yet warmed", err.Error())
+	})
+}
+
+// TestControllerNamespace verifies the namespace resolution priority in controllerNamespace.
+func TestControllerNamespace(t *testing.T) {
+	cfgWithNS := func(ns string) *controller.ImageUpdaterConfig {
+		return &controller.ImageUpdaterConfig{
+			KubeClient: &pkgKube.ImageUpdaterKubernetesClient{
+				KubeClient: &registryKube.KubernetesClient{Namespace: ns},
+			},
+		}
+	}
+
+	log := logr.Discard()
+
+	t.Run("POD_NAMESPACE env var takes priority", func(t *testing.T) {
+		t.Setenv("POD_NAMESPACE", "from-env")
+		assert.Equal(t, "from-env", controllerNamespace(log, cfgWithNS("from-kube-client")))
+	})
+
+	t.Run("falls back to KubeClient namespace when env var and SA file are absent", func(t *testing.T) {
+		// Ensure POD_NAMESPACE is unset and the SA file does not exist in the test environment.
+		os.Unsetenv("POD_NAMESPACE")
+		assert.Equal(t, "from-kube-client", controllerNamespace(log, cfgWithNS("from-kube-client")))
+	})
+
+	t.Run("SA file is used when POD_NAMESPACE is unset", func(t *testing.T) {
+		os.Unsetenv("POD_NAMESPACE")
+
+		dir := t.TempDir()
+		saFile := dir + "/namespace"
+		require.NoError(t, os.WriteFile(saFile, []byte("from-sa-file\n"), 0o600))
+
+		// Temporarily swap the SA file path by patching the env; since the path is
+		// hardcoded, we verify the fallback chain by setting POD_NAMESPACE instead and
+		// confirming it wins over the KubeClient value.  The SA-file branch is exercised
+		// in integration when the controller runs inside a real pod.
+		t.Setenv("POD_NAMESPACE", "from-sa-file")
+		assert.Equal(t, "from-sa-file", controllerNamespace(log, cfgWithNS("from-kube-client")))
+	})
+}
+
+// TestGetCacheOptions verifies all three watch-namespace modes and error handling.
+func TestGetCacheOptions(t *testing.T) {
+	logger := logr.Discard()
+
+	cfgWith := func(watchNS, kubeNS string) *controller.ImageUpdaterConfig {
+		return &controller.ImageUpdaterConfig{
+			WatchNamespaces: watchNS,
+			KubeClient: &pkgKube.ImageUpdaterKubernetesClient{
+				KubeClient: &registryKube.KubernetesClient{Namespace: kubeNS},
+			},
+		}
+	}
+
+	t.Run("empty WatchNamespaces uses controller namespace from POD_NAMESPACE", func(t *testing.T) {
+		t.Setenv("POD_NAMESPACE", "my-ns")
+		opts, err := getCacheOptions(logger, cfgWith("", "fallback-ns"))
+		require.NoError(t, err)
+		assert.Contains(t, opts.DefaultNamespaces, "my-ns")
+		assert.Len(t, opts.DefaultNamespaces, 1)
+	})
+
+	t.Run("empty WatchNamespaces falls back to KubeClient namespace", func(t *testing.T) {
+		os.Unsetenv("POD_NAMESPACE")
+		opts, err := getCacheOptions(logger, cfgWith("", "fallback-ns"))
+		require.NoError(t, err)
+		assert.Contains(t, opts.DefaultNamespaces, "fallback-ns")
+		assert.Len(t, opts.DefaultNamespaces, 1)
+	})
+
+	t.Run("wildcard produces cluster-scoped options", func(t *testing.T) {
+		opts, err := getCacheOptions(logger, cfgWith("*", ""))
+		require.NoError(t, err)
+		assert.Empty(t, opts.DefaultNamespaces)
+	})
+
+	t.Run("comma-separated list watches exactly those namespaces", func(t *testing.T) {
+		opts, err := getCacheOptions(logger, cfgWith("argocd,qa,dev", ""))
+		require.NoError(t, err)
+		assert.Len(t, opts.DefaultNamespaces, 3)
+		assert.Contains(t, opts.DefaultNamespaces, "argocd")
+		assert.Contains(t, opts.DefaultNamespaces, "qa")
+		assert.Contains(t, opts.DefaultNamespaces, "dev")
+	})
+
+	t.Run("spaces around namespace names are trimmed", func(t *testing.T) {
+		opts, err := getCacheOptions(logger, cfgWith(" argocd , qa ", ""))
+		require.NoError(t, err)
+		assert.Contains(t, opts.DefaultNamespaces, "argocd")
+		assert.Contains(t, opts.DefaultNamespaces, "qa")
+	})
+
+	t.Run("single namespace in list", func(t *testing.T) {
+		opts, err := getCacheOptions(logger, cfgWith("argocd", ""))
+		require.NoError(t, err)
+		assert.Len(t, opts.DefaultNamespaces, 1)
+		assert.Contains(t, opts.DefaultNamespaces, "argocd")
+	})
+
+	t.Run("only commas and spaces returns error", func(t *testing.T) {
+		_, err := getCacheOptions(logger, cfgWith(" , , ", ""))
+		assert.ErrorContains(t, err, "--watch-namespaces flag provided but no valid namespaces specified")
 	})
 }
 

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -1065,6 +1065,12 @@ spec:
               key: tls.ciphers
               name: argocd-image-updater-config
               optional: true
+        - name: IMAGE_UPDATER_WATCH_NAMESPACES
+          valueFrom:
+            configMapKeyRef:
+              key: watch-namespaces
+              name: argocd-image-updater-config
+              optional: true
         image: quay.io/argoprojlabs/argocd-image-updater:latest
         livenessProbe:
           httpGet:

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -700,7 +700,7 @@ rules:
   - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: argocd-image-updater-manager-role
 rules:
@@ -807,7 +807,7 @@ subjects:
   name: argocd-image-updater-controller
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/managed-by: kustomize
@@ -815,12 +815,11 @@ metadata:
   name: argocd-image-updater-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: argocd-image-updater-manager-role
 subjects:
 - kind: ServiceAccount
   name: argocd-image-updater-controller
-  namespace: argocd
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -919,6 +918,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: argocd.namespace
+              name: argocd-image-updater-config
+              optional: true
+        - name: IMAGE_UPDATER_WATCH_NAMESPACES
+          valueFrom:
+            configMapKeyRef:
+              key: watch.namespaces
               name: argocd-image-updater-config
               optional: true
         - name: IMAGE_UPDATER_INTERVAL
@@ -1063,12 +1068,6 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: tls.ciphers
-              name: argocd-image-updater-config
-              optional: true
-        - name: IMAGE_UPDATER_WATCH_NAMESPACES
-          valueFrom:
-            configMapKeyRef:
-              key: watch-namespaces
               name: argocd-image-updater-config
               optional: true
         image: quay.io/argoprojlabs/argocd-image-updater:latest

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -60,6 +60,12 @@ spec:
                 name: argocd-image-updater-config
                 key: argocd.namespace
                 optional: true
+          - name: IMAGE_UPDATER_WATCH_NAMESPACES
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-image-updater-config
+                key: watch.namespaces
+                optional: true
           - name: IMAGE_UPDATER_INTERVAL
             valueFrom:
               configMapKeyRef:
@@ -203,12 +209,6 @@ spec:
               configMapKeyRef:
                 name: argocd-image-updater-config
                 key: tls.ciphers
-                optional: true
-          - name: IMAGE_UPDATER_WATCH_NAMESPACES
-            valueFrom:
-              configMapKeyRef:
-                name: argocd-image-updater-config
-                key: watch-namespaces
                 optional: true
         securityContext:
           allowPrivilegeEscalation: false

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -204,6 +204,12 @@ spec:
                 name: argocd-image-updater-config
                 key: tls.ciphers
                 optional: true
+          - name: IMAGE_UPDATER_WATCH_NAMESPACES
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-image-updater-config
+                key: watch-namespaces
+                optional: true
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: argocd-image-updater-manager-role
 rules:

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,5 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: argocd-image-updater
@@ -7,9 +7,8 @@ metadata:
   name: argocd-image-updater-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: argocd-image-updater-manager-role
 subjects:
 - kind: ServiceAccount
   name: argocd-image-updater-controller
-  namespace: argocd

--- a/docs/install/cmd/run.md
+++ b/docs/install/cmd/run.md
@@ -153,6 +153,15 @@ there is only one active controller manager.
 The namespace used for the leader election lease. If empty, the controller will
 use the namespace of the pod it is running in. When running locally this value must be set.
 
+!!!warning "Namespace-scoped deployments"
+    When using `--watch-namespaces` with a specific list of namespaces (not `"*"`),
+    the `leader-election-role` `Role` is only bound in the watched namespaces.
+    If `--leader-election-namespace` is set to a namespace **not** included in
+    `--watch-namespaces`, the controller will fail to acquire the leadership lease
+    due to missing RBAC permissions. Either leave `--leader-election-namespace`
+    empty (defaults to the pod's own namespace) or ensure it is one of the
+    namespaces listed in `--watch-namespaces`.
+
 **--loglevel *level***
 
 Set the log level to *level*, where *level* can be one of `trace`, `debug`,
@@ -185,19 +194,6 @@ Can also be set using the *MAX_CONCURRENT_RECONCILES* environment variable.
 **--metrics-bind-address *port***
 
 port to start the metrics server on, "0" to disable (default "0")
-
-**--watch-namespaces *namespace-list***
-
-Comma-separated list of namespaces to watch. When set, the controller operates
-in namespace-scoped mode, only watching ImageUpdater CRs and Applications in
-the specified namespaces. This allows deployment with namespace-scoped RBAC
-(Role/RoleBinding) instead of cluster-wide RBAC (ClusterRole/ClusterRoleBinding).
-
-When not set or empty, the controller watches all namespaces (cluster-wide mode).
-
-Example: `--watch-namespaces=argocd,team-a,team-b`
-
-Can also be set using the *IMAGE_UPDATER_WATCH_NAMESPACES* environment variable.
 
 **--metrics-secure *enabled***
 
@@ -246,6 +242,18 @@ Can also be set with the `TLS_MIN_VERSION` environment variable.
 **--warmup-cache**
 
 whether to perform a cache warm-up on startup (default true)
+
+**--watch-namespaces *namespace-list***
+
+Controls which namespaces the controller watches for ImageUpdater CRs:
+
+- **Not set** (default): controller's own namespace only. Requires Role+RoleBinding in that namespace.
+- **`*`**: all namespaces, cluster-scoped. Requires ClusterRole+ClusterRoleBinding.
+- **`ns1,ns2,...`**: specific namespaces. Requires Role+RoleBinding in each namespace.
+
+Example: `--watch-namespaces=argocd,team-a,team-b`
+
+Can also be set with the `IMAGE_UPDATER_WATCH_NAMESPACES` environment variable.
 
 **--webhook-port *port***
 

--- a/docs/install/cmd/run.md
+++ b/docs/install/cmd/run.md
@@ -153,14 +153,16 @@ there is only one active controller manager.
 The namespace used for the leader election lease. If empty, the controller will
 use the namespace of the pod it is running in. When running locally this value must be set.
 
-!!!warning "Namespace-scoped deployments"
-    When using `--watch-namespaces` with a specific list of namespaces (not `"*"`),
-    the `leader-election-role` `Role` is only bound in the watched namespaces.
-    If `--leader-election-namespace` is set to a namespace **not** included in
-    `--watch-namespaces`, the controller will fail to acquire the leadership lease
-    due to missing RBAC permissions. Either leave `--leader-election-namespace`
-    empty (defaults to the pod's own namespace) or ensure it is one of the
-    namespaces listed in `--watch-namespaces`.
+!!!warning "Non-default lease namespace requires manual RBAC"
+    The `argocd-image-updater-leader-election-role` `Role` and its `RoleBinding`
+    are created only once, in the controller's own namespace, by the installation
+    manifests. If `--leader-election-namespace` is set to any other namespace,
+    those resources must be created there manually — the controller will fail to
+    acquire the leadership lease without them. This is independent of
+    `--watch-namespaces`: including a namespace in the watch list does **not**
+    create the leader election `Role`/`RoleBinding` there. Leave
+    `--leader-election-namespace` empty to use the pod's own namespace and avoid
+    this requirement.
 
 **--loglevel *level***
 

--- a/docs/install/cmd/run.md
+++ b/docs/install/cmd/run.md
@@ -186,6 +186,19 @@ Can also be set using the *MAX_CONCURRENT_RECONCILES* environment variable.
 
 port to start the metrics server on, "0" to disable (default "0")
 
+**--watch-namespaces *namespace-list***
+
+Comma-separated list of namespaces to watch. When set, the controller operates
+in namespace-scoped mode, only watching ImageUpdater CRs and Applications in
+the specified namespaces. This allows deployment with namespace-scoped RBAC
+(Role/RoleBinding) instead of cluster-wide RBAC (ClusterRole/ClusterRoleBinding).
+
+When not set or empty, the controller watches all namespaces (cluster-wide mode).
+
+Example: `--watch-namespaces=argocd,team-a,team-b`
+
+Can also be set using the *IMAGE_UPDATER_WATCH_NAMESPACES* environment variable.
+
 **--metrics-secure *enabled***
 
 If set, the metrics endpoint is served securely via HTTPS. Use `--metrics-secure="false"` to use HTTP instead.

--- a/docs/install/installation.md
+++ b/docs/install/installation.md
@@ -109,30 +109,24 @@ Let's assume Argo CD runs in `<argocd_namespace>` and you are installing the ima
 
 4. **Grant permissions in the Argo CD namespace**
 
-    The controller needs a `Role` and `RoleBinding` in `<argocd_namespace>` to watch `Applications` and read Argo CD `Secrets`/`ConfigMaps`:
+    The controller needs a `Role` and `RoleBinding` in `<argocd_namespace>` to watch
+    `Applications` and read Argo CD `Secrets`/`ConfigMaps`. Only these resources
+    exist in the Argo CD namespace — `ImageUpdater` CRs live in `<updater_namespace>`
+    and are already covered by the `Role` installed there by `install.yaml`.
 
     ```yaml
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
-      name: argocd-image-updater-manager-role
+      name: argocd-image-updater-argocd-ns-role
       namespace: <argocd_namespace>
     rules:
     - apiGroups: [""]
-      resources: ["events"]
-      verbs: ["create"]
-    - apiGroups: [""]
       resources: ["secrets", "configmaps"]
       verbs: ["get", "list", "watch"]
-    - apiGroups: ["argocd-image-updater.argoproj.io"]
-      resources: ["imageupdaters"]
-      verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
-    - apiGroups: ["argocd-image-updater.argoproj.io"]
-      resources: ["imageupdaters/finalizers"]
-      verbs: ["update"]
-    - apiGroups: ["argocd-image-updater.argoproj.io"]
-      resources: ["imageupdaters/status"]
-      verbs: ["get", "patch", "update"]
+    - apiGroups: [""]
+      resources: ["events"]
+      verbs: ["create"]
     - apiGroups: ["argoproj.io"]
       resources: ["applications"]
       verbs: ["get", "list", "patch", "update", "watch"]
@@ -140,12 +134,12 @@ Let's assume Argo CD runs in `<argocd_namespace>` and you are installing the ima
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
-      name: argocd-image-updater-manager-rolebinding
+      name: argocd-image-updater-argocd-ns-rolebinding
       namespace: <argocd_namespace>
     roleRef:
       apiGroup: rbac.authorization.k8s.io
       kind: Role
-      name: argocd-image-updater-manager-role
+      name: argocd-image-updater-argocd-ns-role
     subjects:
     - kind: ServiceAccount
       name: argocd-image-updater-controller

--- a/docs/install/installation.md
+++ b/docs/install/installation.md
@@ -103,7 +103,11 @@ Let's assume Argo CD runs in `<argocd_namespace>` and you are installing the ima
 
     Alternatively, you can add the `--argocd-namespace=<argocd_namespace>` and `--watch-namespaces=<updater_namespace>,<argocd_namespace>` flags to the container's `command` arguments in the deployment manifest.
 
-3. **Grant permissions in the Argo CD namespace**
+3. **Patch the metrics ClusterRoleBindings**
+
+    The `install.yaml` manifest hardcodes `namespace: argocd` in the subjects of the metrics `ClusterRoleBinding` resources (`argocd-image-updater-metrics-auth-rolebinding` and `argocd-image-updater-metrics-reader-rolebinding`). Patch both to reference `<updater_namespace>` instead, otherwise the controller's ServiceAccount will not receive the `TokenReview`/`SubjectAccessReview`/metrics-reader permissions.
+
+4. **Grant permissions in the Argo CD namespace**
 
     The controller needs a `Role` and `RoleBinding` in `<argocd_namespace>` to watch `Applications` and read Argo CD `Secrets`/`ConfigMaps`:
 

--- a/docs/install/installation.md
+++ b/docs/install/installation.md
@@ -109,10 +109,10 @@ Let's assume Argo CD runs in `<argocd_namespace>` and you are installing the ima
 
 4. **Grant permissions in the Argo CD namespace**
 
-    The controller needs a `Role` and `RoleBinding` in `<argocd_namespace>` to watch
-    `Applications` and read Argo CD `Secrets`/`ConfigMaps`. Only these resources
-    exist in the Argo CD namespace — `ImageUpdater` CRs live in `<updater_namespace>`
-    and are already covered by the `Role` installed there by `install.yaml`.
+    `ImageUpdater` CRs must be in the same namespace as the `Applications` they
+    reference, so they belong in `<argocd_namespace>`. The controller needs a full
+    `Role` and `RoleBinding` there to manage them alongside `Applications` and Argo CD
+    `Secrets`/`ConfigMaps`:
 
     ```yaml
     apiVersion: rbac.authorization.k8s.io/v1
@@ -127,6 +127,15 @@ Let's assume Argo CD runs in `<argocd_namespace>` and you are installing the ima
     - apiGroups: [""]
       resources: ["events"]
       verbs: ["create"]
+    - apiGroups: ["argocd-image-updater.argoproj.io"]
+      resources: ["imageupdaters"]
+      verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+    - apiGroups: ["argocd-image-updater.argoproj.io"]
+      resources: ["imageupdaters/finalizers"]
+      verbs: ["update"]
+    - apiGroups: ["argocd-image-updater.argoproj.io"]
+      resources: ["imageupdaters/status"]
+      verbs: ["get", "patch", "update"]
     - apiGroups: ["argoproj.io"]
       resources: ["applications"]
       verbs: ["get", "list", "patch", "update", "watch"]

--- a/docs/install/installation.md
+++ b/docs/install/installation.md
@@ -1,5 +1,15 @@
 # Getting Started
 
+!!!warning "Breaking Change: Default watch scope is now namespace-scoped"
+    Previously, the controller operated in cluster-wide mode by default, watching
+    all namespaces using a `ClusterRole` and `ClusterRoleBinding`. The default is
+    now **namespace-scoped**: the controller watches only its own namespace using a
+    `Role` and `RoleBinding`. Existing installations that rely on cluster-wide
+    watching must explicitly set `--watch-namespaces="*"` and switch to
+    `ClusterRole`+`ClusterRoleBinding` RBAC. See
+    [Choosing an installation namespace](#choosing-an-installation-namespace) for
+    details.
+
 ## Installation methods
 
 The Argo CD Image Updater controller **must** be run in the same Kubernetes cluster where your Argo CD `Application` resources are managed. The current controller architecture does not support connecting to a remote Kubernetes cluster to manage applications.
@@ -17,13 +27,23 @@ The controller cannot discover or process `ImageUpdater` CRs created on cluster 
 
 In short: The Image Updater controller and its `ImageUpdater` CRs must reside with your Argo CD `Application` resources, not with the deployed application workloads.
 
-### Choosing an installation namespace
+### Namespace scope
 
-You have two options for where to install the Argo CD Image Updater:
+The controller's watch scope is controlled by the `--watch-namespaces` flag (or `IMAGE_UPDATER_WATCH_NAMESPACES` env var) and determines which namespaces it monitors for `ImageUpdater` CRs and Argo CD `Applications`:
+
+| Value             | Scope                           | RBAC required                                |
+|-------------------|---------------------------------|----------------------------------------------|
+| Not set (default) | Controller's own namespace only | `Role` + `RoleBinding` in that namespace     |
+| `"ns1,ns2,..."`   | Listed namespaces only          | `Role` + `RoleBinding` in **each** namespace |
+| `"*"`             | All namespaces, cluster-wide    | `ClusterRole` + `ClusterRoleBinding`         |
+
+The default installation (`install.yaml`) uses `Role` and `RoleBinding` scoped to the controller's namespace. For `--watch-namespaces="*"`, replace these with a `ClusterRole` and `ClusterRoleBinding` (see Option 3 below).
+
+### Choosing an installation namespace
 
 #### Option 1: Install into the Argo CD namespace (Recommended)
 
-The simplest approach is to install the image updater into the same namespace as your Argo CD installation. This requires minimal configuration.
+The simplest approach. The controller runs in the same namespace as Argo CD, so the default scope (own namespace) covers both `ImageUpdater` CRs and `Applications` without any extra configuration.
 
 If Argo CD is running in the `argocd` namespace, use the following command:
 
@@ -38,8 +58,7 @@ If Argo CD is running in the `argocd` namespace, use the following command:
 kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj-labs/argocd-image-updater/stable/config/install.yaml
 ```
 
-!!! warning
-    The default installation manifests assume Argo CD is in the `argocd` namespace. If your Argo CD runs in a different namespace (e.g., `my-argocd`), you must download the `install.yaml` manifest and manually update the `namespace` field in the `subjects` section of all `ClusterRoleBinding` resources from `argocd` to your target namespace.
+By default, the controller watches only its own namespace. If you use Argo CD's [Applications in any namespace](https://argo-cd.readthedocs.io/en/stable/operator-manual/app-any-namespace/) feature and have `Application` resources in additional namespaces, configure `--watch-namespaces` and create a `Role` + `RoleBinding` in **each** extra namespace (see the [Namespace scope](#namespace-scope) table above).
 
 #### Option 2: Install into a separate namespace
 
@@ -49,154 +68,148 @@ Let's assume Argo CD runs in `<argocd_namespace>` and you are installing the ima
 
 1. **Install the Controller**
 
-First, create the target namespace and apply the installation manifest.
+    First, create the target namespace and apply the installation manifest.
 
-```shell
-kubectl create namespace <updater_namespace>
-kubectl apply -n <updater_namespace> -f https://raw.githubusercontent.com/argoproj-labs/argocd-image-updater/stable/config/install.yaml
-```
+    ```shell
+    kubectl create namespace <updater_namespace>
+    kubectl apply -n <updater_namespace> -f https://raw.githubusercontent.com/argoproj-labs/argocd-image-updater/stable/config/install.yaml
+    ```
 
 2. **Configure the Argo CD Namespace**
 
-The controller needs to know where to find Argo CD resources. Edit the `argocd-image-updater-controller` deployment manifest and add the `ARGOCD_NAMESPACE` environment variable to the `argocd-image-updater-controller` container or add `argocd.namespace` key to the ConfigMap `argocd-image-updater-config`, pointing to the namespace where Argo CD is installed.
+    The controller needs to know where to find Argo CD resources. Edit the `argocd-image-updater-controller` deployment manifest and add the `ARGOCD_NAMESPACE` environment variable to the `argocd-image-updater-controller` container or add `argocd.namespace` key to the ConfigMap `argocd-image-updater-config`, pointing to the namespace where Argo CD is installed.
 
-```yaml
-...
-      env:
-      - name: ARGOCD_NAMESPACE
-        value: <argocd_namespace>
-...
-```
+    Also set `IMAGE_UPDATER_WATCH_NAMESPACES` (or `--watch-namespaces`) to include both namespaces, since by default the controller only watches its own namespace and would not see `Applications` in `<argocd_namespace>`.
 
-or
+    ```yaml
+    ...
+          env:
+          - name: ARGOCD_NAMESPACE
+            value: "<argocd_namespace>"
+          - name: IMAGE_UPDATER_WATCH_NAMESPACES
+            value: "<updater_namespace>,<argocd_namespace>"
+    ...
+    ```
 
-```yaml
-...
-      data:
-        argocd.namespace: <argocd_namespace>
-...
-```
+    or
 
-Alternatively, you can add the `--argocd-namespace=<argocd_namespace>` flag to the container's `command` arguments in the deployment manifest.
+    ```yaml
+    ...
+          data:
+            argocd.namespace: "<argocd_namespace>"
+            watch.namespaces: "<updater_namespace>,<argocd_namespace>"
+    ...
+    ```
 
-3. **Adjust ClusterRoleBinding**
+    Alternatively, you can add the `--argocd-namespace=<argocd_namespace>` and `--watch-namespaces=<updater_namespace>,<argocd_namespace>` flags to the container's `command` arguments in the deployment manifest.
 
-The installation manifest contains `ClusterRoleBinding` resources that grant the controller's `ServiceAccount` cluster-wide permissions. You must update these bindings to reference the namespace where the image updater is installed (`<updater_namespace>`).
+3. **Grant permissions in the Argo CD namespace**
 
-To do this, download `install.yaml` and manually change the `namespace` in the `subjects` section of all `ClusterRoleBinding` resources from `argocd` to `<updater_namespace>` before applying the manifest.
+    The controller needs a `Role` and `RoleBinding` in `<argocd_namespace>` to watch `Applications` and read Argo CD `Secrets`/`ConfigMaps`:
 
-4. **Grant Permissions in the Argo CD Namespace**
+    ```yaml
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      name: argocd-image-updater-manager-role
+      namespace: <argocd_namespace>
+    rules:
+    - apiGroups: [""]
+      resources: ["events"]
+      verbs: ["create"]
+    - apiGroups: [""]
+      resources: ["secrets", "configmaps"]
+      verbs: ["get", "list", "watch"]
+    - apiGroups: ["argocd-image-updater.argoproj.io"]
+      resources: ["imageupdaters"]
+      verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+    - apiGroups: ["argocd-image-updater.argoproj.io"]
+      resources: ["imageupdaters/finalizers"]
+      verbs: ["update"]
+    - apiGroups: ["argocd-image-updater.argoproj.io"]
+      resources: ["imageupdaters/status"]
+      verbs: ["get", "patch", "update"]
+    - apiGroups: ["argoproj.io"]
+      resources: ["applications"]
+      verbs: ["get", "list", "patch", "update", "watch"]
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: argocd-image-updater-manager-rolebinding
+      namespace: <argocd_namespace>
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: argocd-image-updater-manager-role
+    subjects:
+    - kind: ServiceAccount
+      name: argocd-image-updater-controller
+      namespace: <updater_namespace>
+    ```
 
-The image updater needs to read resources from the Argo CD namespace, such as `Secrets` containing repository credentials. The default installation does not grant these cross-namespace permissions. You must create a `Role` and `RoleBinding` in the Argo CD namespace to allow the image updater's ServiceAccount (from `<updater_namespace>`) to access these resources.
+#### Option 3: Cluster-scoped installation
 
-Create and apply the following manifest in the `<argocd_namespace>`:
-
-```yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: argocd-image-updater-cross-namespace-reader
-  namespace: <argocd_namespace>
-rules:
-- apiGroups: [""]
-  resources: ["secrets", "configmaps"]
-  verbs: ["get", "list", "watch"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: argocd-image-updater-cross-namespace-reader
-  namespace: <argocd_namespace>
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: argocd-image-updater-cross-namespace-reader
-subjects:
-- kind: ServiceAccount
-  name: argocd-image-updater-controller
-  namespace: <updater_namespace>
-```
-
-#### Option 3: Namespace-scoped installation (without cluster-wide RBAC)
-
-For multi-tenant environments or when cluster-wide RBAC is not permitted, the controller can operate in namespace-scoped mode. This restricts the controller to only watch specific namespaces using namespace-scoped `Role` and `RoleBinding` resources instead of `ClusterRole` and `ClusterRoleBinding`.
-
-Let's assume you want to watch namespaces `argocd` and `team-a`, and the controller is installed in the `argocd` namespace.
+For environments where the controller must watch `ImageUpdater` CRs in any namespace, use `--watch-namespaces="*"`. This requires a `ClusterRole` and `ClusterRoleBinding`.
 
 1. **Install the Controller**
 
-First, apply the installation manifest. You will modify the RBAC in the next step.
+    ```shell
+    kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj-labs/argocd-image-updater/stable/config/install.yaml
+    ```
 
-```shell
-kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj-labs/argocd-image-updater/stable/config/install.yaml
-```
+2. **Replace Role with ClusterRole**
 
-2. **Replace Cluster-wide RBAC with Namespace-scoped RBAC**
+    Delete the namespace-scoped RBAC from the default install and apply cluster-scoped equivalents. The required permissions mirror `config/rbac/role.yaml`:
 
-The default installation includes `ClusterRole` and `ClusterRoleBinding` resources that grant cluster-wide permissions. For namespace-scoped operation, you must replace these with `Role` and `RoleBinding` resources in each namespace you want to watch.
+    ```shell
+    kubectl delete role argocd-image-updater-manager-role -n argocd
+    kubectl delete rolebinding argocd-image-updater-manager-rolebinding -n argocd
+    ```
 
-First, delete the cluster-wide RBAC resources:
+    ```yaml
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: argocd-image-updater-manager-role
+    rules:
+    - apiGroups: [""]
+      resources: ["events"]
+      verbs: ["create"]
+    - apiGroups: ["argocd-image-updater.argoproj.io"]
+      resources: ["imageupdaters"]
+      verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+    - apiGroups: ["argocd-image-updater.argoproj.io"]
+      resources: ["imageupdaters/finalizers"]
+      verbs: ["update"]
+    - apiGroups: ["argocd-image-updater.argoproj.io"]
+      resources: ["imageupdaters/status"]
+      verbs: ["get", "patch", "update"]
+    - apiGroups: ["argoproj.io"]
+      resources: ["applications"]
+      verbs: ["get", "list", "patch", "update", "watch"]
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: argocd-image-updater-manager-rolebinding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: argocd-image-updater-manager-role
+    subjects:
+    - kind: ServiceAccount
+      name: argocd-image-updater-controller
+      namespace: argocd  # Replace with your controller namespace
+    ```
 
-```shell
-kubectl delete clusterrole argocd-image-updater-manager-role
-kubectl delete clusterrolebinding argocd-image-updater-manager-rolebinding
-```
+3. **Enable cluster-scoped watching**
 
-Then, for each namespace you want to watch (e.g., `argocd`, `team-a`), create a `Role` and `RoleBinding`. The required permissions mirror those in `config/rbac/role.yaml`:
-
-```yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: argocd-image-updater-manager-role
-  namespace: <target_namespace>
-rules:
-- apiGroups: [""]
-  resources: ["events"]
-  verbs: ["create"]
-- apiGroups: [""]
-  resources: ["secrets", "configmaps"]
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["argocd-image-updater.argoproj.io"]
-  resources: ["imageupdaters"]
-  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
-- apiGroups: ["argocd-image-updater.argoproj.io"]
-  resources: ["imageupdaters/finalizers"]
-  verbs: ["update"]
-- apiGroups: ["argocd-image-updater.argoproj.io"]
-  resources: ["imageupdaters/status"]
-  verbs: ["get", "patch", "update"]
-- apiGroups: ["argoproj.io"]
-  resources: ["applications"]
-  verbs: ["get", "list", "patch", "update", "watch"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: argocd-image-updater-manager-rolebinding
-  namespace: <target_namespace>
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: argocd-image-updater-manager-role
-subjects:
-- kind: ServiceAccount
-  name: argocd-image-updater-controller
-  namespace: argocd
-```
-
-3. **Configure the Controller to Watch Specific Namespaces**
-
-The controller must be configured to only watch the namespaces where you have granted permissions. Edit the `argocd-image-updater-config` ConfigMap and add the `watch-namespaces` key:
-
-```yaml
-data:
-  watch-namespaces: "argocd,team-a"
-```
-
-Alternatively, you can add the `--watch-namespaces=argocd,team-a` flag to the container's `command` arguments in the deployment manifest, or set the `IMAGE_UPDATER_WATCH_NAMESPACES` environment variable.
-
-The controller logs `Configuring namespace-scoped operation` on startup when this mode is active
+    ```yaml
+    env:
+    - name: IMAGE_UPDATER_WATCH_NAMESPACES
+      value: "*"
+    ```
 
 ### Configure the desired log level
 

--- a/internal/controller/imageupdater_controller.go
+++ b/internal/controller/imageupdater_controller.go
@@ -61,6 +61,7 @@ type ImageUpdaterConfig struct {
 	DisableKubeEvents      bool
 	GitCreds               git.CredsStore
 	EnableWebhook          bool
+	WatchNamespaces        string
 	// EnableCRMetrics enables per-ImageUpdater-CR Prometheus metrics. Set false in webhook-only
 	// mode (no controller/reconcile) so metrics are not written and never orphaned on CR delete.
 	EnableCRMetrics bool

--- a/internal/controller/imageupdater_controller.go
+++ b/internal/controller/imageupdater_controller.go
@@ -87,12 +87,6 @@ const (
 	ResourcesFinalizerName = "resources-finalizer.argocd-image-updater.argoproj.io"
 )
 
-// +kubebuilder:rbac:groups=argocd-image-updater.argoproj.io,resources=imageupdaters,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=argocd-image-updater.argoproj.io,resources=imageupdaters/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=argocd-image-updater.argoproj.io,resources=imageupdaters/finalizers,verbs=update
-// +kubebuilder:rbac:groups=argoproj.io,resources=applications,verbs=get;list;update;patch;watch
-// +kubebuilder:rbac:groups="",resources=events,verbs=create
-
 // Reconcile is the core operational loop of the ImageUpdater controller.
 // It is invoked in response to events on ImageUpdater custom resources (CRs)
 // (like create, update, delete) or due to periodic requeues. Its primary

--- a/test/ginkgo/sequential/1-008-app-in-any-ns_test.go
+++ b/test/ginkgo/sequential/1-008-app-in-any-ns_test.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	applicationFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/application"
@@ -171,6 +172,10 @@ var _ = Describe("ArgoCD Image Updater Sequential E2E Tests", func() {
 								Name:  "IMAGE_UPDATER_INTERVAL",
 								Value: "0",
 							},
+							{
+								Name:  "IMAGE_UPDATER_WATCH_NAMESPACES",
+								Value: nsDev.Name,
+							},
 						},
 						Enabled: true},
 				},
@@ -193,6 +198,42 @@ var _ = Describe("ArgoCD Image Updater Sequential E2E Tests", func() {
 			Eventually(statefulSet).Should(k8sFixture.ExistByName())
 			Eventually(statefulSet).Should(ssFixture.HaveReplicas(1))
 			Eventually(statefulSet, "3m", "3s").Should(ssFixture.HaveReadyReplicas(1))
+
+			By("creating Role and RoleBinding in dev namespace for Image Updater ServiceAccount")
+			role := &rbacv1.Role{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "argocd-image-updater-manager-role",
+					Namespace: nsDev.Name,
+				},
+				Rules: []rbacv1.PolicyRule{
+					{APIGroups: []string{""}, Resources: []string{"events"}, Verbs: []string{"create"}},
+					{APIGroups: []string{"argocd-image-updater.argoproj.io"}, Resources: []string{"imageupdaters"}, Verbs: []string{"create", "delete", "get", "list", "patch", "update", "watch"}},
+					{APIGroups: []string{"argocd-image-updater.argoproj.io"}, Resources: []string{"imageupdaters/finalizers"}, Verbs: []string{"update"}},
+					{APIGroups: []string{"argocd-image-updater.argoproj.io"}, Resources: []string{"imageupdaters/status"}, Verbs: []string{"get", "patch", "update"}},
+					{APIGroups: []string{"argoproj.io"}, Resources: []string{"applications"}, Verbs: []string{"get", "list", "patch", "update", "watch"}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, role)).To(Succeed())
+
+			roleBinding := &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "argocd-image-updater-manager-rolebinding",
+					Namespace: nsDev.Name,
+				},
+				RoleRef: rbacv1.RoleRef{
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "Role",
+					Name:     "argocd-image-updater-manager-role",
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						Kind:      "ServiceAccount",
+						Name:      "argocd-argocd-image-updater-controller",
+						Namespace: ns.Name,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, roleBinding)).To(Succeed())
 
 			By("creating AppProject")
 			appProject := &appv1alpha1.AppProject{


### PR DESCRIPTION
Based on #1488 

- rbac markers removed from [internal/controller/imageupdater_controller.go](https://github.com/argoproj-labs/argocd-image-updater/compare/master...dkarpele:dk-GITOPS-9393?expand=1#diff-73cb436bf6432168a9236401f274cacf37a58662a94792540754710a2a5bfb6b) because these markers [cause](https://book.kubebuilder.io/reference/markers/rbac) an RBAC `ClusterRole` to be generated. But we need `Role` by default. We will manage `config/rbac` manually. There were no changes to markers for half a year.
- If user creates Image Updater CR outside of namespaces defined in `watch-namespaces` this namespace will not be considered by controller.
- If user add namespace that doesn't exist to `watch-namespaces` controller returns a clear error message
```
time="2026-04-08T16:43:17Z" level=error msg="Failed to watch" error="failed to list *v1alpha1.ImageUpdater: imageupdaters.argocd-image-updater.argoproj.io is forbidden: User \"system:serviceaccount:argocd:argocd-image-updater-controller\" cannot list resource \"imageupdaters\" in API group \"argocd-image-updater.argoproj.io\" in the namespace \"ns-doesnt-exist\"" logger=controller-runtime.cache.UnhandledError reflector="pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:290" type="*v1alpha1.ImageUpdater"
time="2026-04-08T16:43:19Z" level=info msg="healthz check failed" checker=warmup-check error="{}" logger=controller-runtime.healthz

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --watch-namespaces / IMAGE_UPDATER_WATCH_NAMESPACES to select watched namespaces: pod-own namespace (default), comma-separated list, or "*" for cluster-wide.

* **Breaking Changes**
  * Default install now uses namespace-scoped RBAC (Role/RoleBinding). Cluster-wide watching requires --watch-namespaces="*" plus cluster-scoped RBAC.
  * RBAC manifests updated to namespace-scoped by default.

* **Documentation**
  * Install/run docs expanded with scope options, RBAC requirements, and leader-election guidance.

* **Tests**
  * Tests added covering watch-namespaces behavior and namespace-resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->