### PR TITLE
fix(test): add --no-gpg-sign when creating the unsigned commit to prevent the global git config commit.gpgsign=true

### DIFF
--- a/ext/git/git_test.go
+++ b/ext/git/git_test.go
@@ -823,7 +823,7 @@ func setupRepoWithSignedCommit(t *testing.T) (repoPath, signedSHA, unsignedSHA s
 	signedSHA, err = runCmdOut(repoPath, "git", "rev-parse", "HEAD")
 	require.NoError(t, err)
 
-	require.NoError(t, runCmd(repoPath, "git", "commit", "--allow-empty", "-m", "unsigned commit"))
+	require.NoError(t, runCmd(repoPath, "git", "commit", "--allow-empty", "--no-gpg-sign", "-m", "unsigned commit"))
 	unsignedSHA, err = runCmdOut(repoPath, "git", "rev-parse", "HEAD")
 	require.NoError(t, err)
 


### PR DESCRIPTION
This test verifies an unsigned commit and expects empty output. But when the global git config has commit.gpgsign=true, the commit will be signed, causing the test to fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced test configuration to ensure unsigned commits are properly created without cryptographic signatures, improving validation of commit handling across different signing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->