### PR TITLE
test(e2e): test different installation modes

### DIFF
--- a/test/ginkgo/sequential/1-008-app-in-any-ns_test.go
+++ b/test/ginkgo/sequential/1-008-app-in-any-ns_test.go
@@ -20,16 +20,11 @@ import (
 	"context"
 	"time"
 
-	appv1alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
-	"github.com/argoproj/gitops-engine/pkg/health"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	applicationFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/application"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -40,7 +35,6 @@ import (
 	"github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture"
 	argocdFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/argocd"
 	deplFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/deployment"
-	iuFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/imageupdater"
 	k8sFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/k8s"
 	ssFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/statefulset"
 	fixtureUtils "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/utils"
@@ -88,9 +82,13 @@ var _ = Describe("ArgoCD Image Updater Sequential E2E Tests", func() {
 						break
 					}
 				}
+				if operatorDeploy.Spec.Template.ObjectMeta.Annotations == nil {
+					operatorDeploy.Spec.Template.ObjectMeta.Annotations = map[string]string{}
+				}
 				operatorDeploy.Spec.Template.ObjectMeta.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
 				_ = k8sClient.Update(ctx, operatorDeploy)
 			}
+
 			if imageUpdater != nil {
 				By("deleting ImageUpdater CR")
 				_ = k8sClient.Delete(ctx, imageUpdater)
@@ -214,269 +212,18 @@ var _ = Describe("ArgoCD Image Updater Sequential E2E Tests", func() {
 			Eventually(statefulSet).Should(ssFixture.HaveReplicas(1))
 			Eventually(statefulSet, "3m", "3s").Should(ssFixture.HaveReadyReplicas(1))
 
-			// TODO: Role+RB creation should be removed after updating to ArgoCD Operator with the fix https://github.com/argoproj-labs/argocd-operator/pull/2172
-			By("creating Role and RoleBinding in dev namespace for Image Updater ServiceAccount")
-			role := &rbacv1.Role{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "argocd-image-updater-manager-role",
-					Namespace: nsDev.Name,
-				},
-				Rules: []rbacv1.PolicyRule{
-					{APIGroups: []string{""}, Resources: []string{"events"}, Verbs: []string{"create"}},
-					{APIGroups: []string{"argocd-image-updater.argoproj.io"}, Resources: []string{"imageupdaters"}, Verbs: []string{"create", "delete", "get", "list", "patch", "update", "watch"}},
-					{APIGroups: []string{"argocd-image-updater.argoproj.io"}, Resources: []string{"imageupdaters/finalizers"}, Verbs: []string{"update"}},
-					{APIGroups: []string{"argocd-image-updater.argoproj.io"}, Resources: []string{"imageupdaters/status"}, Verbs: []string{"get", "patch", "update"}},
-					{APIGroups: []string{"argoproj.io"}, Resources: []string{"applications"}, Verbs: []string{"get", "list", "patch", "update", "watch"}},
-				},
-			}
-			Expect(k8sClient.Create(ctx, role)).To(Succeed())
+			// TODO: Remove after ArgoCD Operator fix https://github.com/argoproj-labs/argocd-operator/pull/2172
+			createImageUpdaterRoleAndBinding(ctx, k8sClient, nsDev.Name, ns.Name)
+			createImageUpdaterRoleAndBinding(ctx, k8sClient, nsQE.Name, ns.Name)
 
-			roleBinding := &rbacv1.RoleBinding{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "argocd-image-updater-manager-rolebinding",
-					Namespace: nsDev.Name,
-				},
-				RoleRef: rbacv1.RoleRef{
-					APIGroup: "rbac.authorization.k8s.io",
-					Kind:     "Role",
-					Name:     "argocd-image-updater-manager-role",
-				},
-				Subjects: []rbacv1.Subject{
-					{
-						Kind:      "ServiceAccount",
-						Name:      "argocd-argocd-image-updater-controller",
-						Namespace: ns.Name,
-					},
-				},
-			}
-			Expect(k8sClient.Create(ctx, roleBinding)).To(Succeed())
+			createAppProject(ctx, k8sClient, nsDev.Name, ns.Name)
+			createAppProject(ctx, k8sClient, nsQE.Name, ns.Name)
 
-			By("creating Role and RoleBinding in QE namespace for Image Updater ServiceAccount")
-			roleQE := &rbacv1.Role{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "argocd-image-updater-manager-role",
-					Namespace: nsQE.Name,
-				},
-				Rules: []rbacv1.PolicyRule{
-					{APIGroups: []string{""}, Resources: []string{"events"}, Verbs: []string{"create"}},
-					{APIGroups: []string{"argocd-image-updater.argoproj.io"}, Resources: []string{"imageupdaters"}, Verbs: []string{"create", "delete", "get", "list", "patch", "update", "watch"}},
-					{APIGroups: []string{"argocd-image-updater.argoproj.io"}, Resources: []string{"imageupdaters/finalizers"}, Verbs: []string{"update"}},
-					{APIGroups: []string{"argocd-image-updater.argoproj.io"}, Resources: []string{"imageupdaters/status"}, Verbs: []string{"get", "patch", "update"}},
-					{APIGroups: []string{"argoproj.io"}, Resources: []string{"applications"}, Verbs: []string{"get", "list", "patch", "update", "watch"}},
-				},
-			}
-			Expect(k8sClient.Create(ctx, roleQE)).To(Succeed())
+			app := createGuestbookApp(ctx, k8sClient, nsDev.Name, nsDev.Name)
+			appQE := createGuestbookApp(ctx, k8sClient, nsQE.Name, nsQE.Name)
 
