### PR TITLE
fix(git): ignore injected GIT_CONFIG_* for git subprocesses

### DIFF
--- a/ext/git/client.go
+++ b/ext/git/client.go
@@ -789,7 +789,7 @@ func (m *nativeGitClient) runCmdOutput(ctx context.Context, cmd *exec.Cmd, ropts
 	log := log.LoggerFromContext(ctx)
 
 	cmd.Dir = m.root
-	cmd.Env = append(os.Environ(), cmd.Env...)
+	cmd.Env = append(sanitizedGitEnv(os.Environ()), cmd.Env...)
 	// Set $HOME to nowhere, so we can be execute Git regardless of any external
 	// authentication keys (e.g. in ~/.ssh) -- this is especially important for
 	// running tests on local machines and/or CircleCI.

--- a/ext/git/client_test.go
+++ b/ext/git/client_test.go
@@ -38,6 +38,7 @@ func TestMain(m *testing.M) {
 func runCmd(workingDir string, name string, args ...string) error {
 	cmd := exec.Command(name, args...)
 	cmd.Dir = workingDir
+	cmd.Env = sanitizedGitEnv(os.Environ())
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()

--- a/ext/git/env.go
+++ b/ext/git/env.go
@@ -1,0 +1,30 @@
+package git
+
+import "strings"
+
+// sanitizedGitEnv removes process-level Git config injection that would make
+// git subprocess behavior depend on the caller environment instead of the repo
+// or explicit command options.
+func sanitizedGitEnv(env []string) []string {
+	filtered := make([]string, 0, len(env))
+	for _, kv := range env {
+		key := kv
+		if idx := strings.IndexByte(kv, '='); idx >= 0 {
+			key = kv[:idx]
+		}
+		if shouldDropGitEnv(key) {
+			continue
+		}
+		filtered = append(filtered, kv)
+	}
+	return filtered
+}
+
+func shouldDropGitEnv(key string) bool {
+	switch key {
+	case "GIT_CONFIG", "GIT_CONFIG_COUNT", "GIT_CONFIG_GLOBAL", "GIT_CONFIG_NOSYSTEM", "GIT_CONFIG_PARAMETERS", "GIT_CONFIG_SYSTEM":
+		return true
+	}
+
+	return strings.HasPrefix(key, "GIT_CONFIG_KEY_") || strings.HasPrefix(key, "GIT_CONFIG_VALUE_")
+}

--- a/ext/git/git_test.go
+++ b/ext/git/git_test.go
@@ -741,6 +741,7 @@ func addGitVerifyWrapperToPath(t *testing.T) {
 func runCmdOut(workingDir, name string, args ...string) (string, error) {
 	cmd := exec.Command(name, args...)
 	cmd.Dir = workingDir
+	cmd.Env = sanitizedGitEnv(os.Environ())
 	out, err := cmd.Output()
 	return strings.TrimSpace(string(out)), err
 }

--- a/ext/git/writer_test.go
+++ b/ext/git/writer_test.go
@@ -174,6 +174,23 @@ func TestCommit(t *testing.T) {
 		assert.Contains(t, body, "Signed-off-by:")
 	})
 
+	t.Run("IgnoresExternalGitConfigParameters", func(t *testing.T) {
+		t.Setenv("GIT_CONFIG_PARAMETERS", "'commit.gpgsign=true'")
+
+		dir, client := newWriterTestRepo(t)
+		stageFile(t, dir, "f.txt", "content")
+
+		err := client.Commit(ctx, "*", &CommitOptions{
+			CommitMessageText: "signed off",
+			SignOff:           true,
+		})
+		assert.NoError(t, err)
+
+		signatureStatus, err := runCmdOut(dir, "git", "log", "-1", "--format=%G?")
+		assert.NoError(t, err)
+		assert.Equal(t, "N", signatureStatus)
+	})
+
 	t.Run("SSHSigning", func(t *testing.T) {
 		// Reuse setupRepoWithSignedCommit which already configures SSH signing
 		// in the local repo config (gpg.format, user.signingkey, allowed signers).


### PR DESCRIPTION
This fixes a pretty annoying env leak in `ext/git`.

If `GIT_CONFIG_PARAMETERS` is exported, git subprocesses can inherit `commit.gpgsign=true` and `user.signingkey`. Then `ext/git` tests can blow up on a normal dev machine, because the git client also forces `HOME=/dev/null`.

Repro:
1. `export GIT_CONFIG_PARAMETERS="'commit.gpgsign=true' 'user.signingkey=F7BC234BE02886EE'"`
2. `go test ./ext/git -run 'TestCommit/(SignOff|SSHSigning)' -count=1`

On current `master` this fails with `gpg: Fatal: can't create directory '/dev/null/.gnupg'`.

Fix is simple:
1. drop injected `GIT_CONFIG_*` vars before running git subprocesses
2. do the same in the test helpers
3. add a regression test for `GIT_CONFIG_PARAMETERS`

Checked with `make test`. Also re-ran the same repro on upstream `master` and on this branch. `master` fails, this branch passes. small patch, but it plugs the leak nicely.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Git subprocesses now execute with a filtered set of environment variables, excluding configuration-related entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->