### PR TITLE
chore(deps): bump go version from 1.25.5 to 1.25.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/argoproj-labs/argocd-image-updater
 
-go 1.25.5
+go 1.25.9
 
 require (
 	github.com/argoproj-labs/argocd-image-updater/registry-scanner v1.1.1

--- a/registry-scanner/go.mod
+++ b/registry-scanner/go.mod
@@ -1,6 +1,6 @@
 module github.com/argoproj-labs/argocd-image-updater/registry-scanner
 
-go 1.25.5
+go 1.25.9
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0

--- a/test/ginkgo/go.mod
+++ b/test/ginkgo/go.mod
@@ -1,6 +1,6 @@
 module github.com/argoproj-labs/argocd-image-updater/test/ginkgo
 
-go 1.25.5
+go 1.25.9
 
 require (
 	github.com/argoproj-labs/argocd-image-updater v1.1.0


### PR DESCRIPTION
https://go.dev/doc/devel/release#go1.25.minor