### PR TITLE
fix: GetImagesAndAliasesFromApplication returns only the images that are live in the cluster

### DIFF
--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -935,43 +935,58 @@ func GetImagesFromApplication(applicationImages *ApplicationImages) image.Contai
 	return images
 }
 
-// GetImagesAndAliasesFromApplication returns the list of known images for the given application
+// GetImagesAndAliasesFromApplication returns only the images that are live in the
+// cluster, with ImageAlias and ContainerImage set from the corresponding entry in
+// app.Status.Summary.Images.
+//
+// For each image in applicationImages.Images the function checks whether it is live
+// (i.e. present in GetImagesFromApplication). Images that are not live are silently
+// dropped from the result. For each live image:
+//   - ContainerImage is replaced with the live instance, which carries the actual
+//     running tag. This is a mutation of the original *Image element.
+//   - ImageAlias is set from the configured alias (or ImageName as fallback).
+//
+// When two configured aliases reference the same live image, the second alias
+// receives a shallow copy of the live ContainerImage so that both alias entries
+// carry independent ImageAlias values without interfering with each other.
+//
 // TODO: this function together with GetImagesFromApplication should be refactored. We iterate through
 // applicationImages.Images 3 times in one place (2 in functions and in containerImages.ContainsImage).
 // Also the 4th loop is in marshalParamsOverride. See GITOPS-7415
 func GetImagesAndAliasesFromApplication(applicationImages *ApplicationImages) ImageList {
 	containerImages := GetImagesFromApplication(applicationImages)
 
+	result := make(ImageList, 0, len(applicationImages.Images))
+
 	// We iterate through the list of images with alias information.
 	for _, aliasedImage := range applicationImages.Images {
-		// For each one, we find its corresponding entry in the list of images found in the app source.
+		// For each one, we find its corresponding entry in the list of live images.
+		// Images not found here are not live and are excluded from the result.
 		if sourceImage := containerImages.ContainsImage(aliasedImage.ContainerImage, false); sourceImage != nil {
 			if sourceImage.ImageAlias != "" {
-				// this image has already been matched to an alias, so create a copy
-				// and assign this alias to the image copy to avoid overwriting the existing alias association
+				// This live image has already been matched to a previous alias, so create
+				// a copy to avoid overwriting the existing alias association.
 				imageCopy := *sourceImage
 				if aliasedImage.ImageAlias == "" {
 					imageCopy.ImageAlias = aliasedImage.ImageName
 				} else {
 					imageCopy.ImageAlias = aliasedImage.ImageAlias
 				}
-				// We update the aliasedImage to point to this new copy.
 				aliasedImage.ContainerImage = &imageCopy
 			} else {
-				// This is the first alias for this image. We can modify it in place.
+				// This is the first alias for this live image. We can modify it in place.
 				if aliasedImage.ImageAlias == "" {
 					sourceImage.ImageAlias = aliasedImage.ImageName
 				} else {
 					sourceImage.ImageAlias = aliasedImage.ImageAlias
 				}
-				// We update the aliasedImage to point to the now-aliased source image.
 				aliasedImage.ContainerImage = sourceImage
 			}
+			result = append(result, aliasedImage)
 		}
 	}
 
-	// The applicationImages.Images list is now correctly aliased.
-	return applicationImages.Images
+	return result
 }
 
 // GetApplicationType returns the type of the ArgoCD application

--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -935,15 +935,22 @@ func GetImagesFromApplication(applicationImages *ApplicationImages) image.Contai
 	return images
 }
 
-// GetImagesAndAliasesFromApplication returns only the images that are live in the
-// cluster, with ImageAlias and ContainerImage set from the corresponding entry in
-// app.Status.Summary.Images.
+// GetImagesAndAliasesFromApplication returns only the images that are considered
+// "live", with ImageAlias and ContainerImage set from the corresponding entry
+// returned by GetImagesFromApplication.
+//
+// The live-image set is built by GetImagesFromApplication from two sources:
+//   - app.Status.Summary.Images — images actually running in the cluster.
+//   - Force-update images — configured images with ForceUpdate == true are
+//     injected with a nil tag so they are always treated as live even when no
+//     running container is detected.
 //
 // For each image in applicationImages.Images the function checks whether it is live
 // (i.e. present in GetImagesFromApplication). Images that are not live are silently
 // dropped from the result. For each live image:
 //   - ContainerImage is replaced with the live instance, which carries the actual
