### PR TITLE
PLAT-6086 Add functionality to enable multi source image updates

### DIFF
--- a/.bandwidth/catalog-info.yaml
+++ b/.bandwidth/catalog-info.yaml
@@ -1,0 +1,11 @@
+apiVersion: backstage.io/v1alpha1
+kind: Location
+metadata:
+  schemaVersion: v1.0.0
+  name: argocd-image-updater-location
+  description: Links to additional entities in the argocd-image-updater repository.
+  annotations:
+    github.com/project-slug: Bandwidth/argocd-image-updater
+spec:
+  targets:
+    - ./component.yaml

--- a/.bandwidth/component.yaml
+++ b/.bandwidth/component.yaml
@@ -1,0 +1,19 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  schemaVersion: v1.0.0
+  name: argocd-image-updater
+  description: Forked from https://github.com/argoproj-labs/argocd-image-updater
+  annotations:
+    github.com/project-slug: Bandwidth/argocd-image-updater
+  organization: BW
+  costCenter: undefined
+  platformType: OCP4
+  buildPlatform: GitHub Actions
+spec:
+  type: Service
+  owner: github/band-platform
+  lifecycle: Prototype
+  dependsOn:
+    - resource:platform/GitHub Actions
+    - resource:cost-center/undefined

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Bandwidth/band-platform @Bandwidth/band-platform-github-repo-admin

--- a/api/v1alpha1/imageupdater_types.go
+++ b/api/v1alpha1/imageupdater_types.go
@@ -255,6 +255,12 @@ type ManifestTarget struct {
 
 // HelmTarget defines parameters for updating image references within Helm values.
 type HelmTarget struct {
+	// ChartName is the name of the Helm chart within a multi-source Argo CD Application.
+	// When an Application uses multiple sources, this field identifies which source's
+	// Helm values should be updated. If not specified, the first Helm source is used.
+	// +optional
+	ChartName *string `json:"chartName,omitempty"`
+
 	// Name is the dot-separated path to the Helm key for the image repository/name part.
 	// Example: "image.repository", "frontend.deployment.image.name".
 	// If neither spec nor name/tag are set, defaults to "image.name".

--- a/api/v1alpha1/imageupdater_types_test.go
+++ b/api/v1alpha1/imageupdater_types_test.go
@@ -466,6 +466,115 @@ var _ = Describe("ApplicationRef UseAnnotations Validation", func() {
 	})
 })
 