-			roleBindingQE := &rbacv1.RoleBinding{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "argocd-image-updater-manager-rolebinding",
-					Namespace: nsQE.Name,
-				},
-				RoleRef: rbacv1.RoleRef{
-					APIGroup: "rbac.authorization.k8s.io",
-					Kind:     "Role",
-					Name:     "argocd-image-updater-manager-role",
-				},
-				Subjects: []rbacv1.Subject{
-					{
-						Kind:      "ServiceAccount",
-						Name:      "argocd-argocd-image-updater-controller",
-						Namespace: ns.Name,
-					},
-				},
-			}
-			Expect(k8sClient.Create(ctx, roleBindingQE)).To(Succeed())
-
-			By("creating AppProject")
-			appProject := &appv1alpha1.AppProject{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      nsDev.Name,
-					Namespace: ns.Name,
-				},
-				Spec: appv1alpha1.AppProjectSpec{
-					SourceRepos:      []string{"*"},
-					SourceNamespaces: []string{nsDev.Name},
-					Destinations: []appv1alpha1.ApplicationDestination{{
-						Server:    "*",
-						Namespace: "*",
-					}},
-					ClusterResourceWhitelist: []appv1alpha1.ClusterResourceRestrictionItem{{
-						Group: "*",
-						Kind:  "*",
-					}},
-				},
-			}
-			Expect(k8sClient.Create(ctx, appProject)).To(Succeed())
-
-			By("creating AppProject for QE namespace")
-			appProjectQE := &appv1alpha1.AppProject{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      nsQE.Name,
-					Namespace: ns.Name,
-				},
-				Spec: appv1alpha1.AppProjectSpec{
-					SourceRepos:      []string{"*"},
-					SourceNamespaces: []string{nsQE.Name},
-					Destinations: []appv1alpha1.ApplicationDestination{{
-						Server:    "*",
-						Namespace: "*",
-					}},
-					ClusterResourceWhitelist: []appv1alpha1.ClusterResourceRestrictionItem{{
-						Group: "*",
-						Kind:  "*",
-					}},
-				},
-			}
-			Expect(k8sClient.Create(ctx, appProjectQE)).To(Succeed())
-
-			By("creating Application")
-			app := &appv1alpha1.Application{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "app-01",
-					Namespace: nsDev.Name,
-				},
-				Spec: appv1alpha1.ApplicationSpec{
-					Project: nsDev.Name,
-					Source: &appv1alpha1.ApplicationSource{
-						RepoURL:        "https://github.com/argoproj-labs/argocd-image-updater/",
-						Path:           "test/e2e/testdata/005-public-guestbook",
-						TargetRevision: "HEAD",
-					},
-					Destination: appv1alpha1.ApplicationDestination{
-						Server:    "https://kubernetes.default.svc",
-						Namespace: nsDev.Name,
-					},
-					SyncPolicy: &appv1alpha1.SyncPolicy{Automated: &appv1alpha1.SyncPolicyAutomated{}},
-				},
-			}
-			Expect(k8sClient.Create(ctx, app)).To(Succeed())
-
-			By("verifying deploying the Application succeeded")
-			Eventually(app, "4m", "3s").Should(applicationFixture.HaveHealthStatusCode(health.HealthStatusHealthy))
-			Eventually(app, "4m", "3s").Should(applicationFixture.HaveSyncStatusCode(appv1alpha1.SyncStatusCodeSynced))
-
-			By("creating Application in QE namespace")
-			appQE := &appv1alpha1.Application{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "app-01",
-					Namespace: nsQE.Name,
-				},
-				Spec: appv1alpha1.ApplicationSpec{
-					Project: nsQE.Name,
-					Source: &appv1alpha1.ApplicationSource{
-						RepoURL:        "https://github.com/argoproj-labs/argocd-image-updater/",
-						Path:           "test/e2e/testdata/005-public-guestbook",
-						TargetRevision: "HEAD",
-					},
-					Destination: appv1alpha1.ApplicationDestination{
-						Server:    "https://kubernetes.default.svc",
-						Namespace: nsQE.Name,
-					},
-					SyncPolicy: &appv1alpha1.SyncPolicy{Automated: &appv1alpha1.SyncPolicyAutomated{}},
-				},
-			}
-			Expect(k8sClient.Create(ctx, appQE)).To(Succeed())
-
-			By("verifying deploying the QE Application succeeded")
-			Eventually(appQE, "4m", "3s").Should(applicationFixture.HaveHealthStatusCode(health.HealthStatusHealthy))
-			Eventually(appQE, "4m", "3s").Should(applicationFixture.HaveSyncStatusCode(appv1alpha1.SyncStatusCodeSynced))
-
-			By("creating ImageUpdater CR")
-			updateStrategy := "semver"
-			imageUpdater = &imageUpdaterApi.ImageUpdater{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "image-updater",
-					Namespace: nsDev.Name,
-				},
-				Spec: imageUpdaterApi.ImageUpdaterSpec{
-					ApplicationRefs: []imageUpdaterApi.ApplicationRef{
-						{
-							NamePattern: "app*",
-							Images: []imageUpdaterApi.ImageConfig{
-								{
-									Alias:     "guestbook",
-									ImageName: "quay.io/dkarpele/my-guestbook:~29437546.0",
-									CommonUpdateSettings: &imageUpdaterApi.CommonUpdateSettings{
-										UpdateStrategy: &updateStrategy,
-									},
-								},
-							},
-						},
-					},
-				},
-			}
-
-			Expect(k8sClient.Create(ctx, imageUpdater)).To(Succeed())
-
-			By("ensuring that the Application image has `29437546.0` version after update")
-			triggerRefresh := iuFixture.TriggerArgoCDRefresh(ctx, k8sClient, app)
-			Eventually(func() string {
-				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(app), app)
-
-				if err != nil {
-					return "" // Let Eventually retry on error
-				}
-
-				// Trigger ArgoCD refresh periodically to force immediate git check
-				triggerRefresh()
-
-				// Nil-safe check: The Kustomize block is only added by the Image Updater after its first run.
-				// We must check that it and its Images field exist before trying to access them.
-				if app.Spec.Source.Kustomize != nil && len(app.Spec.Source.Kustomize.Images) > 0 {
-					return string(app.Spec.Source.Kustomize.Images[0])
-				}
-
-				// Return an empty string to signify the condition is not yet met.
-				return ""
-			}, "5m", "3s").Should(Equal("quay.io/dkarpele/my-guestbook:29437546.0"))
-
-			By("creating ImageUpdater CR for QE namespace")
-			updateStrategyQE := "semver"
-			imageUpdaterQE = &imageUpdaterApi.ImageUpdater{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "image-updater",
-					Namespace: nsQE.Name,
-				},
-				Spec: imageUpdaterApi.ImageUpdaterSpec{
-					ApplicationRefs: []imageUpdaterApi.ApplicationRef{
-						{
-							NamePattern: "app*",
-							Images: []imageUpdaterApi.ImageConfig{
-								{
-									Alias:     "guestbook",
-									ImageName: "quay.io/dkarpele/my-guestbook:~29437546.0",
-									CommonUpdateSettings: &imageUpdaterApi.CommonUpdateSettings{
-										UpdateStrategy: &updateStrategyQE,
-									},
-								},
-							},
-						},
-					},
-				},
-			}
-			Expect(k8sClient.Create(ctx, imageUpdaterQE)).To(Succeed())
-
-			By("ensuring that the QE Application image has `29437546.0` version after update")
-			triggerRefreshQE := iuFixture.TriggerArgoCDRefresh(ctx, k8sClient, appQE)
-			Eventually(func() string {
-				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(appQE), appQE)
-
-				if err != nil {
-					return "" // Let Eventually retry on error
-				}
-
-				// Trigger ArgoCD refresh periodically to force immediate git check
-				triggerRefreshQE()
-
-				// Nil-safe check: The Kustomize block is only added by the Image Updater after its first run.
-				// We must check that it and its Images field exist before trying to access them.
-				if appQE.Spec.Source.Kustomize != nil && len(appQE.Spec.Source.Kustomize.Images) > 0 {
-					return string(appQE.Spec.Source.Kustomize.Images[0])
-				}
-
-				// Return an empty string to signify the condition is not yet met.
-				return ""
-			}, "5m", "3s").Should(Equal("quay.io/dkarpele/my-guestbook:29437546.0"))
+			imageUpdater = createImageUpdaterAndVerify(ctx, k8sClient, nsDev.Name, app)
+			imageUpdaterQE = createImageUpdaterAndVerify(ctx, k8sClient, nsQE.Name, appQE)
 		})
 	})
 })

