### PR TITLE
fix(webhook): align standalone webhook HTTP/2 hardening

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -23,6 +23,8 @@ import (
 type WebhookConfig struct {
 	// Port is the port number for the webhook server to listen on
 	Port int
+	// EnableHTTP2 allows the webhook TLS server to negotiate HTTP/2
+	EnableHTTP2 bool
 	// DockerSecret is the secret for validating Docker Hub webhooks
 	DockerSecret string
 	// GHCRSecret is the secret for validating GitHub Container Registry webhooks
@@ -144,11 +146,12 @@ func SetupWebhookServer(webhookCfg *WebhookConfig, reconciler *controller.ImageU
 	// Configure TLS
 	server.DisableTLS = webhookCfg.DisableTLS
 	server.TLS = &webhook.TLSConfig{
-		CertFile:   webhook.DefaultTLSCertPath,
-		KeyFile:    webhook.DefaultTLSKeyPath,
-		MinVersion: webhookCfg.TLSMinVersion,
-		MaxVersion: webhookCfg.TLSMaxVersion,
-		Ciphers:    webhookCfg.TLSCiphers,
+		CertFile:    webhook.DefaultTLSCertPath,
+		KeyFile:     webhook.DefaultTLSKeyPath,
+		MinVersion:  webhookCfg.TLSMinVersion,
+		MaxVersion:  webhookCfg.TLSMaxVersion,
+		Ciphers:     webhookCfg.TLSCiphers,
+		EnableHTTP2: webhookCfg.EnableHTTP2,
 	}
 
 	if webhookCfg.RateLimitNumAllowedRequests > 0 {

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -46,6 +46,8 @@ func TestSetupWebhookServer(t *testing.T) {
 		require.NotNil(t, server)
 		assert.Equal(t, 8080, server.Port)
 		assert.Nil(t, server.RateLimiter)
+		require.NotNil(t, server.TLS)
+		assert.False(t, server.TLS.EnableHTTP2)
 	})
 
 	t.Run("should create a server with rate limiting", func(t *testing.T) {
@@ -58,6 +60,20 @@ func TestSetupWebhookServer(t *testing.T) {
 		require.NotNil(t, server)
 		assert.Equal(t, 8080, server.Port)
 		assert.NotNil(t, server.RateLimiter)
+		require.NotNil(t, server.TLS)
+		assert.False(t, server.TLS.EnableHTTP2)
+	})
+
+	t.Run("should thread enable-http2 into TLS config", func(t *testing.T) {
+		webhookCfg := &WebhookConfig{
+			Port:        8080,
+			EnableHTTP2: true,
+		}
+		reconciler := &controller.ImageUpdaterReconciler{}
+		server := SetupWebhookServer(webhookCfg, reconciler)
+		require.NotNil(t, server)
+		require.NotNil(t, server.TLS)
+		assert.True(t, server.TLS.EnableHTTP2)
 	})
 }
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -138,6 +138,7 @@ This enables a CRD-driven approach to automated image updates with Argo CD.
 			if !enableHTTP2 {
 				tlsOpts = append(tlsOpts, disableHTTP2)
 			}
+			webhookCfg.EnableHTTP2 = enableHTTP2
 
 			// Metrics endpoint is enabled in 'config/default/kustomization.yaml'. The Metrics options configure the server.
 			// More info:

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -261,6 +261,62 @@ func TestCacheWarmerStart_RunOnce_NoCRs_ClosesStopChan(t *testing.T) {
 	}
 }
 
+// TestWebhookServerRunnable_EnableHTTP2_ThreadedIntoServer verifies that the
+// EnableHTTP2 value from WebhookConfig reaches the webhook server's TLS
+// configuration after WebhookServerRunnable.Start() calls SetupWebhookServer.
+// This is the integration point for the line "webhookCfg.EnableHTTP2 = enableHTTP2"
+// in cmd/run.go: the flag value must survive the entire setup path.
+func TestWebhookServerRunnable_EnableHTTP2_ThreadedIntoServer(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		enableHTTP2 bool
+	}{
+		{"disabled (default)", false},
+		{"enabled explicitly", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			_ = api.AddToScheme(scheme)
+			c := fake.NewClientBuilder().WithScheme(scheme).Build()
+			reconciler := &controller.ImageUpdaterReconciler{
+				Client:                  c,
+				Scheme:                  scheme,
+				Config:                  &controller.ImageUpdaterConfig{},
+				MaxConcurrentReconciles: 1,
+			}
+
+			// Simulate what cmd/run.go does: assign the CLI flag value to webhookCfg.
+			webhookCfg := &WebhookConfig{
+				Port:        0, // let the OS pick a port
+				EnableHTTP2: tc.enableHTTP2,
+			}
+			ws := &WebhookServerRunnable{Reconciler: reconciler, WebhookConfig: webhookCfg}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			errCh := make(chan error, 1)
+			go func() {
+				errCh <- ws.Start(ctx)
+			}()
+
+			// Give the server time to initialise before cancelling.
+			time.Sleep(100 * time.Millisecond)
+			cancel()
+
+			select {
+			case err := <-errCh:
+				assert.NoError(t, err)
+			case <-time.After(3 * time.Second):
+				t.Fatal("webhook server did not shut down within timeout after context cancellation")
+			}
+
+			require.NotNil(t, ws.webhookServer, "webhookServer must be set after Start")
+			require.NotNil(t, ws.webhookServer.TLS, "TLS config must be non-nil")
+			assert.Equal(t, tc.enableHTTP2, ws.webhookServer.TLS.EnableHTTP2,
+				"TLS.EnableHTTP2 must match the WebhookConfig.EnableHTTP2 value threaded in from the CLI flag")
+		})
+	}
+}
+
 // Assisted-by: Gemini AI
 // TestWebhookServerRunnable_Start_ContextCancelStopsServer verifies that the webhook server starts
 // and shuts down gracefully when the context is canceled.

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -101,6 +101,7 @@ Supported registries:
 	webhookCmd.Flags().IntVar(&webhookCfg.RateLimitNumAllowedRequests, "webhook-ratelimit-allowed", env.ParseNumFromEnv("WEBHOOK_RATELIMIT_ALLOWED", 0, 0, math.MaxInt), "The number of allowed requests in an hour for webhook rate limiting, setting to 0 disables ratelimiting")
 
 	// TLS flags