+var _ = Describe("HelmTarget ChartName Validation", func() {
+	Context("when chartName is set", func() {
+		It("should accept HelmTarget with only chartName", func() {
+			cr := &ImageUpdater{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "image-updater-helm-chartname-only",
+					Namespace: "argocd",
+				},
+				Spec: ImageUpdaterSpec{
+					ApplicationRefs: []ApplicationRef{
+						{
+							NamePattern: "*",
+							Images: []ImageConfig{
+								{
+									Alias:     "test",
+									ImageName: "nginx:1.21.0",
+									ManifestTarget: &ManifestTarget{
+										Helm: &HelmTarget{
+											ChartName: strPtr("my-chart"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			err := k8sClient.Create(context.Background(), cr)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Cleanup
+			err = k8sClient.Delete(context.Background(), cr)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should accept HelmTarget with chartName and name/tag", func() {
+			cr := &ImageUpdater{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "image-updater-helm-chartname-name-tag",
+					Namespace: "argocd",
+				},
+				Spec: ImageUpdaterSpec{
+					ApplicationRefs: []ApplicationRef{
+						{
+							NamePattern: "*",
+							Images: []ImageConfig{
+								{
+									Alias:     "test",
+									ImageName: "nginx:1.21.0",
+									ManifestTarget: &ManifestTarget{
+										Helm: &HelmTarget{
+											ChartName: strPtr("my-chart"),
+											Name:      strPtr("image.repository"),
+											Tag:       strPtr("image.tag"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			err := k8sClient.Create(context.Background(), cr)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Cleanup
+			err = k8sClient.Delete(context.Background(), cr)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should accept HelmTarget with chartName and spec", func() {
+			cr := &ImageUpdater{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "image-updater-helm-chartname-spec",
+					Namespace: "argocd",
+				},
+				Spec: ImageUpdaterSpec{
+					ApplicationRefs: []ApplicationRef{
+						{
+							NamePattern: "*",
+							Images: []ImageConfig{
+								{
+									Alias:     "test",
+									ImageName: "nginx:1.21.0",
+									ManifestTarget: &ManifestTarget{
+										Helm: &HelmTarget{
+											ChartName: strPtr("my-chart"),
+											Spec:      strPtr("image"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			err := k8sClient.Create(context.Background(), cr)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Cleanup
+			err = k8sClient.Delete(context.Background(), cr)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})
+
 var _ = Describe("HelmTarget Validation", func() {
 	Context("when spec is set", func() {
 		It("should accept HelmTarget with only spec", func() {

--- a/docs/configuration/images.md
+++ b/docs/configuration/images.md
@@ -415,6 +415,51 @@ images:
         tag: "images[0].tag"
 ```
 
+## Multi-source Helm applications
+
+Argo CD supports [multiple sources](https://argo-cd.readthedocs.io/en/stable/user-guide/multiple_sources/)
+in a single Application. When an Application has more than one Helm chart source,
+you need to tell Image Updater which source to update. Use the `manifestTargets.helm.chartName`
+field to specify the chart name of the target source.
+
+The `chartName` value must match the `spec.sources[].chart` field of the Argo CD
+Application source you want to update.
+
+For example, if your Application has two Helm sources — a plain-manifest source
+and a Helm chart named `my-app` — and you want to update the image in `my-app`:
+
+```yaml
+images:
+  - alias: "myimage"
+    imageName: "myorg/myimage:1.0.0"
+    manifestTargets:
+      helm:
+        chartName: "my-app"
+        name: "image.repository"
+        tag: "image.tag"
+```
+
+This also works with `spec` instead of `name`/`tag`:
+
+```yaml
+images:
+  - alias: "myimage"
+    imageName: "myorg/myimage:1.0.0"
+    manifestTargets:
+      helm:
+        chartName: "my-app"
+        spec: "image"
+```
+
+If `chartName` is not set, Image Updater falls back to the existing behavior: it
+selects the first Helm source it finds in the Application. For single-source
+Applications, `chartName` is ignored.
+
+!!!note
+    `chartName` only applies to Helm chart repository sources where the Argo CD
+    Application's `spec.sources[].chart` field is set. It cannot be used to
+    select a Git repository source by path.
+
 ## Examples
 
 ### Following an image's patch branch
@@ -606,11 +651,12 @@ update strategies and set options for images.
 
 #### HelmTarget fields
 
-| Field  | Type   | Required | Description                                                                                                                        |
-|--------|--------|----------|------------------------------------------------------------------------------------------------------------------------------------|
-| `name` | string | No       | Dot-separated path to Helm key for image name                                                                                      |
-| `tag`  | string | No       | Dot-separated path to Helm key for image tag                                                                                       |
-| `spec` | string | No       | Dot-separated path to Helm key for full image specification. If this is set, other Helm parameter-related options will be ignored. |
+| Field       | Type   | Required | Description                                                                                                                        |
+|-------------|--------|----------|------------------------------------------------------------------------------------------------------------------------------------|
+| `chartName` | string | No       | Chart name of the Helm source to update in a multi-source Argo CD Application. Must match `spec.sources[].chart`. Ignored for single-source Applications. |
+| `name`      | string | No       | Dot-separated path to Helm key for image name                                                                                      |
+| `tag`       | string | No       | Dot-separated path to Helm key for image tag                                                                                       |
+| `spec`      | string | No       | Dot-separated path to Helm key for full image specification. If this is set, other Helm parameter-related options will be ignored. |
 
 #### KustomizeTarget fields
 

--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -592,14 +592,19 @@ func newImageFromManifestTargetSettings(settings *iuapi.ManifestTarget, img *Ima
 	}
 
 	// Layer the new settings on top, only if they are explicitly set (non-nil).
-	if settings.Helm != nil && settings.Helm.Spec != nil {
-		img.HelmImageSpec = *settings.Helm.Spec
-	} else {
-		if settings.Helm != nil && settings.Helm.Name != nil {
-			img.HelmImageName = *settings.Helm.Name
+	if settings.Helm != nil {
+		if settings.Helm.ChartName != nil {
+			img.HelmChartName = *settings.Helm.ChartName
 		}
-		if settings.Helm != nil && settings.Helm.Tag != nil {
-			img.HelmImageTag = *settings.Helm.Tag
+		if settings.Helm.Spec != nil {
+			img.HelmImageSpec = *settings.Helm.Spec
+		} else {
+			if settings.Helm.Name != nil {
+				img.HelmImageName = *settings.Helm.Name
+			}
+			if settings.Helm.Tag != nil {
+				img.HelmImageTag = *settings.Helm.Tag
+			}
 		}
 	}
 	if settings.Kustomize != nil && settings.Kustomize.Name != nil {
@@ -824,7 +829,21 @@ func SetHelmImage(ctx context.Context, app *argocdapi.Application, newImage *ima
 		}
 	}
 
-	appSource := getApplicationSource(ctx, app, wbc)
+	var appSource *argocdapi.ApplicationSource
+	if applicationImage.HelmChartName != "" && app.Spec.HasMultipleSources() {
+		for i := range app.Spec.Sources {
+			s := &app.Spec.Sources[i]
+			if s.Chart == applicationImage.HelmChartName {
+				appSource = s
+				break
+			}
+		}
+		if appSource == nil {
+			return fmt.Errorf("no Helm source with chart name %q found in application %s", applicationImage.HelmChartName, app.Name)
+		}
+	} else {
+		appSource = getApplicationSource(ctx, app, wbc)
+	}
 
 	if appSource.Helm == nil {
 		appSource.Helm = &argocdapi.ApplicationSourceHelm{}

--- a/pkg/argocd/argocd_test.go
+++ b/pkg/argocd/argocd_test.go
@@ -1316,6 +1316,145 @@ func Test_SetHelmImage(t *testing.T) {
 		assert.Equal(t, "mq@sha256:123456", tagParam.Value, "Existing tag value should not be overwritten with empty string")
 	})
 
+	t.Run("Test set Helm image on multi-source app with matching ChartName", func(t *testing.T) {
+		app := &v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "test-app",
+				Namespace: "testns",
+			},
+			Spec: v1alpha1.ApplicationSpec{
+				Sources: v1alpha1.ApplicationSources{
+					{
+						RepoURL: "https://github.com/org/manifests",
+						Path:    "k8s/",
+					},
+					{
+						RepoURL: "https://charts.example.com",
+						Chart:   "my-app",
+						Helm: &v1alpha1.ApplicationSourceHelm{
+							Parameters: []v1alpha1.HelmParameter{
+								{Name: "image.tag", Value: "1.0.0"},
+								{Name: "image.name", Value: "jannfis/foobar"},
+							},
+						},
+					},
+				},
+			},
+			Status: v1alpha1.ApplicationStatus{
+				SourceTypes: []v1alpha1.ApplicationSourceType{
+					v1alpha1.ApplicationSourceTypeDirectory,
+					v1alpha1.ApplicationSourceTypeHelm,
+				},
+				Summary: v1alpha1.ApplicationSummary{
+					Images: []string{"jannfis/foobar:1.0.0"},
+				},
+			},
+		}
+
+		img := image.NewFromIdentifier("foobar=jannfis/foobar:1.0.1")
+		wbc := &WriteBackConfig{Target: "helmvalues:."}
+		appImage := &Image{
+			HelmChartName: "my-app",
+			HelmImageName: "image.name",
+			HelmImageTag:  "image.tag",
+		}
+		err := SetHelmImage(context.Background(), app, img, wbc, appImage)
+		require.NoError(t, err)
+
+		// Only the second source (my-app chart) should be updated
+		require.NotNil(t, app.Spec.Sources[1].Helm)
+		var tagParam v1alpha1.HelmParameter
+		for _, p := range app.Spec.Sources[1].Helm.Parameters {
+			if p.Name == "image.tag" {
+				tagParam = p
+				break
+			}
+		}
+		assert.Equal(t, "1.0.1", tagParam.Value)
+
+		// First source should be untouched (no Helm block)
+		assert.Nil(t, app.Spec.Sources[0].Helm)
+	})
+
+	t.Run("Test set Helm image on multi-source app with non-existent ChartName returns error", func(t *testing.T) {
+		app := &v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "test-app",
+				Namespace: "testns",
+			},
+			Spec: v1alpha1.ApplicationSpec{
+				Sources: v1alpha1.ApplicationSources{
+					{
+						RepoURL: "https://charts.example.com",
+						Chart:   "my-app",
+						Helm:    &v1alpha1.ApplicationSourceHelm{},
+					},
+				},
+			},
+			Status: v1alpha1.ApplicationStatus{
+				SourceTypes: []v1alpha1.ApplicationSourceType{
+					v1alpha1.ApplicationSourceTypeHelm,
+				},
+			},
+		}
+
+		img := image.NewFromIdentifier("foobar=jannfis/foobar:1.0.1")
+		wbc := &WriteBackConfig{Target: "helmvalues:."}
+		appImage := &Image{
+			HelmChartName: "does-not-exist",
+			HelmImageName: "image.name",
+			HelmImageTag:  "image.tag",
+		}
+		err := SetHelmImage(context.Background(), app, img, wbc, appImage)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does-not-exist")
+	})
+
+	t.Run("Test set Helm image on single-source app ignores ChartName and uses existing logic", func(t *testing.T) {
+		app := &v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "test-app",
+				Namespace: "testns",
+			},
+			Spec: v1alpha1.ApplicationSpec{
+				Source: &v1alpha1.ApplicationSource{
+					Helm: &v1alpha1.ApplicationSourceHelm{
+						Parameters: []v1alpha1.HelmParameter{
+							{Name: "image.tag", Value: "1.0.0"},
+							{Name: "image.name", Value: "jannfis/foobar"},
+						},
+					},
+				},
+			},
+			Status: v1alpha1.ApplicationStatus{
+				SourceType: v1alpha1.ApplicationSourceTypeHelm,
+				Summary: v1alpha1.ApplicationSummary{
+					Images: []string{"jannfis/foobar:1.0.0"},
+				},
+			},
+		}
+
+		img := image.NewFromIdentifier("foobar=jannfis/foobar:1.0.1")
+		wbc := &WriteBackConfig{Target: "helmvalues:."}
+		appImage := &Image{
+			HelmChartName: "my-app", // set but should be ignored for single-source
+			HelmImageName: "image.name",
+			HelmImageTag:  "image.tag",
+		}
+		err := SetHelmImage(context.Background(), app, img, wbc, appImage)
+		require.NoError(t, err)
+		require.NotNil(t, app.Spec.Source.Helm)
+
+		var tagParam v1alpha1.HelmParameter
+		for _, p := range app.Spec.Source.Helm.Parameters {
+			if p.Name == "image.tag" {
+				tagParam = p
+				break
+			}
+		}
+		assert.Equal(t, "1.0.1", tagParam.Value)
+	})
+
 }
 
 func TestKubernetesClient(t *testing.T) {
@@ -2293,6 +2432,32 @@ func Test_newImageFromManifestTargetSettings(t *testing.T) {
 		img, err := newImageFromManifestTargetSettings(settings, image)
 		assert.NoError(t, err)
 		assert.Equal(t, "child-kustomize", img.KustomizeImageName)
+	})
+
+	t.Run("should populate HelmChartName from settings", func(t *testing.T) {
+		settings := &api.ManifestTarget{
+			Helm: &api.HelmTarget{
+				ChartName: strPtr("my-chart"),
+				Name:      strPtr("image.name"),
+				Tag:       strPtr("image.tag"),
+			},
+		}
+		img, err := newImageFromManifestTargetSettings(settings, &Image{})
+		assert.NoError(t, err)
+		assert.Equal(t, "my-chart", img.HelmChartName)
+		assert.Equal(t, "image.name", img.HelmImageName)
+		assert.Equal(t, "image.tag", img.HelmImageTag)
+	})
+
+	t.Run("should not overwrite HelmChartName when settings has no ChartName", func(t *testing.T) {
+		settings := &api.ManifestTarget{
+			Helm: &api.HelmTarget{
+				Name: strPtr("image.name"),
+			},
+		}
+		img, err := newImageFromManifestTargetSettings(settings, &Image{HelmChartName: "inherited-chart"})
+		assert.NoError(t, err)
+		assert.Equal(t, "inherited-chart", img.HelmChartName)
 	})
 
 	t.Run("should return error when both helm and kustomize are set", func(t *testing.T) {

--- a/pkg/argocd/types.go
+++ b/pkg/argocd/types.go
@@ -169,6 +169,7 @@ type Image struct {
 	Platforms      []string
 
 	// ManifestTarget settings
+	HelmChartName      string
 	HelmImageName      string
 	HelmImageTag       string
 	HelmImageSpec      string


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added the ability to specify which Helm chart to update in Argo CD Applications with multiple sources using the new `chartName` configuration option.

* **Documentation**
  * Updated configuration documentation with guidance on using `chartName` for multi-source Helm applications.

* **Tests**
  * Added test coverage for multi-source Helm chart targeting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->