--- a/test/ginkgo/sequential/1-009-cluster-wide-mode_test.go
+++ b/test/ginkgo/sequential/1-009-cluster-wide-mode_test.go
@@ -20,16 +20,12 @@ import (
 	"context"
 	"time"
 
-	appv1alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
-	"github.com/argoproj/gitops-engine/pkg/health"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	applicationFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/application"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -40,7 +36,6 @@ import (
 	"github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture"
 	argocdFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/argocd"
 	deplFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/deployment"
-	iuFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/imageupdater"
 	k8sFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/k8s"
 	ssFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/statefulset"
 	fixtureUtils "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/utils"
@@ -51,19 +46,19 @@ var _ = Describe("ArgoCD Image Updater Sequential E2E Tests", func() {
 	Context("1-009-cluster-wide-mode_test", func() {
 
 		var (
-			k8sClient           client.Client
-			ctx                 context.Context
-			ns                  *corev1.Namespace
-			nsDev               *corev1.Namespace
-			nsQE                *corev1.Namespace
-			cleanupFunc         func()
-			cleanupFuncDev      func()
-			cleanupFuncQE       func()
-			imageUpdater        *imageUpdaterApi.ImageUpdater
-			imageUpdaterQE      *imageUpdaterApi.ImageUpdater
-			argoCD              *argov1beta1api.ArgoCD
-			clusterRoleName     string
-			clusterRoleBinding  *rbacv1.ClusterRoleBinding
+			k8sClient          client.Client
+			ctx                context.Context
+			ns                 *corev1.Namespace
+			nsDev              *corev1.Namespace
+			nsQE               *corev1.Namespace
+			cleanupFunc        func()
+			cleanupFuncDev     func()
+			cleanupFuncQE      func()
+			imageUpdater       *imageUpdaterApi.ImageUpdater
+			imageUpdaterQE     *imageUpdaterApi.ImageUpdater
+			argoCD             *argov1beta1api.ArgoCD
+			clusterRoleName    string
+			clusterRoleBinding *rbacv1.ClusterRoleBinding
 		)
 
 		BeforeEach(func() {
@@ -89,6 +84,9 @@ var _ = Describe("ArgoCD Image Updater Sequential E2E Tests", func() {
 						}
 						break
 					}
+				}
+				if operatorDeploy.Spec.Template.ObjectMeta.Annotations == nil {
+					operatorDeploy.Spec.Template.ObjectMeta.Annotations = map[string]string{}
 				}
 				operatorDeploy.Spec.Template.ObjectMeta.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
 				_ = k8sClient.Update(ctx, operatorDeploy)
@@ -227,21 +225,13 @@ var _ = Describe("ArgoCD Image Updater Sequential E2E Tests", func() {
 			Eventually(statefulSet).Should(ssFixture.HaveReplicas(1))
 			Eventually(statefulSet, "3m", "3s").Should(ssFixture.HaveReadyReplicas(1))
 
-			// TODO: ClusterRole+CRB creation should be removed after updating to ArgoCD Operator with the fix https://github.com/argoproj-labs/argocd-operator/pull/2172
+			// TODO: Remove after ArgoCD Operator fix https://github.com/argoproj-labs/argocd-operator/pull/2172
+			// Use ns.Name as a suffix to keep cluster-scoped names unique across parallel test runs.
 			By("creating ClusterRole and ClusterRoleBinding for Image Updater ServiceAccount (cluster-wide mode)")
-			// Use the ArgoCD instance namespace as a suffix to keep names unique across parallel test runs.
 			clusterRoleName = "argocd-image-updater-manager-role-" + ns.Name
 			clusterRole := &rbacv1.ClusterRole{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: clusterRoleName,
-				},
-				Rules: []rbacv1.PolicyRule{
-					{APIGroups: []string{""}, Resources: []string{"events"}, Verbs: []string{"create"}},
-					{APIGroups: []string{"argocd-image-updater.argoproj.io"}, Resources: []string{"imageupdaters"}, Verbs: []string{"create", "delete", "get", "list", "patch", "update", "watch"}},
-					{APIGroups: []string{"argocd-image-updater.argoproj.io"}, Resources: []string{"imageupdaters/finalizers"}, Verbs: []string{"update"}},
-					{APIGroups: []string{"argocd-image-updater.argoproj.io"}, Resources: []string{"imageupdaters/status"}, Verbs: []string{"get", "patch", "update"}},
-					{APIGroups: []string{"argoproj.io"}, Resources: []string{"applications"}, Verbs: []string{"get", "list", "patch", "update", "watch"}},
-				},
+				ObjectMeta: metav1.ObjectMeta{Name: clusterRoleName},
+				Rules:      imageUpdaterManagerPolicyRules(),
 			}
 			Expect(k8sClient.Create(ctx, clusterRole)).To(Succeed())
 
@@ -264,195 +254,14 @@ var _ = Describe("ArgoCD Image Updater Sequential E2E Tests", func() {
 			}
 			Expect(k8sClient.Create(ctx, clusterRoleBinding)).To(Succeed())
 
-			By("creating AppProject for dev namespace")
-			appProject := &appv1alpha1.AppProject{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      nsDev.Name,
-					Namespace: ns.Name,
-				},
-				Spec: appv1alpha1.AppProjectSpec{
-					SourceRepos:      []string{"*"},
-					SourceNamespaces: []string{nsDev.Name},
-					Destinations: []appv1alpha1.ApplicationDestination{{
-						Server:    "*",
-						Namespace: "*",
-					}},
-					ClusterResourceWhitelist: []appv1alpha1.ClusterResourceRestrictionItem{{
-						Group: "*",
-						Kind:  "*",
-					}},
-				},
-			}
-			Expect(k8sClient.Create(ctx, appProject)).To(Succeed())
+			createAppProject(ctx, k8sClient, nsDev.Name, ns.Name)
+			createAppProject(ctx, k8sClient, nsQE.Name, ns.Name)
 
-			By("creating AppProject for QE namespace")
-			appProjectQE := &appv1alpha1.AppProject{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      nsQE.Name,
-					Namespace: ns.Name,
-				},
-				Spec: appv1alpha1.AppProjectSpec{
-					SourceRepos:      []string{"*"},
-					SourceNamespaces: []string{nsQE.Name},
-					Destinations: []appv1alpha1.ApplicationDestination{{
-						Server:    "*",
-						Namespace: "*",
-					}},
-					ClusterResourceWhitelist: []appv1alpha1.ClusterResourceRestrictionItem{{
-						Group: "*",
-						Kind:  "*",
-					}},
-				},
-			}
-			Expect(k8sClient.Create(ctx, appProjectQE)).To(Succeed())
+			app := createGuestbookApp(ctx, k8sClient, nsDev.Name, nsDev.Name)
+			appQE := createGuestbookApp(ctx, k8sClient, nsQE.Name, nsQE.Name)
 
-			By("creating Application in dev namespace")
-			app := &appv1alpha1.Application{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "app-01",
-					Namespace: nsDev.Name,
-				},
-				Spec: appv1alpha1.ApplicationSpec{
-					Project: nsDev.Name,
-					Source: &appv1alpha1.ApplicationSource{
-						RepoURL:        "https://github.com/argoproj-labs/argocd-image-updater/",
-						Path:           "test/e2e/testdata/005-public-guestbook",
-						TargetRevision: "HEAD",
-					},
-					Destination: appv1alpha1.ApplicationDestination{
-						Server:    "https://kubernetes.default.svc",
-						Namespace: nsDev.Name,
-					},
-					SyncPolicy: &appv1alpha1.SyncPolicy{Automated: &appv1alpha1.SyncPolicyAutomated{}},
-				},
-			}
-			Expect(k8sClient.Create(ctx, app)).To(Succeed())
-
-			By("verifying deploying the dev Application succeeded")
-			Eventually(app, "4m", "3s").Should(applicationFixture.HaveHealthStatusCode(health.HealthStatusHealthy))
-			Eventually(app, "4m", "3s").Should(applicationFixture.HaveSyncStatusCode(appv1alpha1.SyncStatusCodeSynced))
-
-			By("creating Application in QE namespace")
-			appQE := &appv1alpha1.Application{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "app-01",
-					Namespace: nsQE.Name,
-				},
-				Spec: appv1alpha1.ApplicationSpec{
-					Project: nsQE.Name,
-					Source: &appv1alpha1.ApplicationSource{
-						RepoURL:        "https://github.com/argoproj-labs/argocd-image-updater/",
-						Path:           "test/e2e/testdata/005-public-guestbook",
-						TargetRevision: "HEAD",
-					},
-					Destination: appv1alpha1.ApplicationDestination{
-						Server:    "https://kubernetes.default.svc",
-						Namespace: nsQE.Name,
-					},
-					SyncPolicy: &appv1alpha1.SyncPolicy{Automated: &appv1alpha1.SyncPolicyAutomated{}},
-				},
-			}
-			Expect(k8sClient.Create(ctx, appQE)).To(Succeed())
-
-			By("verifying deploying the QE Application succeeded")
-			Eventually(appQE, "4m", "3s").Should(applicationFixture.HaveHealthStatusCode(health.HealthStatusHealthy))
-			Eventually(appQE, "4m", "3s").Should(applicationFixture.HaveSyncStatusCode(appv1alpha1.SyncStatusCodeSynced))
-
-			By("creating ImageUpdater CR in dev namespace")
-			updateStrategy := "semver"
-			imageUpdater = &imageUpdaterApi.ImageUpdater{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "image-updater",
-					Namespace: nsDev.Name,
-				},
-				Spec: imageUpdaterApi.ImageUpdaterSpec{
-					ApplicationRefs: []imageUpdaterApi.ApplicationRef{
-						{
-							NamePattern: "app*",
-							Images: []imageUpdaterApi.ImageConfig{
-								{
-									Alias:     "guestbook",
-									ImageName: "quay.io/dkarpele/my-guestbook:~29437546.0",
-									CommonUpdateSettings: &imageUpdaterApi.CommonUpdateSettings{
-										UpdateStrategy: &updateStrategy,
-									},
-								},
-							},
-						},
-					},
-				},
-			}
-			Expect(k8sClient.Create(ctx, imageUpdater)).To(Succeed())
-
-			By("ensuring that the dev Application image has `29437546.0` version after update")
-			triggerRefresh := iuFixture.TriggerArgoCDRefresh(ctx, k8sClient, app)
-			Eventually(func() string {
-				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(app), app)
-
-				if err != nil {
-					return "" // Let Eventually retry on error
-				}
-
-				// Trigger ArgoCD refresh periodically to force immediate git check
-				triggerRefresh()
-
-				// Nil-safe check: The Kustomize block is only added by the Image Updater after its first run.
-				// We must check that it and its Images field exist before trying to access them.
-				if app.Spec.Source.Kustomize != nil && len(app.Spec.Source.Kustomize.Images) > 0 {
-					return string(app.Spec.Source.Kustomize.Images[0])
-				}
-
-				// Return an empty string to signify the condition is not yet met.
-				return ""
-			}, "5m", "3s").Should(Equal("quay.io/dkarpele/my-guestbook:29437546.0"))
-
-			By("creating ImageUpdater CR in QE namespace")
-			updateStrategyQE := "semver"
-			imageUpdaterQE = &imageUpdaterApi.ImageUpdater{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "image-updater",
-					Namespace: nsQE.Name,
-				},
-				Spec: imageUpdaterApi.ImageUpdaterSpec{
-					ApplicationRefs: []imageUpdaterApi.ApplicationRef{
-						{
-							NamePattern: "app*",
-							Images: []imageUpdaterApi.ImageConfig{
-								{
-									Alias:     "guestbook",
-									ImageName: "quay.io/dkarpele/my-guestbook:~29437546.0",
-									CommonUpdateSettings: &imageUpdaterApi.CommonUpdateSettings{
-										UpdateStrategy: &updateStrategyQE,
-									},
-								},
-							},
-						},
-					},
-				},
-			}
-			Expect(k8sClient.Create(ctx, imageUpdaterQE)).To(Succeed())
-
-			By("ensuring that the QE Application image has `29437546.0` version after update")
-			triggerRefreshQE := iuFixture.TriggerArgoCDRefresh(ctx, k8sClient, appQE)
-			Eventually(func() string {
-				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(appQE), appQE)
-
-				if err != nil {
-					return "" // Let Eventually retry on error
-				}
-
-				// Trigger ArgoCD refresh periodically to force immediate git check
-				triggerRefreshQE()
-
-				// Nil-safe check: The Kustomize block is only added by the Image Updater after its first run.
-				// We must check that it and its Images field exist before trying to access them.
-				if appQE.Spec.Source.Kustomize != nil && len(appQE.Spec.Source.Kustomize.Images) > 0 {
-					return string(appQE.Spec.Source.Kustomize.Images[0])
-				}
-
-				// Return an empty string to signify the condition is not yet met.
-				return ""
-			}, "5m", "3s").Should(Equal("quay.io/dkarpele/my-guestbook:29437546.0"))
+			imageUpdater = createImageUpdaterAndVerify(ctx, k8sClient, nsDev.Name, app)
+			imageUpdaterQE = createImageUpdaterAndVerify(ctx, k8sClient, nsQE.Name, appQE)
 		})
 	})
 })