+	webhookCmd.Flags().BoolVar(&webhookCfg.EnableHTTP2, "enable-http2", false, "If set, HTTP/2 will be enabled for the standalone webhook server")
 	webhookCmd.Flags().BoolVar(&webhookCfg.DisableTLS, "disable-tls", env.GetBoolVal("DISABLE_TLS", false), "Disable TLS and run the server with plain HTTP")
 	webhookCmd.Flags().StringVar(&webhookCfg.TLSMinVersion, "tlsminversion", env.GetStringVal("TLS_MIN_VERSION", webhook.DefaultTLSMinVersion), "Minimum TLS version (e.g. 1.2, 1.3)")
 	webhookCmd.Flags().StringVar(&webhookCfg.TLSMaxVersion, "tlsmaxversion", env.GetStringVal("TLS_MAX_VERSION", webhook.DefaultTLSMaxVersion), "Maximum TLS version (e.g. 1.2, 1.3)")

--- a/cmd/webhook_test.go
+++ b/cmd/webhook_test.go
@@ -47,6 +47,7 @@ func TestNewWebhookCommand(t *testing.T) {
 	asser.Equal(strconv.Itoa(env.ParseNumFromEnv("WEBHOOK_RATELIMIT_ALLOWED", 0, 0, math.MaxInt)), controllerCommand.Flag("webhook-ratelimit-allowed").Value.String())
 
 	// TLS flags
+	asser.Equal("false", controllerCommand.Flag("enable-http2").Value.String())
 	asser.Equal("false", controllerCommand.Flag("disable-tls").Value.String())
 	asser.Equal(env.GetStringVal("TLS_MIN_VERSION", "1.3"), controllerCommand.Flag("tlsminversion").Value.String())
 	asser.Equal(env.GetStringVal("TLS_MAX_VERSION", "1.3"), controllerCommand.Flag("tlsmaxversion").Value.String())

--- a/docs/configuration/webhook.md
+++ b/docs/configuration/webhook.md
@@ -320,6 +320,18 @@ at `/app/config/tls/`). If the secret is not provided or its fields are empty, t
 server automatically generates a self-signed certificate in memory so that TLS is
 still active.
 