-//     running tag. This is a mutation of the original *Image element.
+//     running tag (or nil for force-update images). This is a mutation of the
+//     original *Image element.
 //   - ImageAlias is set from the configured alias (or ImageName as fallback).
 //
 // When two configured aliases reference the same live image, the second alias

--- a/pkg/argocd/argocd_test.go
+++ b/pkg/argocd/argocd_test.go
@@ -224,6 +224,35 @@ func Test_GetImagesAndAliasesFromApplication(t *testing.T) {
 		imageList := GetImagesAndAliasesFromApplication(applicationImages)
 		assert.Empty(t, imageList)
 	})
+
+	t.Run("Non-live images are excluded from the result", func(t *testing.T) {
+		// Only nginx is live; redis is configured but not running in the cluster.
+		// GetImagesAndAliasesFromApplication must return only nginx.
+		application := &v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "test-app",
+				Namespace: "argocd",
+			},
+			Spec: v1alpha1.ApplicationSpec{},
+			Status: v1alpha1.ApplicationStatus{
+				Summary: v1alpha1.ApplicationSummary{
+					Images: []string{"nginx:1.25.0"},
+				},
+			},
+		}
+		applicationImages := &ApplicationImages{
+			Application: *application,
+			Images: ImageList{
+				NewImage(image.NewFromIdentifier("nginx:1.25.0")),
+				NewImage(image.NewFromIdentifier("redis:7.0")),
+			},
+		}
+
+		imageList := GetImagesAndAliasesFromApplication(applicationImages)
+
+		require.Len(t, imageList, 1)
+		assert.Equal(t, "nginx", imageList[0].ImageName)
+	})
 }
 
 func Test_GetApplicationType(t *testing.T) {

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -2625,6 +2625,92 @@ redis:
 		assert.Equal(t, strings.TrimSpace(strings.ReplaceAll(expected, "\t", "  ")), strings.TrimSpace(string(yaml)))
 	})
 
