### PR TITLE
fix(webhook): normalize ghcr repository casing

### DIFF
--- a/pkg/webhook/ghcr.go
+++ b/pkg/webhook/ghcr.go
@@ -135,8 +135,10 @@ func (g *GHCRWebhook) Parse(r *http.Request) (*argocd.WebhookEvent, error) {
 		return nil, fmt.Errorf("tag not found in webhook payload")
 	}
 
-	// Construct repository name: owner/package
-	repository := fmt.Sprintf("%s/%s", payload.Package.Owner.Login, payload.Package.Name)
+	// GHCR webhook payloads can preserve the GitHub owner casing, while OCI
+	// image references are normalized to lowercase. Normalize here so webhook
+	// matching works against image names from manifests.
+	repository := strings.ToLower(fmt.Sprintf("%s/%s", payload.Package.Owner.Login, payload.Package.Name))
 
 	return &argocd.WebhookEvent{
 		RegistryURL: "ghcr.io",

--- a/pkg/webhook/ghcr_test.go
+++ b/pkg/webhook/ghcr_test.go
@@ -242,6 +242,30 @@ func TestGHCRWebhook_Parse(t *testing.T) {
 			expectError:  false,
 		},
 		{
+			name: "normalizes owner and package casing to lowercase",
+			payload: `{
+				"action": "published",
+				"package": {
+					"name": "MyApp",
+					"package_type": "container",
+					"owner": {
+						"login": "MyOrg"
+					},
+					"package_version": {
+						"name": "v1.2.3",
+						"container_metadata": {
+							"tag": {
+								"name": "v1.2.3"
+							}
+						}
+					}
+				}
+			}`,
+			expectedRepo: "myorg/myapp",
+			expectedTag:  "v1.2.3",
+			expectError:  false,
+		},
+		{
 			name: "fallback to package version name when tag name is missing",
 			payload: `{
 				"action": "published",

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -105,6 +105,34 @@ func TestWebhookHandler_ProcessWebhook(t *testing.T) {
 			expectError:  false,
 		},
 		{
+			name:         "valid GHCR webhook with mixed-case owner and package",
+			registryType: "ghcr.io",
+			payload: `{
+				"action": "published",
+				"package": {
+					"name": "MyApp",
+					"package_type": "container",
+					"owner": {
+						"login": "MyUser"
+					},
+					"package_version": {
+						"name": "v1.0.0",
+						"container_metadata": {
+							"tag": {
+								"name": "v1.0.0"
+							}
+						}
+					}
+				}
+			}`,
+			headers: map[string]string{
+				"X-GitHub-Event": "package",
+			},
+			expectedRepo: "myuser/myapp",
+			expectedTag:  "v1.0.0",
+			expectError:  false,
+		},
+		{
 			name:         "missing registry type parameter",
 			registryType: "",
 			payload: `{


### PR DESCRIPTION
## Summary

GHCR webhook payloads can preserve the GitHub owner/package casing, while the
configured OCI image references are matched in lowercase form.

This causes webhook-triggered updates to be skipped when the webhook repository
and configured repository differ only by case, for example:

- webhook: `MyOrg/MyRepo/myimage`
- configured image: `myorg/myrepo/myimage`

In that case, the webhook event is accepted, but the image is filtered out
before the application update cycle starts.

## What changed

- normalize the GHCR webhook repository (`owner/package`) to lowercase before
  building the `WebhookEvent`
- add a GHCR parser test covering mixed-case owner/package input
- add a higher-level webhook handler test covering the same normalization path

## Scope

This change only affects the GHCR webhook path.

It does not change normal polling behavior, and it does not change matching for
other webhook providers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GHCR webhook events now normalize repository identifiers to lowercase to ensure consistent, case-insensitive matching with OCI-style registry names.

* **Tests**
  * Added and extended tests to verify repository owner/name casing is normalized across parsing and handler flows for GHCR webhook payloads.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/argoproj-labs/argocd-image-updater/pull/1639)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->