+!!!note "HTTP/2 disabled by default"
+    HTTP/2 is now **disabled by default** on the webhook TLS server.
+    If your environment requires HTTP/2, opt in explicitly:
+
+    ```bash
+    # standalone webhook command
+    argocd-image-updater webhook --enable-http2
+
+    # combined run command
+    argocd-image-updater run --enable-http2
+    ```
+
 ### Disabling TLS (plain HTTP)
 
 To revert to plain HTTP, pass `--disable-tls` or set the environment variable:

--- a/docs/install/cmd/webhook.md
+++ b/docs/install/cmd/webhook.md
@@ -54,6 +54,10 @@ Secret for validating Docker Hub webhooks.
 
 Can also be set with the `DOCKER_WEBHOOK_SECRET` environment variable.
 
+**--enable-http2 *disabled***
+
+If set, HTTP/2 will be enabled for the standalone webhook server.
+
 **--ghcr-webhook-secret *secret***
 
 Secret for validating GitHub container registry secrets.

--- a/docs/install/cmd/webhook.md
+++ b/docs/install/cmd/webhook.md
@@ -54,9 +54,9 @@ Secret for validating Docker Hub webhooks.
 
 Can also be set with the `DOCKER_WEBHOOK_SECRET` environment variable.
 
-**--enable-http2 *disabled***
+**--enable-http2**
 
-If set, HTTP/2 will be enabled for the standalone webhook server.
+Enable HTTP/2 for the standalone webhook server. Disabled by default.
 
 **--ghcr-webhook-secret *secret***
 
@@ -82,9 +82,9 @@ Whether to sign-off git commits
 
 GnuPG key ID or path to Private SSH Key used to sign the commits
 
-Can also be set using the *GIT_COMMIT_SIGNING_KEY* environment variable. 
+Can also be set using the *GIT_COMMIT_SIGNING_KEY* environment variable.
 
