### PR TITLE
fix: allow webhook traffic through NetworkPolicy (#1544)

### DIFF
--- a/config/install.yaml
+++ b/config/install.yaml
@@ -1168,3 +1168,26 @@ spec:
       control-plane: argocd-image-updater-controller
   policyTypes:
   - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: argocd-image-updater-controller
+    control-plane: argocd-image-updater-controller
+  name: allow-webhook-traffic
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          webhooks: enabled
+    ports:
+    - port: 8082
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      control-plane: argocd-image-updater-controller
+  policyTypes:
+  - Ingress

--- a/config/network-policy/allow-webhook-traffic.yaml
+++ b/config/network-policy/allow-webhook-traffic.yaml
@@ -1,0 +1,26 @@
+# This NetworkPolicy allows ingress traffic to the webhook server
+# from Pods running in namespaces labeled with 'webhooks: enabled'. Only Pods in those
+# namespaces are able to send webhook notifications to the controller.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    control-plane: argocd-image-updater-controller
+    app.kubernetes.io/name: argocd-image-updater-controller
+    app.kubernetes.io/managed-by: kustomize
+  name: allow-webhook-traffic
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: argocd-image-updater-controller
+  policyTypes:
+    - Ingress
+  ingress:
+    # This allows ingress traffic from any namespace with the label webhooks: enabled
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            webhooks: enabled  # Only from namespaces with this label
+      ports:
+        - port: 8082
+          protocol: TCP

--- a/config/network-policy/kustomization.yaml
+++ b/config/network-policy/kustomization.yaml
@@ -1,2 +1,3 @@
 resources:
 - allow-metrics-traffic.yaml
+- allow-webhook-traffic.yaml

--- a/docs/configuration/webhook.md
+++ b/docs/configuration/webhook.md
@@ -274,11 +274,28 @@ not be able to use this method.
 
 ## Exposing the Server
 
-To expose the webhook server we have provided a service and ingress to get 
-started. These manifests are not applied with `install.yaml` so you will need 
-to apply them yourself. 
+To expose the webhook server we have provided a service and ingress to get
+started. These manifests are not applied with `install.yaml` so you will need
+to apply them yourself.
 
-They are located in the `manifets/base/networking` directory.
+They are located in the `config/networking` directory.
+
+### NetworkPolicy Considerations
+
+The default installation includes a NetworkPolicy for the Image Updater controller.
+If you expose the webhook server through the provided Service and Ingress manifests,
+make sure the source namespace is allowed by the webhook NetworkPolicy.
+
+By default, the webhook Service exposes port 8080 and forwards traffic to the
+controller webhook port 8082. If you use the default NetworkPolicy, label the
+namespace of your ingress controller or webhook client with:
+
+```bash
+kubectl label namespace <namespace> webhooks=enabled
+```
+
+If you customize webhook.port or the Service targetPort, update the NetworkPolicy
+port accordingly.
 
 ## Rate Limiting
 


### PR DESCRIPTION
## Summary

This PR addresses #1544 by documenting the NetworkPolicy requirement for the webhook server and adding a NetworkPolicy manifest that allows webhook traffic to the argocd-image-updater controller.

The original issue could probably be fixed with documentation only, because users can create their own NetworkPolicy when exposing the webhook server. However, the default installation already includes NetworkPolicy resources for the controller, so exposing the webhook server with the provided Service and Ingress manifests does not work unless traffic to the webhook port is explicitly allowed.

For that reason, I added a webhook-specific NetworkPolicy in addition to the documentation update.

If maintainers prefer to keep this as a docs-only change, I can remove the manifest changes and keep only the documentation update.

## Notes

The webhook Service exposes port `8080` and forwards traffic to the controller webhook port `8082`, so the NetworkPolicy allows traffic to port `8082`.


Closes: #1544

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added network policy configuration for secure webhook traffic handling with built-in port configuration and namespace-level access controls.

* **Documentation**
  * Updated webhook setup documentation with comprehensive instructions, default port information, and guidance for custom webhook port configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->