+	t.Run("Helmvalues write-back must not blank tags of non-live images (issue #1584)", func(t *testing.T) {
+		// Reproduce the regression from issue #1584:
+		// CRD mode with useAnnotations:true + multiple image aliases in a shared helmvalues file.
+		// When one alias is updated, non-live aliases must NOT have their tags blanked in the file.
+		originalData := []byte(`
+image:
+  tag: "main-0000000"
+  repository: registry.local/aiu/manager
+session:
+  image:
+    tag: "main-0000000"
+    repository: registry.local/aiu/session
+reaper:
+  image:
+    tag: "main-0000000"
+    repository: registry.local/aiu/reaper
+tokenRotator:
+  image:
+    tag: "main-0000000"
+    repository: registry.local/aiu/token_rotator
+`)
+		// Only manager is live in the cluster
+		app := v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "aiu-repro",
+			},
+			Spec: v1alpha1.ApplicationSpec{
+				Source: &v1alpha1.ApplicationSource{
+					RepoURL:        "https://example.com/repo",
+					TargetRevision: "main",
+					Helm: &v1alpha1.ApplicationSourceHelm{
+						// Simulates state after SetHelmImage(manager, "main-1111111"):
+						// only manager params are set, because session/reaper/tokenRotator are not live.
+						Parameters: []v1alpha1.HelmParameter{
+							{Name: "image.repository", Value: "registry.local/aiu/manager", ForceString: true},
+							{Name: "image.tag", Value: "main-1111111", ForceString: true},
+						},
+					},
+				},
+			},
+			Status: v1alpha1.ApplicationStatus{
+				SourceType: v1alpha1.ApplicationSourceTypeHelm,
+				Summary: v1alpha1.ApplicationSummary{
+					// Only manager is live; session, reaper, tokenRotator are not
+					Images: []string{"registry.local/aiu/manager:main-0000000"},
+				},
+			},
+		}
+
+		// All four images are configured (as they would be from annotations or CRD)
+		imManager := NewImage(image.NewFromIdentifier("manager=registry.local/aiu/manager"))
+		imManager.HelmImageName = "image.repository"
+		imManager.HelmImageTag = "image.tag"
+
+		imSession := NewImage(image.NewFromIdentifier("session=registry.local/aiu/session"))
+		imSession.HelmImageName = "session.image.repository"
+		imSession.HelmImageTag = "session.image.tag"
+
+		imReaper := NewImage(image.NewFromIdentifier("reaper=registry.local/aiu/reaper"))
+		imReaper.HelmImageName = "reaper.image.repository"
+		imReaper.HelmImageTag = "reaper.image.tag"
+
+		imTokenRotator := NewImage(image.NewFromIdentifier("tokenrotator=registry.local/aiu/token_rotator"))
+		imTokenRotator.HelmImageName = "tokenRotator.image.repository"
+		imTokenRotator.HelmImageTag = "tokenRotator.image.tag"
+
+		applicationImages := &ApplicationImages{
+			Application: app,
+			Images:      ImageList{imManager, imSession, imReaper, imTokenRotator},
+			WriteBackConfig: &WriteBackConfig{
+				Target: "./env/values.yaml",
+			},
+		}
+
+		result, err := marshalParamsOverride(context.Background(), applicationImages, originalData)
+		require.NoError(t, err)
+		require.NotEmpty(t, result)
+
+		// Manager tag must be updated to the new value
+		assert.Contains(t, string(result), "main-1111111")
+
+		// Non-live images' tags must NOT be blanked - they must keep their original values
+		assert.NotContains(t, string(result), `tag: ""`)
+		assert.Contains(t, string(result), "main-0000000", "non-live image tags must be preserved")
+	})
+
 	t.Run("Valid Helm source with Helm values file with multiple aliases", func(t *testing.T) {
 		expected := `
 foo.image.name: nginx

--- a/test/ginkgo/parallel/1-008-helmvalues-non-live-images_test.go
+++ b/test/ginkgo/parallel/1-008-helmvalues-non-live-images_test.go
@@ -1,0 +1,325 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package parallel
+
+import (
+	"context"
+	"fmt"
+
+	appv1alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/gitops-engine/pkg/health"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	applicationFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/application"
+
+	imageUpdaterApi "github.com/argoproj-labs/argocd-image-updater/api/v1alpha1"
+
+	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
+
+	"github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture"
+	argocdFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/argocd"
+	deplFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/deployment"
+	iuFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/imageupdater"
+	k8sFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/k8s"
+	ssFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/statefulset"
+	fixtureUtils "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/utils"
+)
+
+var _ = Describe("ArgoCD Image Updater Parallel E2E Tests", func() {
+
+	// This test is a regression test for issue #1584.
+	//
+	// When multiple image aliases share a single helmvalues write-back target, only the
+	// images that are actually running in the cluster ("live") should have their tags
+	// written. Images that are configured in the ImageUpdater CR but are NOT currently
+	// deployed ("non-live") must not have their existing tag values overwritten with "".
+	//
+	// Setup:
+	//   - A Helm chart with three image entries in values.yaml: manager, session, reaper.
+	//   - The Deployment template uses only the manager image, so only manager will appear
+	//     in app.Status.Summary.Images (live image).
+	//   - Session and reaper are present in values.yaml but are not used by any pod
+	//     template, so they will never appear in app.Status.Summary.Images (non-live).
+	//   - A ConfigMap rendered by the chart exposes the session and reaper tags directly
+	//     from values.yaml so the test can assert their values after an ArgoCD sync.
+	//
+	// Expected behaviour after Image Updater runs:
+	//   - manager.image.tag is updated to the latest semver tag found in the registry.
+	//   - session.image.tag and reaper.image.tag remain at "1.0.0" (not blanked to "").
+	Context("1-008-helmvalues-non-live-images_test", func() {
+
+		var (
+			k8sClient    client.Client
+			ctx          context.Context
+			ns           *corev1.Namespace
+			cleanupFunc  func()
+			imageUpdater *imageUpdaterApi.ImageUpdater
+			argoCD       *argov1beta1api.ArgoCD
+		)
+
+		BeforeEach(func() {
+			fixture.EnsureParallelCleanSlate()
+
+			k8sClient, _ = fixtureUtils.GetE2ETestKubeClient()
+			ctx = context.Background()
+		})
+
+		AfterEach(func() {
+			// Delete the ImageUpdater CR first and wait for its finalizer to be
+			// processed before tearing down the ArgoCD CR (which removes the controller).
+
+			if imageUpdater != nil {
+				By("deleting ImageUpdater CR")
+				_ = k8sClient.Delete(ctx, imageUpdater)
+				Eventually(imageUpdater, "2m", "3s").Should(k8sFixture.NotExistByName())
+			}
+
+			if argoCD != nil {
+				By("deleting ArgoCD CR")
+				_ = k8sClient.Delete(ctx, argoCD)
+			}
+
+			if cleanupFunc != nil {
+				cleanupFunc()
+			}
+
+			fixture.OutputDebugOnFail(ns)
+		})
+
+		It("ensures that helmvalues write-back does not blank non-live image tags (issue #1584)", func() {
+
+			By("creating simple namespace-scoped Argo CD instance with image updater enabled")
+			ns, cleanupFunc = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
+
+			By("Creating local git repo")
+			iuFixture.CreateLocalGitRepo(ctx, k8sClient, ns.Name)
+
+			By("waiting for local git repo to be ready")
+			gitDepl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: iuFixture.Name, Namespace: ns.Name}}
+			Eventually(gitDepl).Should(k8sFixture.ExistByName())
+			Eventually(gitDepl, "2m", "3s").Should(deplFixture.HaveReadyReplicas(1), "git repo server was not ready")
+
+			argoCD = &argov1beta1api.ArgoCD{
+				ObjectMeta: metav1.ObjectMeta{Name: "argocd", Namespace: ns.Name},
+				Spec: argov1beta1api.ArgoCDSpec{
+					ImageUpdater: argov1beta1api.ArgoCDImageUpdaterSpec{
+						Env: []corev1.EnvVar{
+							{
+								Name:  "IMAGE_UPDATER_LOGLEVEL",
+								Value: "trace",
+							},
+							{
+								Name:  "IMAGE_UPDATER_INTERVAL",
+								Value: "0",
+							},
+						},
+						Enabled: true},
+				},
+			}
+			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
+
+			By("waiting for ArgoCD CR to be reconciled and the instance to be ready")
+			Eventually(argoCD, "5m", "3s").Should(argocdFixture.BeAvailable())
+
+			By("verifying all workloads are started")
+			deploymentsShouldExist := []string{"argocd-redis", "argocd-server", "argocd-repo-server", "argocd-argocd-image-updater-controller"}
+			for _, depl := range deploymentsShouldExist {
+				depl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: depl, Namespace: ns.Name}}
+				Eventually(depl).Should(k8sFixture.ExistByName())
+				Eventually(depl).Should(deplFixture.HaveReplicas(1))
+				Eventually(depl, "3m", "3s").Should(deplFixture.HaveReadyReplicas(1), depl.Name+" was not ready")
+			}
+
+			statefulSet := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "argocd-application-controller", Namespace: ns.Name}}
+			Eventually(statefulSet).Should(k8sFixture.ExistByName())
+			Eventually(statefulSet).Should(ssFixture.HaveReplicas(1))
+			Eventually(statefulSet, "3m", "3s").Should(ssFixture.HaveReadyReplicas(1))
+
+			By("creating Helm Application with multiple image aliases sharing one helmvalues file")
+			gitRepoURL := fmt.Sprintf("https://%s.%s.svc.cluster.local:8081/testdata.git", iuFixture.Name, ns.Name)
+			app := &appv1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "multi-image-helm-app",
+					Namespace: ns.Name,
+				},
+				Spec: appv1alpha1.ApplicationSpec{
+					Project: "default",
+					Source: &appv1alpha1.ApplicationSource{
+						RepoURL:        gitRepoURL,
+						Path:           "1-008-helmvalues-non-live-images/helm",
+						TargetRevision: "HEAD",
+						Helm: &appv1alpha1.ApplicationSourceHelm{
+							ValueFiles: []string{"values.yaml"},
+						},
+					},
+					Destination: appv1alpha1.ApplicationDestination{
+						Server:    "https://kubernetes.default.svc",
+						Namespace: ns.Name,
+					},
+					SyncPolicy: &appv1alpha1.SyncPolicy{
+						Automated: &appv1alpha1.SyncPolicyAutomated{
+							Prune: true,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+
+			By("verifying deploying the Application succeeded")
+			Eventually(app, "4m", "3s").Should(applicationFixture.HaveHealthStatusCode(health.HealthStatusHealthy))
+			Eventually(app, "4m", "3s").Should(applicationFixture.HaveSyncStatusCode(appv1alpha1.SyncStatusCodeSynced))
+
+			By("creating ImageUpdater CR with three image aliases sharing one helmvalues write-back target")
+			updateStrategy := "semver"
+			forceUpdate := false
+			method := fmt.Sprintf("git:secret:%s/%s", ns.Name, iuFixture.Name)
+			branch := "master"
+			repository := gitRepoURL
+			// All three images share the same helmvalues target.
+			writeBackTarget := "helmvalues:/1-008-helmvalues-non-live-images/helm/values.yaml"
+
+			managerHelmImageName := "manager.image.repository"
+			managerHelmImageTag := "manager.image.tag"
+			sessionHelmImageName := "session.image.repository"
+			sessionHelmImageTag := "session.image.tag"
+			reaperHelmImageName := "reaper.image.repository"
+			reaperHelmImageTag := "reaper.image.tag"
+
+			imageUpdater = &imageUpdaterApi.ImageUpdater{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "image-updater",
+					Namespace: ns.Name,
+				},
+				Spec: imageUpdaterApi.ImageUpdaterSpec{
+					CommonUpdateSettings: &imageUpdaterApi.CommonUpdateSettings{
+						UpdateStrategy: &updateStrategy,
+						ForceUpdate:    &forceUpdate,
+					},
+					WriteBackConfig: &imageUpdaterApi.WriteBackConfig{
+						Method: &method,
+						GitConfig: &imageUpdaterApi.GitConfig{
+							Branch:          &branch,
+							Repository:      &repository,
+							WriteBackTarget: &writeBackTarget,
+						},
+					},
+					ApplicationRefs: []imageUpdaterApi.ApplicationRef{
+						{
+							NamePattern: "multi-image-helm-app",
+							Images: []imageUpdaterApi.ImageConfig{
+								// manager: live image — its Deployment container is running,
+								// so it appears in app.Status.Summary.Images. AIU will find
+								// a newer semver tag and update manager.image.tag.
+								{
+									Alias:     "manager",
+									ImageName: "quay.io/dkarpele/my-guestbook:29437546.X",
+									ManifestTarget: &imageUpdaterApi.ManifestTarget{
+										Helm: &imageUpdaterApi.HelmTarget{
+											Name: &managerHelmImageName,
+											Tag:  &managerHelmImageTag,
+										},
+									},
+								},
+								// session: non-live image — no container runs this image,
+								// so it never appears in app.Status.Summary.Images.
+								// A distinct repository name is required so that ContainsImage
+								// does NOT match this alias against the running manager pod.
+								// AIU must NOT blank session.image.tag in the helmvalues file.
+								{
+									Alias:     "session",
+									ImageName: "quay.io/dkarpele/my-guestbook-session:29437546.X",
+									ManifestTarget: &imageUpdaterApi.ManifestTarget{
+										Helm: &imageUpdaterApi.HelmTarget{
+											Name: &sessionHelmImageName,
+											Tag:  &sessionHelmImageTag,
+										},
+									},
+								},
+								// reaper: non-live image — same constraint as session.
+								{
+									Alias:     "reaper",
+									ImageName: "quay.io/dkarpele/my-guestbook-reaper:29437546.X",
+									ManifestTarget: &imageUpdaterApi.ManifestTarget{
+										Helm: &imageUpdaterApi.HelmTarget{
+											Name: &reaperHelmImageName,
+											Tag:  &reaperHelmImageTag,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, imageUpdater)).To(Succeed())
+
+			By("ensuring that the manager image has been updated to the latest semver tag")
+			triggerRefresh := iuFixture.TriggerArgoCDRefresh(ctx, k8sClient, app)
+			Eventually(func() string {
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(app), app)
+				if err != nil {
+					return ""
+				}
+
+				triggerRefresh()
+
+				// For git write-back, changes are pushed to git and ArgoCD syncs from there.
+				// The updated image appears in Status.Summary.Images once ArgoCD re-syncs.
+				for _, img := range app.Status.Summary.Images {
+					if img == "quay.io/dkarpele/my-guestbook:29437546.0" {
+						return img
+					}
+				}
+				return ""
+			}, "5m", "3s").Should(Equal("quay.io/dkarpele/my-guestbook:29437546.0"))
+
+			By("verifying the Application is still healthy after the helmvalues update")
+			Eventually(app, "4m", "3s").Should(applicationFixture.HaveHealthStatusCode(health.HealthStatusHealthy))
+			Eventually(app, "4m", "3s").Should(applicationFixture.HaveSyncStatusCode(appv1alpha1.SyncStatusCodeSynced))
+
+			// At this point ArgoCD has already re-synced from the updated helmvalues file,
+			// so the ConfigMap rendered by the chart reflects the current values.yaml state.
+			// If issue #1584 has regressed, session.image.tag and reaper.image.tag will have
+			// been overwritten with "" in the helmvalues file, and the ConfigMap will expose
+			// that corruption here.
+			By("verifying that non-live image tags were not blanked in the helmvalues file (issue #1584)")
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "non-live-image-tags",
+					Namespace: ns.Name,
+				},
+			}
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(configMap.Data["session-tag"]).ToNot(BeEmpty(),
+					"session image tag must not be blanked by helmvalues write-back (issue #1584)")
+				g.Expect(configMap.Data["reaper-tag"]).ToNot(BeEmpty(),
+					"reaper image tag must not be blanked by helmvalues write-back (issue #1584)")
+				g.Expect(configMap.Data["session-tag"]).To(Equal("1.0.0"),
+					"session image tag must retain its original value after manager-only update")
+				g.Expect(configMap.Data["reaper-tag"]).To(Equal("1.0.0"),
+					"reaper image tag must retain its original value after manager-only update")
+			}, "2m", "3s").Should(Succeed())
+		})
+	})
+})

--- a/test/ginkgo/prereqs/containers/git/testdata/1-008-helmvalues-non-live-images/helm/Chart.yaml
+++ b/test/ginkgo/prereqs/containers/git/testdata/1-008-helmvalues-non-live-images/helm/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: non-live-images-test
+description: Helm chart for testing that helmvalues write-back does not blank non-live image tags (issue #1584)
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/test/ginkgo/prereqs/containers/git/testdata/1-008-helmvalues-non-live-images/helm/templates/configmap.yaml
+++ b/test/ginkgo/prereqs/containers/git/testdata/1-008-helmvalues-non-live-images/helm/templates/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: non-live-image-tags
+  namespace: {{ .Release.Namespace }}
+data:
+  # These values are sourced directly from values.yaml.
+  # After argocd-image-updater writes back only the live manager tag, these
+  # non-live image tags must remain at their original non-empty values.
+  # If issue #1584 regresses, these will be blanked to "".
+  session-tag: {{ .Values.session.image.tag | quote }}
+  reaper-tag: {{ .Values.reaper.image.tag | quote }}

--- a/test/ginkgo/prereqs/containers/git/testdata/1-008-helmvalues-non-live-images/helm/templates/deployment.yaml
+++ b/test/ginkgo/prereqs/containers/git/testdata/1-008-helmvalues-non-live-images/helm/templates/deployment.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: manager
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: manager
+  template:
+    metadata:
+      labels:
+        app: manager
+    spec:
+      containers:
+      - name: manager
+        image: "{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}"

--- a/test/ginkgo/prereqs/containers/git/testdata/1-008-helmvalues-non-live-images/helm/values.yaml
+++ b/test/ginkgo/prereqs/containers/git/testdata/1-008-helmvalues-non-live-images/helm/values.yaml
@@ -1,0 +1,24 @@
+# manager is the only image that runs as a live container.
+# session and reaper are configured here but are not used in any Deployment
+# template, so they will never appear in app.Status.Summary.Images (non-live).
+# After argocd-image-updater updates manager, the tags for session and reaper
+# must remain unchanged ("1.0.0") and must NOT be blanked to "".
+#
+# IMPORTANT: session and reaper intentionally use distinct image repositories so
+# that ContainsImage does NOT match them against the running manager pod.  Using
+# the same repository for all three would cause all aliases to resolve to the same
+# live image, defeating the purpose of this regression test.
+manager:
+  image:
+    repository: quay.io/dkarpele/my-guestbook
+    tag: "1.0.0"
+session:
+  image:
+    repository: 127.0.0.1:30000/session
+    tag: "1.0.0"
+reaper:
+  image:
+    repository: 127.0.0.1:30000/reaper
+    tag: "1.0.0"
+
+replicaCount: 1


### PR DESCRIPTION
Closes #1584 

The regression was introduced in d4d7f320

In 0.* GetImagesAndAliasesFromApplication returned a list of live images. 
https://github.com/argoproj-labs/argocd-image-updater/blob/f3a6ce333d935df1120a1ed3640d8c369ac1d41b/pkg/argocd/argocd.go#L621-L648

The broken version returned the mutated `applicationImages.Images` causing errors. 
Returning the original behaviour back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure only live images are considered for aliasing and updates; non-live image entries are excluded and their tags are preserved (not blanked) during shared Helm values write-back.

* **Tests**
  * Added unit and end-to-end tests validating that non-live image tags remain unchanged and only live image references are updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->