-**--git-commit-signing-method *method*** 
+**--git-commit-signing-method *method***
 
 Method used to sign Git commits ('openpgp' or 'ssh') (default "openpgp")
 

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -44,6 +44,8 @@ type TLSConfig struct {
 	CertFile string
 	// KeyFile is the path to the TLS private key file
 	KeyFile string
+	// EnableHTTP2 allows the TLS server to negotiate HTTP/2
+	EnableHTTP2 bool
 	// MinVersion is the minimum TLS version (e.g. "1.2", "1.3")
 	MinVersion string
 	// MaxVersion is the maximum TLS version (e.g. "1.2", "1.3")
@@ -210,6 +212,10 @@ func (t *TLSConfig) buildTLSConfig() (*tls.Config, error) {
 	// Validate TLS version range and cipher/version compatibility
 	if err := ValidateTLSConfig(minVer, maxVer, ciphers); err != nil {
 		return nil, err
+	}
+
+	if !t.EnableHTTP2 {
+		tlsCfg.NextProtos = []string{"http/1.1"}
 	}
 
 	return tlsCfg, nil

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -181,7 +181,8 @@ func ValidateTLSConfig(minVersion, maxVersion uint16, cipherSuites []uint16) err
 }
 
 // buildTLSConfig creates a *tls.Config from the TLSConfig settings.
-func (t *TLSConfig) buildTLSConfig() (*tls.Config, error) {
+func (t *TLSConfig) buildTLSConfig(ctx context.Context) (*tls.Config, error) {
+	log := log.LoggerFromContext(ctx)
 	tlsCfg := &tls.Config{} //nolint:gosec // min version is set below from user config
 
 	minVer, err := ParseTLSVersion(t.MinVersion)
@@ -204,7 +205,7 @@ func (t *TLSConfig) buildTLSConfig() (*tls.Config, error) {
 	// Go's tls.Config.CipherSuites only applies to TLS 1.0–1.2.
 	// TLS 1.3 cipher suites are not configurable and are always enabled.
 	if len(ciphers) > 0 && minVer >= tls.VersionTLS13 {
-		log.Log().Warnf("--tlsciphers has no effect when --tlsminversion is 1.3 or higher (TLS 1.3 cipher suites are not configurable), ignoring")
+		log.Warnf("--tlsciphers has no effect when --tlsminversion is 1.3 or higher (TLS 1.3 cipher suites are not configurable), ignoring")
 		ciphers = nil
 	}
 	tlsCfg.CipherSuites = ciphers
@@ -215,6 +216,7 @@ func (t *TLSConfig) buildTLSConfig() (*tls.Config, error) {
 	}
 
 	if !t.EnableHTTP2 {
+		log.Debugf("Disabling HTTP/2 on webhook TLS server")
 		tlsCfg.NextProtos = []string{"http/1.1"}
 	}
 
@@ -332,9 +334,17 @@ func (s *WebhookServer) Start(ctx context.Context) error {
 			}
 		}
 		// Build TLS config from settings
-		tlsCfg, err := s.TLS.buildTLSConfig()
+		tlsCfg, err := s.TLS.buildTLSConfig(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to configure TLS: %w", err)
+		}
+		if !s.TLS.EnableHTTP2 {
+			// Prevent net/http from automatically enabling HTTP/2 for TLS servers.
+			// Setting only tls.Config.NextProtos prevents ALPN advertisement, but
+			// net/http still registers an h2 handler unless TLSNextProto is
+			// explicitly set to a non-nil map.
+			log.Debugf("Disabling HTTP/2: setting TLSNextProto to empty map to prevent net/http from auto-registering h2 handler")
+			s.Server.TLSNextProto = map[string]func(*http.Server, *tls.Conn, http.Handler){}
 		}
 
 		// Determine whether to load certs from files or generate self-signed

--- a/pkg/webhook/server_test.go
+++ b/pkg/webhook/server_test.go
@@ -498,6 +498,7 @@ func TestBuildTLSConfig(t *testing.T) {
 		assert.Equal(t, uint16(0), tlsCfg.MinVersion)
 		assert.Equal(t, uint16(0), tlsCfg.MaxVersion)
 		assert.Nil(t, tlsCfg.CipherSuites)
+		assert.Equal(t, []string{"http/1.1"}, tlsCfg.NextProtos)
 	})
 
 	t.Run("with min and max version", func(t *testing.T) {
@@ -566,6 +567,15 @@ func TestBuildTLSConfig(t *testing.T) {
 		tlsCfg, err := cfg.buildTLSConfig()
 		require.NoError(t, err)
 		assert.Len(t, tlsCfg.CipherSuites, 2)
+	})
+
+	t.Run("http2 can be enabled explicitly", func(t *testing.T) {
+		cfg := &TLSConfig{
+			EnableHTTP2: true,
+		}
+		tlsCfg, err := cfg.buildTLSConfig()
+		require.NoError(t, err)
+		assert.Empty(t, tlsCfg.NextProtos)
 	})
 }
 

--- a/pkg/webhook/server_test.go
+++ b/pkg/webhook/server_test.go
@@ -493,7 +493,7 @@ func TestParseTLSCiphers(t *testing.T) {
 func TestBuildTLSConfig(t *testing.T) {
 	t.Run("default config", func(t *testing.T) {
 		cfg := &TLSConfig{}
-		tlsCfg, err := cfg.buildTLSConfig()
+		tlsCfg, err := cfg.buildTLSConfig(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, uint16(0), tlsCfg.MinVersion)
 		assert.Equal(t, uint16(0), tlsCfg.MaxVersion)
@@ -506,7 +506,7 @@ func TestBuildTLSConfig(t *testing.T) {
 			MinVersion: "1.2",
 			MaxVersion: "1.3",
 		}
-		tlsCfg, err := cfg.buildTLSConfig()
+		tlsCfg, err := cfg.buildTLSConfig(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, uint16(tls.VersionTLS12), tlsCfg.MinVersion)
 		assert.Equal(t, uint16(tls.VersionTLS13), tlsCfg.MaxVersion)
@@ -517,7 +517,7 @@ func TestBuildTLSConfig(t *testing.T) {
 			MinVersion: "1.3",
 			MaxVersion: "1.3",
 		}
-		tlsCfg, err := cfg.buildTLSConfig()
+		tlsCfg, err := cfg.buildTLSConfig(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, uint16(tls.VersionTLS13), tlsCfg.MinVersion)
 		assert.Equal(t, uint16(tls.VersionTLS13), tlsCfg.MaxVersion)
@@ -528,7 +528,7 @@ func TestBuildTLSConfig(t *testing.T) {
 			MinVersion: "1.3",
 			MaxVersion: "1.2",
 		}
-		_, err := cfg.buildTLSConfig()
+		_, err := cfg.buildTLSConfig(context.Background())
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "cannot be higher than")
 	})
@@ -537,7 +537,7 @@ func TestBuildTLSConfig(t *testing.T) {
 		cfg := &TLSConfig{
 			MinVersion: "invalid",
 		}
-		_, err := cfg.buildTLSConfig()
+		_, err := cfg.buildTLSConfig(context.Background())
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "--tlsminversion")
 	})
@@ -546,7 +546,7 @@ func TestBuildTLSConfig(t *testing.T) {
 		cfg := &TLSConfig{
 			MaxVersion: "invalid",
 		}
-		_, err := cfg.buildTLSConfig()
+		_, err := cfg.buildTLSConfig(context.Background())
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "--tlsmaxversion")
 	})
