### PR TITLE
chore(ginkgo): remove role and rolebinding creation

### DIFF
--- a/test/ginkgo/sequential/1-008-app-in-any-ns_test.go
+++ b/test/ginkgo/sequential/1-008-app-in-any-ns_test.go
@@ -212,10 +212,6 @@ var _ = Describe("ArgoCD Image Updater Sequential E2E Tests", func() {
 			Eventually(statefulSet).Should(ssFixture.HaveReplicas(1))
 			Eventually(statefulSet, "3m", "3s").Should(ssFixture.HaveReadyReplicas(1))
 
-			// TODO: Remove after ArgoCD Operator fix https://github.com/argoproj-labs/argocd-operator/pull/2172
-			createImageUpdaterRoleAndBinding(ctx, k8sClient, nsDev.Name, ns.Name)
-			createImageUpdaterRoleAndBinding(ctx, k8sClient, nsQE.Name, ns.Name)
-
 			createAppProject(ctx, k8sClient, nsDev.Name, ns.Name)
 			createAppProject(ctx, k8sClient, nsQE.Name, ns.Name)
 

--- a/test/ginkgo/sequential/1-009-cluster-wide-mode_test.go
+++ b/test/ginkgo/sequential/1-009-cluster-wide-mode_test.go
@@ -225,35 +225,6 @@ var _ = Describe("ArgoCD Image Updater Sequential E2E Tests", func() {
 			Eventually(statefulSet).Should(ssFixture.HaveReplicas(1))
 			Eventually(statefulSet, "3m", "3s").Should(ssFixture.HaveReadyReplicas(1))
 
-			// TODO: Remove after ArgoCD Operator fix https://github.com/argoproj-labs/argocd-operator/pull/2172
-			// Use ns.Name as a suffix to keep cluster-scoped names unique across parallel test runs.
-			By("creating ClusterRole and ClusterRoleBinding for Image Updater ServiceAccount (cluster-wide mode)")
-			clusterRoleName = "argocd-image-updater-manager-role-" + ns.Name
-			clusterRole := &rbacv1.ClusterRole{
-				ObjectMeta: metav1.ObjectMeta{Name: clusterRoleName},
-				Rules:      imageUpdaterManagerPolicyRules(),
-			}
-			Expect(k8sClient.Create(ctx, clusterRole)).To(Succeed())
-
-			clusterRoleBinding = &rbacv1.ClusterRoleBinding{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "argocd-image-updater-manager-rolebinding-" + ns.Name,
-				},
-				RoleRef: rbacv1.RoleRef{
-					APIGroup: "rbac.authorization.k8s.io",
-					Kind:     "ClusterRole",
-					Name:     clusterRoleName,
-				},
-				Subjects: []rbacv1.Subject{
-					{
-						Kind:      "ServiceAccount",
-						Name:      "argocd-argocd-image-updater-controller",
-						Namespace: ns.Name,
-					},
-				},
-			}
-			Expect(k8sClient.Create(ctx, clusterRoleBinding)).To(Succeed())
-
 			createAppProject(ctx, k8sClient, nsDev.Name, ns.Name)
 			createAppProject(ctx, k8sClient, nsQE.Name, ns.Name)
 

--- a/test/ginkgo/sequential/helpers.go
+++ b/test/ginkgo/sequential/helpers.go
@@ -45,43 +45,6 @@ func imageUpdaterManagerPolicyRules() []rbacv1.PolicyRule {
 	}
 }
 
-// createImageUpdaterRoleAndBinding creates a namespace-scoped Role and RoleBinding
-// in targetNamespace granting the Image Updater ServiceAccount in controllerNamespace
-// the permissions it needs to manage ImageUpdater CRs and Applications.
-//
-// TODO: Remove after ArgoCD Operator fix https://github.com/argoproj-labs/argocd-operator/pull/2172
-func createImageUpdaterRoleAndBinding(ctx context.Context, k8sClient client.Client, targetNamespace, controllerNamespace string) {
-	By("creating Role and RoleBinding in " + targetNamespace + " for Image Updater ServiceAccount")
-	role := &rbacv1.Role{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "argocd-image-updater-manager-role",
-			Namespace: targetNamespace,
-		},
-		Rules: imageUpdaterManagerPolicyRules(),
-	}
-	Expect(k8sClient.Create(ctx, role)).To(Succeed())
-
-	roleBinding := &rbacv1.RoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "argocd-image-updater-manager-rolebinding",
-			Namespace: targetNamespace,
-		},
-		RoleRef: rbacv1.RoleRef{
-			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "Role",
-			Name:     "argocd-image-updater-manager-role",
-		},
-		Subjects: []rbacv1.Subject{
-			{
-				Kind:      "ServiceAccount",
-				Name:      "argocd-argocd-image-updater-controller",
-				Namespace: controllerNamespace,
-			},
-		},
-	}
-	Expect(k8sClient.Create(ctx, roleBinding)).To(Succeed())
-}
-
 // createAppProject creates an ArgoCD AppProject named after sourceNamespace,
 // hosted in argoCDNamespace, permitting all sources and destinations.
 func createAppProject(ctx context.Context, k8sClient client.Client, sourceNamespace, argoCDNamespace string) {


### PR DESCRIPTION
In https://github.com/argoproj-labs/argocd-operator/pull/2172 we added Role and RB creation in argocd operator. Following TODO we should remove related code from Image Updater

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified test setup by removing manual Image Updater controller role and binding provisioning from sequential E2E tests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/argoproj-labs/argocd-image-updater/pull/1642)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->