### PR TITLE
ci: add unit-tests flag to Codecov coverage uploads

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,6 +3,9 @@ ignore:
 - "**/mocks/*.go"
 - "test/**/*"
 - "vendor/**/*"
+flags:
+  unit-tests:
+    carryforward: true
 coverage:
   status:
     # we've found this not to be useful

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -112,6 +112,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.out
+          flags: unit-tests
 
 # Comment out test-manifests job for now since image-updater crd schema is not available to the kubeconform tool yet
 #  test-manifests:
@@ -171,6 +172,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.out
+          flags: unit-tests
   test-e2e:
     name: Run end-to-end tests
     # At most one E2E run per PR at a time.  When a pull_request_target run


### PR DESCRIPTION
## Summary

- Add `flags: unit-tests` to both Codecov upload steps (main module and registry-scanner)
- Define `unit-tests` flag in `.codecov.yml` with `carryforward: true`

This enables flag-filtered coverage views on Codecov, allowing coverage from unit tests to be tracked independently.

## Changes

### `.github/workflows/ci-tests.yaml`
- Add `flags: unit-tests` to the `test` job's codecov-action upload
- Add `flags: unit-tests` to the `registry-scanner` job's codecov-action upload

### `.codecov.yml`
- Add `flags:` section defining `unit-tests` flag
- Flag excludes `test/` directory and enables `carryforward`

## Test plan
- [ ] Verify CI pipeline passes with the flagged coverage uploads
- [ ] Confirm `unit-tests` flag appears on Codecov
- [ ] Verify overall project coverage remains unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a "unit-tests" coverage flag with carryforward enabled to coverage configuration.
  * Updated CI upload steps to include the new "unit-tests" coverage flag so unit-test coverage is reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->