@@ -555,7 +555,7 @@ func TestBuildTLSConfig(t *testing.T) {
 		cfg := &TLSConfig{
 			Ciphers: "NOT_REAL",
 		}
-		_, err := cfg.buildTLSConfig()
+		_, err := cfg.buildTLSConfig(context.Background())
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "--tlsciphers")
 	})
@@ -564,7 +564,7 @@ func TestBuildTLSConfig(t *testing.T) {
 		cfg := &TLSConfig{
 			Ciphers: "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384",
 		}
-		tlsCfg, err := cfg.buildTLSConfig()
+		tlsCfg, err := cfg.buildTLSConfig(context.Background())
 		require.NoError(t, err)
 		assert.Len(t, tlsCfg.CipherSuites, 2)
 	})
@@ -573,9 +573,33 @@ func TestBuildTLSConfig(t *testing.T) {
 		cfg := &TLSConfig{
 			EnableHTTP2: true,
 		}
-		tlsCfg, err := cfg.buildTLSConfig()
+		tlsCfg, err := cfg.buildTLSConfig(context.Background())
 		require.NoError(t, err)
 		assert.Empty(t, tlsCfg.NextProtos)
+	})
+
+	t.Run("http2 disabled explicitly sets NextProtos to http/1.1 only", func(t *testing.T) {
+		cfg := &TLSConfig{EnableHTTP2: false}
+		tlsCfg, err := cfg.buildTLSConfig(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, []string{"http/1.1"}, tlsCfg.NextProtos,
+			"NextProtos must be exactly [http/1.1] so the server never advertises h2")
+	})
+
+	t.Run("http2 disabled does not advertise h2 via ALPN", func(t *testing.T) {
+		cfg := &TLSConfig{EnableHTTP2: false}
+		tlsCfg, err := cfg.buildTLSConfig(context.Background())
+		require.NoError(t, err)
+		assert.NotContains(t, tlsCfg.NextProtos, "h2",
+			"h2 must not appear in NextProtos when HTTP/2 is disabled")
+	})
+
+	t.Run("http2 enabled leaves NextProtos nil", func(t *testing.T) {
+		cfg := &TLSConfig{EnableHTTP2: true}
+		tlsCfg, err := cfg.buildTLSConfig(context.Background())
+		require.NoError(t, err)
+		assert.Nil(t, tlsCfg.NextProtos,
+			"NextProtos must be nil when EnableHTTP2 is true so net/http can manage ALPN freely")
 	})
 }
 
@@ -687,7 +711,7 @@ func TestBuildTLSConfigCipherVersionIncompatibility(t *testing.T) {
 		Ciphers:    tls12OnlyCipher,
 	}
 	// With min=1.2, the cipher is accepted (it supports 1.2) — no error
-	tlsCfg, err := cfg.buildTLSConfig()
+	tlsCfg, err := cfg.buildTLSConfig(context.Background())
 	require.NoError(t, err)
 	assert.Len(t, tlsCfg.CipherSuites, 1)
 }
@@ -698,7 +722,7 @@ func TestBuildTLSConfigCiphersIgnoredForTLS13Only(t *testing.T) {
 		MaxVersion: "1.3",
 		Ciphers:    "TLS_AES_128_GCM_SHA256",
 	}