--- a/test/ginkgo/sequential/1-009-cluster-wide-mode_test.go
+++ b/test/ginkgo/sequential/1-009-cluster-wide-mode_test.go
@@ -48,20 +48,22 @@ import (
 
 var _ = Describe("ArgoCD Image Updater Sequential E2E Tests", func() {
 
-	Context("1-008-app-in-any-ns_test", func() {
+	Context("1-009-cluster-wide-mode_test", func() {
 
 		var (
-			k8sClient      client.Client
-			ctx            context.Context
-			ns             *corev1.Namespace
-			nsDev          *corev1.Namespace
-			nsQE           *corev1.Namespace
-			cleanupFunc    func()
-			cleanupFuncDev func()
-			cleanupFuncQE  func()
-			imageUpdater   *imageUpdaterApi.ImageUpdater
-			imageUpdaterQE *imageUpdaterApi.ImageUpdater
-			argoCD         *argov1beta1api.ArgoCD
+			k8sClient           client.Client
+			ctx                 context.Context
+			ns                  *corev1.Namespace
+			nsDev               *corev1.Namespace
+			nsQE                *corev1.Namespace
+			cleanupFunc         func()
+			cleanupFuncDev      func()
+			cleanupFuncQE       func()
+			imageUpdater        *imageUpdaterApi.ImageUpdater
+			imageUpdaterQE      *imageUpdaterApi.ImageUpdater
+			argoCD              *argov1beta1api.ArgoCD
+			clusterRoleName     string
+			clusterRoleBinding  *rbacv1.ClusterRoleBinding
 		)
 
 		BeforeEach(func() {
@@ -91,6 +93,7 @@ var _ = Describe("ArgoCD Image Updater Sequential E2E Tests", func() {
 				operatorDeploy.Spec.Template.ObjectMeta.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
 				_ = k8sClient.Update(ctx, operatorDeploy)
 			}
+
 			if imageUpdater != nil {
 				By("deleting ImageUpdater CR")
 				_ = k8sClient.Delete(ctx, imageUpdater)
@@ -104,6 +107,16 @@ var _ = Describe("ArgoCD Image Updater Sequential E2E Tests", func() {
 			if argoCD != nil {
 				By("deleting ArgoCD CR")
 				_ = k8sClient.Delete(ctx, argoCD)
+			}
+
+			if clusterRoleBinding != nil {
+				By("deleting ClusterRoleBinding")
+				_ = k8sClient.Delete(ctx, clusterRoleBinding)
+			}
+
+			if clusterRoleName != "" {
+				By("deleting ClusterRole")
+				_ = k8sClient.Delete(ctx, &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: clusterRoleName}})
 			}
 
 			if cleanupFunc != nil {
@@ -123,7 +136,7 @@ var _ = Describe("ArgoCD Image Updater Sequential E2E Tests", func() {
 			fixture.OutputDebugOnFail(nsQE)
 		})
 
-		It("ensures that Image Updater will update Argo CD Application in any namespace", func() {
+		It("ensures that Image Updater in cluster-wide mode will update Argo CD Applications across namespaces", func() {
 
 			By("creating namespaces")
 			ns, cleanupFunc = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
@@ -166,7 +179,7 @@ var _ = Describe("ArgoCD Image Updater Sequential E2E Tests", func() {
 				"3s",
 			).Should(deplFixture.HaveReadyReplicas(1))
 
-			By("creating simple namespace-scoped Argo CD instance with image updater enabled")
+			By("creating simple namespace-scoped Argo CD instance with image updater enabled in cluster-wide mode")
 			argoCD = &argov1beta1api.ArgoCD{
 				ObjectMeta: metav1.ObjectMeta{Name: "argocd", Namespace: ns.Name},
 				Spec: argov1beta1api.ArgoCDSpec{
@@ -175,7 +188,7 @@ var _ = Describe("ArgoCD Image Updater Sequential E2E Tests", func() {
 						nsQE.Name,
 					},
 					CmdParams: map[string]string{
-						"application.namespaces": nsDev.Name + "," + nsQE.Name,
+						"application.namespaces": "*",
 					},
 					ImageUpdater: argov1beta1api.ArgoCDImageUpdaterSpec{
 						Env: []corev1.EnvVar{
@@ -189,7 +202,7 @@ var _ = Describe("ArgoCD Image Updater Sequential E2E Tests", func() {
 							},
 							{
 								Name:  "IMAGE_UPDATER_WATCH_NAMESPACES",
-								Value: nsDev.Name + "," + nsQE.Name,
+								Value: "*",
 							},
 						},
 						Enabled: true},
@@ -214,12 +227,13 @@ var _ = Describe("ArgoCD Image Updater Sequential E2E Tests", func() {
 			Eventually(statefulSet).Should(ssFixture.HaveReplicas(1))
 			Eventually(statefulSet, "3m", "3s").Should(ssFixture.HaveReadyReplicas(1))
 
-			// TODO: Role+RB creation should be removed after updating to ArgoCD Operator with the fix https://github.com/argoproj-labs/argocd-operator/pull/2172
-			By("creating Role and RoleBinding in dev namespace for Image Updater ServiceAccount")
-			role := &rbacv1.Role{
+			// TODO: ClusterRole+CRB creation should be removed after updating to ArgoCD Operator with the fix https://github.com/argoproj-labs/argocd-operator/pull/2172
+			By("creating ClusterRole and ClusterRoleBinding for Image Updater ServiceAccount (cluster-wide mode)")
+			// Use the ArgoCD instance namespace as a suffix to keep names unique across parallel test runs.
+			clusterRoleName = "argocd-image-updater-manager-role-" + ns.Name
+			clusterRole := &rbacv1.ClusterRole{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "argocd-image-updater-manager-role",
-					Namespace: nsDev.Name,
+					Name: clusterRoleName,
 				},
 				Rules: []rbacv1.PolicyRule{
 					{APIGroups: []string{""}, Resources: []string{"events"}, Verbs: []string{"create"}},
@@ -229,17 +243,16 @@ var _ = Describe("ArgoCD Image Updater Sequential E2E Tests", func() {
 					{APIGroups: []string{"argoproj.io"}, Resources: []string{"applications"}, Verbs: []string{"get", "list", "patch", "update", "watch"}},
 				},
 			}
-			Expect(k8sClient.Create(ctx, role)).To(Succeed())
+			Expect(k8sClient.Create(ctx, clusterRole)).To(Succeed())
 
-			roleBinding := &rbacv1.RoleBinding{
+			clusterRoleBinding = &rbacv1.ClusterRoleBinding{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "argocd-image-updater-manager-rolebinding",
-					Namespace: nsDev.Name,
+					Name: "argocd-image-updater-manager-rolebinding-" + ns.Name,
 				},
 				RoleRef: rbacv1.RoleRef{
 					APIGroup: "rbac.authorization.k8s.io",
-					Kind:     "Role",
-					Name:     "argocd-image-updater-manager-role",
+					Kind:     "ClusterRole",
+					Name:     clusterRoleName,
 				},
 				Subjects: []rbacv1.Subject{
 					{
@@ -249,45 +262,9 @@ var _ = Describe("ArgoCD Image Updater Sequential E2E Tests", func() {
 					},
 				},
 			}
-			Expect(k8sClient.Create(ctx, roleBinding)).To(Succeed())
+			Expect(k8sClient.Create(ctx, clusterRoleBinding)).To(Succeed())
 
-			By("creating Role and RoleBinding in QE namespace for Image Updater ServiceAccount")
-			roleQE := &rbacv1.Role{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "argocd-image-updater-manager-role",
-					Namespace: nsQE.Name,
-				},
-				Rules: []rbacv1.PolicyRule{
-					{APIGroups: []string{""}, Resources: []string{"events"}, Verbs: []string{"create"}},
-					{APIGroups: []string{"argocd-image-updater.argoproj.io"}, Resources: []string{"imageupdaters"}, Verbs: []string{"create", "delete", "get", "list", "patch", "update", "watch"}},
-					{APIGroups: []string{"argocd-image-updater.argoproj.io"}, Resources: []string{"imageupdaters/finalizers"}, Verbs: []string{"update"}},
-					{APIGroups: []string{"argocd-image-updater.argoproj.io"}, Resources: []string{"imageupdaters/status"}, Verbs: []string{"get", "patch", "update"}},
-					{APIGroups: []string{"argoproj.io"}, Resources: []string{"applications"}, Verbs: []string{"get", "list", "patch", "update", "watch"}},
-				},
-			}
-			Expect(k8sClient.Create(ctx, roleQE)).To(Succeed())
-
-			roleBindingQE := &rbacv1.RoleBinding{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "argocd-image-updater-manager-rolebinding",
-					Namespace: nsQE.Name,
-				},
-				RoleRef: rbacv1.RoleRef{
-					APIGroup: "rbac.authorization.k8s.io",
-					Kind:     "Role",
-					Name:     "argocd-image-updater-manager-role",
-				},
-				Subjects: []rbacv1.Subject{
-					{
-						Kind:      "ServiceAccount",
-						Name:      "argocd-argocd-image-updater-controller",
-						Namespace: ns.Name,
-					},
-				},
-			}
-			Expect(k8sClient.Create(ctx, roleBindingQE)).To(Succeed())
-
-			By("creating AppProject")
+			By("creating AppProject for dev namespace")
 			appProject := &appv1alpha1.AppProject{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      nsDev.Name,
@@ -329,7 +306,7 @@ var _ = Describe("ArgoCD Image Updater Sequential E2E Tests", func() {
 			}
 			Expect(k8sClient.Create(ctx, appProjectQE)).To(Succeed())
 
-			By("creating Application")
+			By("creating Application in dev namespace")
 			app := &appv1alpha1.Application{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "app-01",
@@ -351,7 +328,7 @@ var _ = Describe("ArgoCD Image Updater Sequential E2E Tests", func() {
 			}
 			Expect(k8sClient.Create(ctx, app)).To(Succeed())
 
-			By("verifying deploying the Application succeeded")
+			By("verifying deploying the dev Application succeeded")
 			Eventually(app, "4m", "3s").Should(applicationFixture.HaveHealthStatusCode(health.HealthStatusHealthy))
 			Eventually(app, "4m", "3s").Should(applicationFixture.HaveSyncStatusCode(appv1alpha1.SyncStatusCodeSynced))
 
@@ -381,7 +358,7 @@ var _ = Describe("ArgoCD Image Updater Sequential E2E Tests", func() {
 			Eventually(appQE, "4m", "3s").Should(applicationFixture.HaveHealthStatusCode(health.HealthStatusHealthy))
 			Eventually(appQE, "4m", "3s").Should(applicationFixture.HaveSyncStatusCode(appv1alpha1.SyncStatusCodeSynced))
 
-			By("creating ImageUpdater CR")
+			By("creating ImageUpdater CR in dev namespace")
 			updateStrategy := "semver"
 			imageUpdater = &imageUpdaterApi.ImageUpdater{
 				ObjectMeta: metav1.ObjectMeta{
@@ -405,10 +382,9 @@ var _ = Describe("ArgoCD Image Updater Sequential E2E Tests", func() {
 					},
 				},
 			}
-
 			Expect(k8sClient.Create(ctx, imageUpdater)).To(Succeed())
 
-			By("ensuring that the Application image has `29437546.0` version after update")
+			By("ensuring that the dev Application image has `29437546.0` version after update")
 			triggerRefresh := iuFixture.TriggerArgoCDRefresh(ctx, k8sClient, app)
 			Eventually(func() string {
 				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(app), app)
@@ -430,7 +406,7 @@ var _ = Describe("ArgoCD Image Updater Sequential E2E Tests", func() {
 				return ""
 			}, "5m", "3s").Should(Equal("quay.io/dkarpele/my-guestbook:29437546.0"))
 
-			By("creating ImageUpdater CR for QE namespace")
+			By("creating ImageUpdater CR in QE namespace")
 			updateStrategyQE := "semver"
 			imageUpdaterQE = &imageUpdaterApi.ImageUpdater{
 				ObjectMeta: metav1.ObjectMeta{

--- a/test/ginkgo/sequential/helpers.go
+++ b/test/ginkgo/sequential/helpers.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sequential
+
+import (
+	"context"
+
+	appv1alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/gitops-engine/pkg/health"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	imageUpdaterApi "github.com/argoproj-labs/argocd-image-updater/api/v1alpha1"
+	applicationFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/application"
+	iuFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/imageupdater"
+)
+
+// imageUpdaterManagerPolicyRules returns the RBAC policy rules required by the
+// Image Updater manager role. Shared by both namespace-scoped (Role) and
+// cluster-scoped (ClusterRole) installations.
+func imageUpdaterManagerPolicyRules() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
+		{APIGroups: []string{""}, Resources: []string{"events"}, Verbs: []string{"create"}},
+		{APIGroups: []string{"argocd-image-updater.argoproj.io"}, Resources: []string{"imageupdaters"}, Verbs: []string{"create", "delete", "get", "list", "patch", "update", "watch"}},
+		{APIGroups: []string{"argocd-image-updater.argoproj.io"}, Resources: []string{"imageupdaters/finalizers"}, Verbs: []string{"update"}},
+		{APIGroups: []string{"argocd-image-updater.argoproj.io"}, Resources: []string{"imageupdaters/status"}, Verbs: []string{"get", "patch", "update"}},
+		{APIGroups: []string{"argoproj.io"}, Resources: []string{"applications"}, Verbs: []string{"get", "list", "patch", "update", "watch"}},
+	}
+}
+
+// createImageUpdaterRoleAndBinding creates a namespace-scoped Role and RoleBinding
+// in targetNamespace granting the Image Updater ServiceAccount in controllerNamespace
+// the permissions it needs to manage ImageUpdater CRs and Applications.
+//
+// TODO: Remove after ArgoCD Operator fix https://github.com/argoproj-labs/argocd-operator/pull/2172
+func createImageUpdaterRoleAndBinding(ctx context.Context, k8sClient client.Client, targetNamespace, controllerNamespace string) {
+	By("creating Role and RoleBinding in " + targetNamespace + " for Image Updater ServiceAccount")
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "argocd-image-updater-manager-role",
+			Namespace: targetNamespace,
+		},
+		Rules: imageUpdaterManagerPolicyRules(),
+	}
+	Expect(k8sClient.Create(ctx, role)).To(Succeed())
+
+	roleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "argocd-image-updater-manager-rolebinding",
+			Namespace: targetNamespace,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     "argocd-image-updater-manager-role",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      "argocd-argocd-image-updater-controller",
+				Namespace: controllerNamespace,
+			},
+		},
+	}
+	Expect(k8sClient.Create(ctx, roleBinding)).To(Succeed())
+}
+
+// createAppProject creates an ArgoCD AppProject named after sourceNamespace,
+// hosted in argoCDNamespace, permitting all sources and destinations.
+func createAppProject(ctx context.Context, k8sClient client.Client, sourceNamespace, argoCDNamespace string) {
+	By("creating AppProject for " + sourceNamespace)
+	appProject := &appv1alpha1.AppProject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sourceNamespace,
+			Namespace: argoCDNamespace,
+		},
+		Spec: appv1alpha1.AppProjectSpec{
+			SourceRepos:      []string{"*"},
+			SourceNamespaces: []string{sourceNamespace},
+			Destinations: []appv1alpha1.ApplicationDestination{{
+				Server:    "*",
+				Namespace: "*",
+			}},
+			ClusterResourceWhitelist: []appv1alpha1.ClusterResourceRestrictionItem{{
+				Group: "*",
+				Kind:  "*",
+			}},
+		},
+	}
+	Expect(k8sClient.Create(ctx, appProject)).To(Succeed())
+}
+
+// createGuestbookApp creates a public guestbook Application named "app-01" in
+// appNamespace, waits for it to become healthy and synced, and returns the object.
+func createGuestbookApp(ctx context.Context, k8sClient client.Client, appNamespace, projectName string) *appv1alpha1.Application {
+	By("creating Application in " + appNamespace)
+	app := &appv1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "app-01",
+			Namespace: appNamespace,
+		},
+		Spec: appv1alpha1.ApplicationSpec{
+			Project: projectName,
+			Source: &appv1alpha1.ApplicationSource{
+				RepoURL:        "https://github.com/argoproj-labs/argocd-image-updater/",
+				Path:           "test/e2e/testdata/005-public-guestbook",
+				TargetRevision: "HEAD",
+			},
+			Destination: appv1alpha1.ApplicationDestination{
+				Server:    "https://kubernetes.default.svc",
+				Namespace: appNamespace,
+			},
+			SyncPolicy: &appv1alpha1.SyncPolicy{Automated: &appv1alpha1.SyncPolicyAutomated{}},
+		},
+	}
+	Expect(k8sClient.Create(ctx, app)).To(Succeed())
+
+	By("verifying Application in " + appNamespace + " is healthy and synced")
+	Eventually(app, "4m", "3s").Should(applicationFixture.HaveHealthStatusCode(health.HealthStatusHealthy))
+	Eventually(app, "4m", "3s").Should(applicationFixture.HaveSyncStatusCode(appv1alpha1.SyncStatusCodeSynced))
+	return app
+}
+
+// createImageUpdaterAndVerify creates an ImageUpdater CR in namespace, waits for the
+// guestbook image in app to be updated to the semver-resolved tag, and returns the CR.
+func createImageUpdaterAndVerify(ctx context.Context, k8sClient client.Client, namespace string, app *appv1alpha1.Application) *imageUpdaterApi.ImageUpdater {
+	By("creating ImageUpdater CR in " + namespace)
+	updateStrategy := "semver"
+	iu := &imageUpdaterApi.ImageUpdater{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "image-updater",
+			Namespace: namespace,
+		},
+		Spec: imageUpdaterApi.ImageUpdaterSpec{
+			ApplicationRefs: []imageUpdaterApi.ApplicationRef{
+				{
+					NamePattern: "app*",
+					Images: []imageUpdaterApi.ImageConfig{
+						{
+							Alias:     "guestbook",
+							ImageName: "quay.io/dkarpele/my-guestbook:~29437546.0",
+							CommonUpdateSettings: &imageUpdaterApi.CommonUpdateSettings{
+								UpdateStrategy: &updateStrategy,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	Expect(k8sClient.Create(ctx, iu)).To(Succeed())
+
+	By("ensuring Application image in " + namespace + " has `29437546.0` version after update")
+	triggerRefresh := iuFixture.TriggerArgoCDRefresh(ctx, k8sClient, app)
+	Eventually(func() string {
+		err := k8sClient.Get(ctx, client.ObjectKeyFromObject(app), app)
+		if err != nil {
+			return "" // Let Eventually retry on error
+		}
+
+		// Trigger ArgoCD refresh periodically to force immediate git check
+		triggerRefresh()
+
+		// Nil-safe check: The Kustomize block is only added by the Image Updater after its first run.
+		// We must check that it and its Images field exist before trying to access them.
+		if app.Spec.Source.Kustomize != nil && len(app.Spec.Source.Kustomize.Images) > 0 {
+			return string(app.Spec.Source.Kustomize.Images[0])
+		}
+
+		// Return an empty string to signify the condition is not yet met.
+		return ""
+	}, "5m", "3s").Should(Equal("quay.io/dkarpele/my-guestbook:29437546.0"))
+
+	return iu
+}


### PR DESCRIPTION
`#### Option 2: Install into a separate namespace` https://github.com/argoproj-labs/argocd-image-updater/blob/master/docs/install/installation.md#option-2-install-into-a-separate-namespace can not be tested in the current infrastructure because ArgoCD Operator doesn't support cross-namespaces installation (Argocd in one ns, Image Updater in another).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded E2E coverage for Image Updater across multiple namespaces (dev + QE).
  * Added a new cluster-wide mode E2E test validating operator, Argo CD, and Image Updater behavior.
  * Introduced test helpers to streamline resource setup, verification, and improved cleanup/debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->