### PR TITLE
test(e2e): create pull_request_target for GH PR workflow

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -15,6 +15,9 @@ on:
   # workflow_dispatch lets maintainers trigger the full suite (including E2E)
   # manually from the Actions UI or via the GitHub CLI.
   workflow_dispatch:
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
   check-go:
@@ -170,6 +173,15 @@ jobs:
           files: coverage.out
   test-e2e:
     name: Run end-to-end tests
+    # At most one E2E run per PR at a time.  When a pull_request_target run
+    # (triggered by the "ok-to-test" label) starts while a pull_request run
+    # for the same PR is already in flight, the older run is cancelled so the
+    # new one — which carries real secrets — takes its place immediately.
+    # For workflow_dispatch and push events github.event.pull_request.number is
+    # empty, so the group falls back to github.ref (e.g. refs/heads/master).
+    concurrency:
+      group: e2e-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     # Run for every pull_request (secrets absent → credential tests skip gracefully).
     # Run for pull_request_target ONLY when a maintainer adds the "ok-to-test"
     # label (secrets present → credential tests execute).

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -3,10 +3,24 @@ on:
   pull_request:
     branches:
     - 'master'
+  # pull_request_target runs in the context of the BASE repo, so repository
+  # secrets ARE available. It fires when a maintainer applies the
+  # "ok-to-test" label to a PR (including fork PRs), allowing E2E tests that
+  # require credentials to run.  The label acts as the security gate: only
+  # maintainers with "Triage" role or above can apply it.
+  pull_request_target:
+    types: [labeled]
+    branches:
+    - 'master'
+  # workflow_dispatch lets maintainers trigger the full suite (including E2E)
+  # manually from the Actions UI or via the GitHub CLI.
+  workflow_dispatch:
 
 jobs:
   check-go:
     name: Ensure Go modules synchronicity
+    # Skip on label events — this job is already covered by the pull_request run.
+    if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -24,6 +38,7 @@ jobs:
           git diff --exit-code -- .
   codegen:
     name: Run codegen
+    if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -51,6 +66,7 @@ jobs:
           git diff --exit-code -- . ':!go.sum' ':!go.mod' ':!assets/swagger.json' | tee codegen.patch
   lint:
     name: Ensure code is correctly linted
+    if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -74,6 +90,7 @@ jobs:
           working-directory: registry-scanner
   test:
     name: Ensure unit tests are passing
+    if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -122,6 +139,7 @@ jobs:
 
   registry-scanner:
     name: Ensure registry-scanner Go modules synchronicity and run tests
+    if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -152,6 +170,14 @@ jobs:
           files: coverage.out
   test-e2e:
     name: Run end-to-end tests
+    # Run for every pull_request (secrets absent → credential tests skip gracefully).
+    # Run for pull_request_target ONLY when a maintainer adds the "ok-to-test"
+    # label (secrets present → credential tests execute).
+    # Run unconditionally for workflow_dispatch (manual trigger by maintainers).
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'pull_request_target' && github.event.label.name == 'ok-to-test')
     runs-on: ubuntu-latest
     timeout-minutes: 100
     strategy:
@@ -174,6 +200,13 @@ jobs:
           df -h /
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          # For pull_request_target, check out the contributor's commit rather
+          # than the base branch (which is the default for that event).
+          # github.event.pull_request.head.sha is set for both pull_request and
+          # pull_request_target; it falls back to github.sha for workflow_dispatch.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Setup Golang
         uses: actions/setup-go@v6
         with:
@@ -201,6 +234,13 @@ jobs:
           ARGOCD_CLUSTER_CONFIG_NAMESPACES: argocd-e2e-cluster-config, argocd-operator-system
           K3D_CLUSTER_NAME: k3s-default
           LOCAL: false
+          # GitHub PR E2E credentials.
+          # When absent (e.g. fork PRs where secrets are not exposed) the
+          # test is automatically skipped via Ginkgo's Skip() call.
+          E2E_GITHUB_TOKEN:  ${{ secrets.E2E_GITHUB_TOKEN }}
+          E2E_GITHUB_OWNER:  ${{ secrets.E2E_GITHUB_OWNER }}
+          E2E_GITHUB_REPO:   ${{ secrets.E2E_GITHUB_REPO }}
+          E2E_GITHUB_BRANCH: ${{ secrets.E2E_GITHUB_BRANCH }}
         run: |
           set -o pipefail
           make -C test/ginkgo test-e2e 2>&1 | tee /tmp/e2e-test-ginkgo.log