-	tlsCfg, err := cfg.buildTLSConfig()
+	tlsCfg, err := cfg.buildTLSConfig(context.Background())
 	require.NoError(t, err)
 	// Ciphers should be silently dropped (warning logged) since TLS 1.3
 	// cipher suites are not configurable in Go.
@@ -781,6 +805,66 @@ func TestWebhookServerStartWithTLS(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 	}
 	assert.NoError(t, lastErr, "Server with self-signed TLS did not start in time")
+
+	cancel()
+	<-errCh
+}
+
+// TestWebhookServerTLSNextProtoDisablesHTTP2 is an end-to-end regression test
+// that verifies HTTP/2 is fully disabled when EnableHTTP2 is false. It starts
+// a TLS server, attempts ALPN negotiation offering both h2 and http/1.1, and
+// asserts that the server selects http/1.1 — confirming that neither ALPN
+// advertisement nor net/http's automatic h2 handler registration is active.
+func TestWebhookServerTLSNextProtoDisablesHTTP2(t *testing.T) {
+	server := createMockServer(t, 8085)
+	server.TLS = &TLSConfig{
+		CertFile:    "/nonexistent/cert.pem",
+		KeyFile:     "/nonexistent/key.pem",
+		MinVersion:  DefaultTLSMinVersion,
+		MaxVersion:  DefaultTLSMaxVersion,
+		EnableHTTP2: false,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- server.Start(ctx)
+	}()
+
+	// Wait for server to be ready before connecting
+	tlsClient := &http.Client{
+		Timeout: 1 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // test only
+		},
+	}
+	address := fmt.Sprintf("https://localhost:%d/healthz", server.Port)
+	var lastErr error
+	for i := 0; i < 50; i++ {
+		resp, err := tlsClient.Get(address)
+		if err == nil {
+			resp.Body.Close()
+			lastErr = nil
+			break
+		}
+		lastErr = err
+		time.Sleep(100 * time.Millisecond)
+	}
+	require.NoError(t, lastErr, "TLS server did not start in time")
+
+	// Attempt ALPN negotiation offering h2 first — the server must reject it
+	// and fall back to http/1.1 because EnableHTTP2 is false.
+	conn, err := tls.Dial("tcp", fmt.Sprintf("localhost:%d", server.Port), &tls.Config{
+		InsecureSkipVerify: true,                       //nolint:gosec // test only
+		NextProtos:         []string{"h2", "http/1.1"}, // offer h2 first
+	})
+	require.NoError(t, err, "failed to connect to TLS server")
+	defer conn.Close()
+
+	negotiated := conn.ConnectionState().NegotiatedProtocol
+	assert.Equal(t, "http/1.1", negotiated,
+		"expected http/1.1 to be negotiated when EnableHTTP2 is false, got %q", negotiated)
 
 	cancel()
 	<-errCh


### PR DESCRIPTION
# Summary

This change threads the `enable-http2` setting through the webhook configuration so the standalone webhook server follows the same HTTP/2 hardening policy as the controller-managed path.

When HTTP/2 is not explicitly enabled, the webhook TLS server now restricts ALPN negotiation to `http/1.1`. A standalone `webhook` command flag was also added so users can opt in to HTTP/2 intentionally.

Closes #1559

# What Changed

- added `EnableHTTP2` to `WebhookConfig`
- added `--enable-http2` to the standalone `webhook` command
- passed the controller's `enableHTTP2` setting into webhook server setup
- updated webhook TLS config building to disable HTTP/2 by default via `NextProtos = []string{"http/1.1"}`
- added regression coverage for flag defaults, config threading, and TLS config behavior

# User Impact

- standalone webhook mode now matches the project's existing HTTP/2 hardening behavior
- HTTP/2 remains disabled by default
- users can explicitly opt in with `--enable-http2`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new --enable-http2 flag (disabled by default) to let the webhook server explicitly enable HTTP/2.

* **Bug Fixes**
  * Ensured TLS/ALPN negotiation and the server’s advertised HTTP protocol respect the enable-http2 setting.

* **Documentation**
  * Documented the new --enable-http2 flag and default behavior.

* **Tests**
  * Added/updated tests validating HTTP/2 enablement, disablement, and TLS negotiation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->