### PR TITLE
chore: test/ginkgo: bump image-updater from v1.1.1 to v1.2.0

### DIFF
--- a/test/ginkgo/go.mod
+++ b/test/ginkgo/go.mod
@@ -3,7 +3,7 @@ module github.com/argoproj-labs/argocd-image-updater/test/ginkgo
 go 1.25.9
 
 require (
-	github.com/argoproj-labs/argocd-image-updater v1.1.1
+	github.com/argoproj-labs/argocd-image-updater v1.2.0
 	github.com/argoproj-labs/argocd-operator v0.17.0
 	github.com/argoproj/argo-cd/v3 v3.3.8
 	github.com/argoproj/gitops-engine v0.7.1-0.20251217140045-5baed5604d2d


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a test dependency (argocd-image-updater) from v1.1.1 to v1.2.0 to keep test tooling current.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->