--- a/test/ginkgo/Makefile
+++ b/test/ginkgo/Makefile
@@ -106,7 +106,7 @@ configure-docker-daemon: ## Configure Docker daemon.json to allow insecure regis
 
 k3d-image-import: ## Import local image to k3d cluster
 	@echo "--- Importing image $(ARGOCD_IMAGE_UPDATER_IMAGE) to k3d cluster $(K3D_CLUSTER_NAME) ---"
-	$(K3D) image import $(ARGOCD_IMAGE_UPDATER_IMAGE) -c $(K3D_CLUSTER_NAME)
+	$(K3D) image import $(ARGOCD_IMAGE_UPDATER_IMAGE) -c $(K3D_CLUSTER_NAME) --mode=direct
 
 # Currently run only parallel tests because we don't have sequential tests yet.
 test-e2e: ## Build local image updater, deploy operator, and run parallel e2e tests.

--- a/test/ginkgo/README.md
+++ b/test/ginkgo/README.md
@@ -48,6 +48,80 @@ make -C test/ginkgo test-e2e
 make -C test/ginkgo k3d-cluster-delete
 ```
 
+### Running SCM pull-request E2E tests
+
+Tests `1-009` (GitHub PR) verify the Image Updater's
+write-back mode that opens a pull request on an external SCM instead of
+committing directly to a branch. Because they push real branches and create
+real PRs/MRs, they require credentials for an actual GitHub repository.
+
+Both tests **skip gracefully** (via Ginkgo's `Skip()`) when the required
+environment variables are absent, so they never block the rest of the test
+suite.
+
+#### Prerequisites — target repository
+
+You need a repository on GitHub that the Image Updater can use as the
+write-back target:
+
+* **GitHub**: any repository where you have write access, with at least one commit on the base branch (e.g. `main`).
+
+The test pushes a branch and opens a PR against that repository.  It cleans
+up after itself (closes the PR and deletes the branch in `AfterEach`), but
+you should use a **dedicated test repository** to avoid polluting a production
+repo.
+
+#### Running locally
+
+Pass the credentials as environment variables to the `make test-e2e` target:
+
+**GitHub (test 1-009)**
+
+```bash
+make -C test/ginkgo test-e2e \
+  E2E_GITHUB_TOKEN=ghp_...          \   # PAT with repo + pull_requests scopes
+  E2E_GITHUB_OWNER=<user-or-org>    \   # owner of the target repo
+  E2E_GITHUB_REPO=<repo-name>       \   # repository name (not the full URL)
+  E2E_GITHUB_BRANCH=main                # base branch for the PR (default: main)
+```
+
+#### Running in CI — `pull_request_target` + label gate
+
+The CI workflow (`ci-tests.yaml`) uses GitHub Actions'
+[`pull_request_target`](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target)
+event to expose repository secrets to trusted fork PRs.
+
+| CI trigger                            | Secrets available               | Credential tests |
+|---------------------------------------|---------------------------------|------------------|
+| `pull_request` from a fork            | No                              | Skipped          |
+| `pull_request` from the same repo     | Yes                             | Run              |
+| Maintainer applies `ok-to-test` label | Yes (via `pull_request_target`) | Run              |
+| `workflow_dispatch` (manual)          | Yes                             | Run              |
+
+**Security model**: `pull_request_target` runs in the context of the *base*
+repository, so repository secrets are available even for fork PRs. The
+`ok-to-test` label is the security gate — only users with *Triage* role or
+above on the repository can apply it, preventing untrusted fork code from
+self-triggering a secrets-bearing run.
+
+#### For maintainers — approving a fork PR to run the credential tests
+
+1. Review the PR to confirm it does not contain malicious code.
+2. Apply the `ok-to-test` label to the PR:
+   GitHub Actions fires a `pull_request_target` event, which starts the
+   `test-e2e` job with all repository secrets available.
+3. Alternatively, trigger the full suite manually at any time.
+
+#### For external contributors
+
+You do **not** need any SCM credentials to contribute. The credential tests
+skip automatically when the environment variables are absent. Your PR will pass
+the full test suite without them.
+
+If you want to validate your changes to the PR/MR write-back code locally
+before submitting, create a personal test repository and pass your own
+credentials to `make test-e2e` as shown above.
+
 ### Run a specific test:
 
 ```bash


### PR DESCRIPTION
To enable github PR e2e testing this should be merged to master first. After that rebase #1609 onto new master

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI: end-to-end tests run in a more secure, controlled environment with injected credentials, refined triggers to reduce unnecessary runs, a label-based approval gate for elevated workflows, and concurrency controls to cancel overlapping runs.
* **Tests**
  * Test environment image import updated for more reliable and deterministic e2e setup.
* **Documentation**
  * Added guidance for running credential-based pull-request e2e tests locally and in CI, including prerequisites and maintainer instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->