### PR TITLE
feat(metrics): add webhook events counter labeled by registry type

### DIFF
--- a/.claude/agents/Claude.agent.md
+++ b/.claude/agents/Claude.agent.md
@@ -1,0 +1,9 @@
+---
+name: Claude
+description: Describe what this custom agent does and when to use it.
+tools: Read, Grep, Glob, Bash # specify the tools this agent can use. If not set, all enabled tools are allowed.
+---
+
+<!-- Tip: Use /create-agent in chat to generate content with agent assistance -->
+
+Define what this custom agent does, including its behavior, capabilities, and any specific instructions for its operation.

--- a/.claude/agents/Claude.agent.md
+++ b/.claude/agents/Claude.agent.md
@@ -1,9 +1,0 @@
----
-name: Claude
-description: Describe what this custom agent does and when to use it.
-tools: Read, Grep, Glob, Bash # specify the tools this agent can use. If not set, all enabled tools are allowed.
----
-
-<!-- Tip: Use /create-agent in chat to generate content with agent assistance -->
-
-Define what this custom agent does, including its behavior, capabilities, and any specific instructions for its operation.

--- a/.claude/agents/pr-writer.agent.md
+++ b/.claude/agents/pr-writer.agent.md
@@ -1,0 +1,40 @@
+---
+name: pr-writer
+description: Use this agent when you have an improvement idea for argocd-image-updater and want it researched, implemented, tested, and submitted as a GitHub PR. Describe your idea in plain English and the agent will handle the rest.
+tools: Read, Grep, Glob, Bash, Edit, Write
+---
+
+You are a Go contributor to the argocd-image-updater project. When given an improvement idea, you:
+
+1. **Research first** — grep the codebase to understand the relevant code paths before touching anything. Read the files that will need to change. Understand the existing patterns (testify for unit tests, Ginkgo for e2e, mockery for mocks).
+
+2. **Plan before coding** — briefly state what files you'll change and why, then wait for confirmation if the scope is large (>3 files).
+
+3. **Implement** — make the changes. Follow the existing code style strictly:
+   - No comments unless the WHY is non-obvious
+   - No error handling for scenarios that can't happen
+   - No new abstractions beyond what the task requires
+   - If changing `api/v1alpha1/imageupdater_types.go`, run `make manifests generate` afterward
+
+4. **Test** — run the relevant tests:
+   ```bash
+   KUBEBUILDER_ASSETS="$(./bin/setup-envtest use 1.31.0 --bin-dir bin -p path)" \
+     go test ./pkg/argocd/... -v
+   ```
+   Fix any failures before continuing. Also run `make lint-fix`.
+
+5. **Commit and PR** — create a focused, single-purpose commit, then open a PR:
+   ```bash
+   git checkout -b <short-kebab-description>
+   git add <specific files only>
+   git commit -m "<type>: <what and why>"
+   gh pr create --title "..." --body "..."
+   ```
+   PR body must include: what changed, why, and how to test it.
+
+Key architecture facts:
+- Two modules: root and `registry-scanner/` — run `go mod tidy` in both if you touch registry-scanner
+- Write-back methods: ArgoCD API (`pkg/argocd/argocd.go`) or Git (`pkg/argocd/git.go`)
+- Annotation-based config is legacy (`pkg/argocd/annotations.go`); prefer CRD-based config
+- Semver uses `github.com/Masterminds/semver/v3`
+- Mocks live in `mocks/` subdirectories, regenerated with `go generate ./...`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,107 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build and Development Commands
+
+```bash
+# Build the binary (output: dist/argocd-image-updater)
+make build
+
+# Run all unit tests (excludes test/, mocks/, e2e/)
+make test
+
+# Run tests with race detector
+make test-race
+
+# Run a single test package
+KUBEBUILDER_ASSETS="$(./bin/setup-envtest use 1.31.0 --bin-dir bin -p path)" \
+  go test ./pkg/argocd/... -run TestFunctionName -v
+
+# Lint
+make lint
+make lint-fix
+
+# Run the controller locally (requires kubeconfig)
+make run
+
+# Test image update behavior without a cluster
+go run ./cmd/main.go test nginx --semver-constraint ">=1.20"
+
+# Generate CRD manifests and DeepCopy code (required after changing api/v1alpha1 types)
+make manifests generate
+
+# Run Ginkgo E2E tests (requires a live cluster)
+make e2e-tests-sequential-ginkgo
+make e2e-tests-parallel-ginkgo
+```
+
+## Module Structure
+
+This repository contains two Go modules:
+
+- **Root module** (`github.com/argoproj-labs/argocd-image-updater`): The controller, CRD types, argocd integration, git write-back, and webhook server.
+- **`registry-scanner/` submodule** (`github.com/argoproj-labs/argocd-image-updater/registry-scanner`): Container registry querying, image/tag parsing, version constraint evaluation, and credential handling. Used as a `require` dependency by the root module.
+
+When changing types or logic in `registry-scanner/`, run `go mod tidy` in both the `registry-scanner/` directory and the root.
+
+## Architecture Overview
+
+### Core Reconciliation Loop
+
+`internal/controller/imageupdater_controller.go` — The `ImageUpdaterReconciler` is a controller-runtime reconciler that watches `ImageUpdater` CRs. On each reconcile it calls `RunImageUpdater` (in `reconcile.go`), which:
+
+1. Creates an `ArgoCDK8sClient` to fetch ArgoCD `Application` objects.
+2. Calls `argocd.FilterApplicationsForUpdate` to match Applications against `ApplicationRef` patterns/selectors in the CR.
+3. Fans out concurrently (bounded by `MaxConcurrentApps`) into `argocd.UpdateApplication` for each matched Application.
+4. Writes back changes either via the ArgoCD API parameter overrides or via a Git commit.
+
+### Configuration: CRD vs Annotations
+
+`ImageUpdater` CRs (`api/v1alpha1/imageupdater_types.go`) are the primary configuration mechanism. Each CR specifies:
+- `applicationRefs[]` — glob patterns + label selectors to match ArgoCD Applications
+- `commonUpdateSettings` — update strategy, semver constraints, tag filters, pull secrets
+- `writeBackConfig` — ArgoCD API or Git write-back, branch, commit message template
+- `images[]` — list of container images to track
+
+When `applicationRef.useAnnotations: true`, image configuration is read from ArgoCD Application annotations (`argocd-image-updater.argoproj.io/*`) instead of the CR — this is the legacy mode, handled in `pkg/argocd/annotations.go`.
+
+### Image Update Pipeline (`pkg/argocd/update.go`)
+
+`UpdateApplication` is the per-application update function:
+1. Reads the current deployed image tags from Application status.
+2. For each tracked image, queries the registry via `registry-scanner` for available tags.
+3. Evaluates version constraints (semver, latest, digest, name, etc.) against available tags.
+4. If a newer tag is found, calls the write-back method.
+
+### Write-back Methods (`pkg/argocd/`)
+
+- **ArgoCD API** (`argocd.go`, `update.go`): Updates Application `spec.source.helm.parameters` or `spec.source.kustomize.images` via `UpdateSpec`.
+- **Git** (`git.go`): Clones the target repo, modifies Helm values or Kustomize overlays, commits and pushes. Uses `ext/git` for git operations. Supports PR creation via `pkg/argocd/pr_github.go`, `pr_gitlab.go`.
+
+### Registry Scanner (`registry-scanner/pkg/`)
+
+- `registry/` — `RegistryEndpoint` holds connection config and credential cache. `GetTags` fetches available tags from the OCI distribution API.
+- `image/` — `ContainerImage` parses image identifiers (`registry/name:tag@digest`). `VersionConstraint` holds the update strategy + filter rules.
+- `tag/` — `ImageTag` represents a parsed tag with semver, metadata, and digest. `ImageTagList` holds the full list from a registry fetch.
+- `cache/` — in-memory tag cache with TTL to reduce registry API calls.
+
+### Webhook Server (`pkg/webhook/`)
+
+Handles registry push events from Docker Hub, Quay, GitHub Container Registry, Harbor, Alibaba ACR, and generic CloudEvents. On receiving a push event, it finds the matching ImageUpdater CRs and triggers an immediate reconcile instead of waiting for the poll interval.
+
+### Metrics (`pkg/metrics/`)
+
+Prometheus metrics for reconcile counts, image update counts, and per-CR application counts. Served on the metrics endpoint configured at startup.
+
+## Key Conventions
+
+**Testing**: Unit tests use `testify`. E2E tests use Ginkgo v2/Gomega. Mock generation via `mockery` — run `go generate ./...` in the relevant package. The `make test` target excludes `test/`, `mocks/`, and `e2e/` directories; run those separately.
+
+**CRD changes**: After modifying `api/v1alpha1/imageupdater_types.go`, always run `make manifests generate` to regenerate `zz_generated.deepcopy.go` and CRD YAML in `config/crd/bases/`. Commit both.
+
+**Registry credentials**: Pulled from Kubernetes Secrets at runtime via `pkg/kube/` — never hardcoded. The `registry-scanner/pkg/registry/creds.go` implements credential resolution from pull secrets.
+
+**Write-back target files**: Git write-back writes to `.argocd-source-<appname>_<namespace>.yaml` (or `.argocd-source-<appname>.yaml` without namespace) by default — see `pkg/common/constants.go`.
+
+**Semver constraints**: Uses `github.com/Masterminds/semver/v3`. Constraints in CRs/annotations follow Masterminds semver syntax (e.g., `>=1.20 <2.0`).

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -13,6 +13,7 @@ type Metrics struct {
 	Endpoint       *EndpointMetrics
 	ImageUpdaterCR *ImageUpdaterCRMetrics
 	Clients        *ClientMetrics
+	Webhook        *WebhookMetrics
 }
 
 var (
@@ -38,6 +39,11 @@ type ImageUpdaterCRMetrics struct {
 type ClientMetrics struct {
 	kubeAPIRequestsTotal       prometheus.Counter
 	kubeAPIRequestsErrorsTotal prometheus.Counter
+}
+
+// WebhookMetrics stores metrics for incoming webhook events
+type WebhookMetrics struct {
+	EventsTotal *prometheus.CounterVec
 }
 
 // NewEndpointMetrics returns a new endpoint metrics object
@@ -100,11 +106,24 @@ func NewClientMetrics() *ClientMetrics {
 	return metrics
 }
 
+// NewWebhookMetrics returns a new WebhookMetrics object
+func NewWebhookMetrics() *WebhookMetrics {
+	metrics := &WebhookMetrics{}
+
+	metrics.EventsTotal = promauto.With(crmetrics.Registry).NewCounterVec(prometheus.CounterOpts{
+		Name: "argocd_image_updater_webhook_events_total",
+		Help: "The total number of webhook events received, labeled by source registry type",
+	}, []string{"registry"})
+
+	return metrics
+}
+
 func NewMetrics() *Metrics {
 	return &Metrics{
 		Endpoint:       NewEndpointMetrics(),
 		ImageUpdaterCR: NewImageUpdaterCRMetrics(),
 		Clients:        NewClientMetrics(),
+		Webhook:        NewWebhookMetrics(),
 	}
 }
 
@@ -130,6 +149,14 @@ func Clients() *ClientMetrics {
 		return nil
 	}
 	return defaultMetrics.Clients
+}
+
+// WebhookM returns the global WebhookMetrics object
+func WebhookM() *WebhookMetrics {
+	if defaultMetrics == nil {
+		return nil
+	}
+	return defaultMetrics.Webhook
 }
 
 // IncreaseRequest increases the request counter of EndpointMetrics object
@@ -176,6 +203,11 @@ func (cpm *ClientMetrics) IncreaseK8sClientRequest(by int) {
 // IncreaseK8sClientError increases the number of failed K8s API requests
 func (cpm *ClientMetrics) IncreaseK8sClientError(by int) {
 	cpm.kubeAPIRequestsErrorsTotal.Add(float64(by))
+}
+
+// IncreaseWebhookEvent increments the webhook events counter for the given registry type
+func (wm *WebhookMetrics) IncreaseWebhookEvent(registryType string) {
+	wm.EventsTotal.WithLabelValues(registryType).Inc()
 }
 
 // InitMetrics initializes the global metrics objects

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -10,6 +10,28 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestWebhookMetrics(t *testing.T) {
+	t.Run("NewWebhookMetrics", func(t *testing.T) {
+		crmetrics.Registry = prometheus.NewRegistry()
+		wm := NewWebhookMetrics()
+		assert.NotNil(t, wm)
+		assert.NotNil(t, wm.EventsTotal)
+	})
+
+	t.Run("IncreaseWebhookEvent", func(t *testing.T) {
+		crmetrics.Registry = prometheus.NewRegistry()
+		wm := NewWebhookMetrics()
+
+		wm.IncreaseWebhookEvent("docker.io")
+		wm.IncreaseWebhookEvent("docker.io")
+		wm.IncreaseWebhookEvent("ghcr.io")
+
+		assert.Equal(t, float64(2), testutil.ToFloat64(wm.EventsTotal.WithLabelValues("docker.io")))
+		assert.Equal(t, float64(1), testutil.ToFloat64(wm.EventsTotal.WithLabelValues("ghcr.io")))
+		assert.Equal(t, float64(0), testutil.ToFloat64(wm.EventsTotal.WithLabelValues("quay.io")))
+	})
+}
+
 func TestMetricsInitialization(t *testing.T) {
 	t.Run("NewEndpointMetrics", func(t *testing.T) {
 		crmetrics.Registry = prometheus.NewRegistry()

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/argoproj-labs/argocd-image-updater/pkg/argocd"
+	"github.com/argoproj-labs/argocd-image-updater/pkg/metrics"
 )
 
 // maxWebhookBodySize limits the size of webhook request bodies to prevent
@@ -64,7 +65,14 @@ func (h *WebhookHandler) ProcessWebhook(r *http.Request) (*argocd.WebhookEvent, 
 	if err := handler.Validate(r); err != nil {
 		return nil, err
 	}
-	return handler.Parse(r)
+	event, err := handler.Parse(r)
+	if err != nil {
+		return nil, err
+	}
+	if wm := metrics.WebhookM(); wm != nil {
+		wm.IncreaseWebhookEvent(registryType)
+	}
+	return event, nil
 }
 
 // getSupportedRegistryTypes returns a list of all supported registry types from registered handlers

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -4,6 +4,14 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/argoproj-labs/argocd-image-updater/pkg/metrics"
 )
 
 func TestNewWebhookHandler(t *testing.T) {
@@ -246,6 +254,40 @@ func TestWebhookHandler_ProcessWebhookWithHeader(t *testing.T) {
 	} else if event.Tag != "v2.0.0" {
 		t.Errorf("expected tag to be 'v2.0.0', got %q", event.Tag)
 	}
+}
+
+func TestProcessWebhookIncrementsMetric(t *testing.T) {
+	crmetrics.Registry = prometheus.NewRegistry()
+	metrics.InitMetrics()
+
+	handler := NewWebhookHandler()
+	handler.RegisterHandler(NewDockerHubWebhook(""))
+	handler.RegisterHandler(NewQuayWebhook(""))
+
+	dockerPayload := `{"repository":{"repo_name":"myuser/myapp"},"push_data":{"tag":"v1.0.0"}}`
+	quayPayload := `{"repository":"myrepo","updated_tags":["latest"]}`
+
+	for _, tc := range []struct {
+		registryType string
+		payload      string
+	}{
+		{"docker.io", dockerPayload},
+		{"docker.io", dockerPayload},
+		{"quay.io", quayPayload},
+	} {
+		req := httptest.NewRequest("POST", "/webhook?type="+tc.registryType, strings.NewReader(tc.payload))
+		_, err := handler.ProcessWebhook(req)
+		if err != nil {
+			t.Fatalf("unexpected error for %s: %v", tc.registryType, err)
+		}
+	}
+
+	wm := metrics.WebhookM()
+	if wm == nil {
+		t.Fatal("expected WebhookMetrics to be initialized")
+	}
+	assert.Equal(t, float64(2), testutil.ToFloat64(wm.EventsTotal.WithLabelValues("docker.io")))
+	assert.Equal(t, float64(1), testutil.ToFloat64(wm.EventsTotal.WithLabelValues("quay.io")))
 }
 
 func TestWebhookHandler_detectRegistryType(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds a new Prometheus counter `argocd_image_updater_webhook_events_total` with a `registry` label to `pkg/metrics/`
- Increments the counter in `WebhookHandler.ProcessWebhook` whenever an event is successfully parsed, covering all six registry handlers (docker.io, quay.io, ghcr.io, harbor, aliyun-acr, cloudevents)
- Follows the same struct/accessor/method pattern as existing metrics (`EndpointMetrics`, `ClientMetrics`, etc.)

## Test plan

- [ ] `go test ./pkg/metrics/... ./pkg/webhook/... -v` — all existing tests pass, new `TestWebhookMetrics` and `TestProcessWebhookIncrementsMetric` tests added
- [ ] `go vet ./pkg/metrics/... ./pkg/webhook/...` — clean
- [ ] Manually verify metric appears in Prometheus scrape after deploying with a webhook-enabled config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Webhook event metrics now available for monitoring.

* **Documentation**
  * Added Claude Code workflow and architecture documentation.
  * Added pr-writer agent workflow definition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->