### PR TITLE
ci: run CI tests on push to master

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -1,5 +1,8 @@
 name: Integration tests
 on:
+  push:
+    branches:
+    - 'master'
   pull_request:
     branches:
     - 'master'
@@ -22,8 +25,8 @@ permissions:
 jobs:
   check-go:
     name: Ensure Go modules synchronicity
-    # Skip on label events — this job is already covered by the pull_request run.
-    if: github.event_name != 'pull_request_target'
+    # Skip on label events and push-to-master (already passed pre-merge).
+    if: github.event_name != 'pull_request_target' && github.event_name != 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -41,7 +44,7 @@ jobs:
           git diff --exit-code -- .
   codegen:
     name: Run codegen
-    if: github.event_name != 'pull_request_target'
+    if: github.event_name != 'pull_request_target' && github.event_name != 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -69,7 +72,7 @@ jobs:
           git diff --exit-code -- . ':!go.sum' ':!go.mod' ':!assets/swagger.json' | tee codegen.patch
   lint:
     name: Ensure code is correctly linted
-    if: github.event_name != 'pull_request_target'
+    if: github.event_name != 'pull_request_target' && github.event_name != 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- Adds `push` trigger for the `master` branch to the CI tests workflow
- Without this, the Codecov upload with the `unit-tests` flag only runs on PRs and never against the default branch, leaving the flag at 0% on Codecov
- This ensures coverage data is uploaded on every merge to master, keeping Codecov's flag-filtered views up to date

## Test plan
- [ ] Verify CI workflow runs on the next merge to master
- [ ] Confirm the `unit-tests` flag on Codecov shows non-zero coverage after the first push-triggered run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration by adding support for running automated checks on direct pushes to the main branch, expanding coverage beyond pull requests while ensuring selected jobs only run under the intended event types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->