### PR TITLE
feat(webhook): enforce mandatory webhook secret configuration

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -11,6 +11,8 @@ import (
 	"github.com/go-logr/logr"
 	"go.uber.org/ratelimit"
 
+	"github.com/argoproj-labs/argocd-image-updater/registry-scanner/pkg/log"
+
 	"github.com/argoproj-labs/argocd-image-updater/internal/controller"
 	"github.com/argoproj-labs/argocd-image-updater/pkg/argocd"
 	"github.com/argoproj-labs/argocd-image-updater/pkg/common"
@@ -21,6 +23,8 @@ import (
 
 // WebhookConfig holds the options for the webhook server
 type WebhookConfig struct {
+	// RequireSecrets requires webhook secrets by default
+	RequireSecrets bool
 	// Port is the port number for the webhook server to listen on
 	Port int
 	// EnableHTTP2 allows the webhook TLS server to negotiate HTTP/2
@@ -128,17 +132,65 @@ func SetupCommon(ctx context.Context, cfg *controller.ImageUpdaterConfig, setupL
 }
 
 // SetupWebhookServer creates and configures a new webhook server.
-func SetupWebhookServer(webhookCfg *WebhookConfig, reconciler *controller.ImageUpdaterReconciler) *webhook.WebhookServer {
+func SetupWebhookServer(ctx context.Context, webhookCfg *WebhookConfig, reconciler *controller.ImageUpdaterReconciler) *webhook.WebhookServer {
+	log := log.LoggerFromContext(ctx)
+
 	// Create webhook handler
 	handler := webhook.NewWebhookHandler()
 
-	// Register supported webhook handlers with default empty secrets
-	handler.RegisterHandler(webhook.NewDockerHubWebhook(webhookCfg.DockerSecret))
-	handler.RegisterHandler(webhook.NewGHCRWebhook(webhookCfg.GHCRSecret))
-	handler.RegisterHandler(webhook.NewHarborWebhook(webhookCfg.HarborSecret))
-	handler.RegisterHandler(webhook.NewQuayWebhook(webhookCfg.QuaySecret))
-	handler.RegisterHandler(webhook.NewAliyunACRWebhook(webhookCfg.AliyunACRSecret))
-	handler.RegisterHandler(webhook.NewCloudEventsWebhook(webhookCfg.CloudEventsSecret))
+	if !webhookCfg.RequireSecrets {
+		// Insecure mode: all handlers are registered regardless of whether a secret is
+		// configured. Handlers without a secret will accept unauthenticated requests.
+		log.Warnf("Webhook secrets are not required (--webhook-require-secrets=false). " +
+			"All registry handlers will be registered without secret validation. " +
+			"This is insecure and should not be used in production.")
+		handler.RegisterHandler(webhook.NewDockerHubWebhook(webhookCfg.DockerSecret))
+		handler.RegisterHandler(webhook.NewGHCRWebhook(webhookCfg.GHCRSecret))
+		handler.RegisterHandler(webhook.NewHarborWebhook(webhookCfg.HarborSecret))
+		handler.RegisterHandler(webhook.NewQuayWebhook(webhookCfg.QuaySecret))
+		handler.RegisterHandler(webhook.NewAliyunACRWebhook(webhookCfg.AliyunACRSecret))
+		handler.RegisterHandler(webhook.NewCloudEventsWebhook(webhookCfg.CloudEventsSecret))
+	} else {
+		// Secure mode (default): only register handlers for which a secret has been
+		// configured. Handlers without a secret are skipped entirely so unauthenticated
+		// requests from that registry are rejected before reaching the server.
+		registered := 0
+		if webhookCfg.DockerSecret != "" {
+			handler.RegisterHandler(webhook.NewDockerHubWebhook(webhookCfg.DockerSecret))
+			log.Infof("Registered Docker Hub webhook handler")
+			registered++
+		}
+		if webhookCfg.GHCRSecret != "" {
+			handler.RegisterHandler(webhook.NewGHCRWebhook(webhookCfg.GHCRSecret))
+			log.Infof("Registered GHCR webhook handler")
+			registered++
+		}
+		if webhookCfg.HarborSecret != "" {
+			handler.RegisterHandler(webhook.NewHarborWebhook(webhookCfg.HarborSecret))
+			log.Infof("Registered Harbor webhook handler")
+			registered++
+		}
+		if webhookCfg.QuaySecret != "" {
+			handler.RegisterHandler(webhook.NewQuayWebhook(webhookCfg.QuaySecret))
+			log.Infof("Registered Quay webhook handler")
+			registered++
+		}
+		if webhookCfg.AliyunACRSecret != "" {
+			handler.RegisterHandler(webhook.NewAliyunACRWebhook(webhookCfg.AliyunACRSecret))
+			log.Infof("Registered Aliyun ACR webhook handler")
+			registered++
+		}
+		if webhookCfg.CloudEventsSecret != "" {
+			handler.RegisterHandler(webhook.NewCloudEventsWebhook(webhookCfg.CloudEventsSecret))
+			log.Infof("Registered CloudEvents webhook handler")
+			registered++
+		}
+		if registered == 0 {
+			log.Warnf("Webhook server is enabled with --webhook-require-secrets=true but no secrets " +
+				"are configured. No handlers will be registered and all webhook requests will be rejected. " +
+				"Configure at least one *-webhook-secret flag or set --webhook-require-secrets=false.")
+		}
+	}
 
 	// Create webhook server
 	server := webhook.NewWebhookServer(webhookCfg.Port, handler, reconciler)

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -23,8 +23,8 @@ import (
 
 // WebhookConfig holds the options for the webhook server
 type WebhookConfig struct {
-	// RequireSecrets requires webhook secrets by default
-	RequireSecrets bool
+	// RequireSecret requires webhook secrets by default
+	RequireSecret bool
 	// Port is the port number for the webhook server to listen on
 	Port int
 	// EnableHTTP2 allows the webhook TLS server to negotiate HTTP/2
@@ -138,10 +138,10 @@ func SetupWebhookServer(ctx context.Context, webhookCfg *WebhookConfig, reconcil
 	// Create webhook handler
 	handler := webhook.NewWebhookHandler()
 
-	if !webhookCfg.RequireSecrets {
+	if !webhookCfg.RequireSecret {
 		// Insecure mode: all handlers are registered regardless of whether a secret is
 		// configured. Handlers without a secret will accept unauthenticated requests.
-		log.Warnf("Webhook secrets are not required (--webhook-require-secrets=false). " +
+		log.Warnf("Webhook secrets are not required (--webhook-require-secret=false). " +
 			"All registry handlers will be registered without secret validation. " +
 			"This is insecure and should not be used in production.")
 		handler.RegisterHandler(webhook.NewDockerHubWebhook(webhookCfg.DockerSecret))
@@ -186,9 +186,9 @@ func SetupWebhookServer(ctx context.Context, webhookCfg *WebhookConfig, reconcil
 			registered++
 		}
 		if registered == 0 {
-			log.Warnf("Webhook server is enabled with --webhook-require-secrets=true but no secrets " +
+			log.Warnf("Webhook server is enabled with --webhook-require-secret=true but no secrets " +
 				"are configured. No handlers will be registered and all webhook requests will be rejected. " +
-				"Configure at least one *-webhook-secret flag or set --webhook-require-secrets=false.")
+				"Configure at least one *-webhook-secret flag or set --webhook-require-secret=false.")
 		}
 	}
 

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -42,7 +42,7 @@ func TestSetupWebhookServer(t *testing.T) {
 			RateLimitNumAllowedRequests: 0,
 		}
 		reconciler := &controller.ImageUpdaterReconciler{}
-		server := SetupWebhookServer(webhookCfg, reconciler)
+		server := SetupWebhookServer(context.Background(), webhookCfg, reconciler)
 		require.NotNil(t, server)
 		assert.Equal(t, 8080, server.Port)
 		assert.Nil(t, server.RateLimiter)
@@ -56,7 +56,7 @@ func TestSetupWebhookServer(t *testing.T) {
 			RateLimitNumAllowedRequests: 100,
 		}
 		reconciler := &controller.ImageUpdaterReconciler{}
-		server := SetupWebhookServer(webhookCfg, reconciler)
+		server := SetupWebhookServer(context.Background(), webhookCfg, reconciler)
 		require.NotNil(t, server)
 		assert.Equal(t, 8080, server.Port)
 		assert.NotNil(t, server.RateLimiter)
@@ -70,10 +70,95 @@ func TestSetupWebhookServer(t *testing.T) {
 			EnableHTTP2: true,
 		}
 		reconciler := &controller.ImageUpdaterReconciler{}
-		server := SetupWebhookServer(webhookCfg, reconciler)
+		server := SetupWebhookServer(context.Background(), webhookCfg, reconciler)
 		require.NotNil(t, server)
 		require.NotNil(t, server.TLS)
 		assert.True(t, server.TLS.EnableHTTP2)
+	})
+}
+
+func TestSetupWebhookServer_HandlerRegistration(t *testing.T) {
+	reconciler := &controller.ImageUpdaterReconciler{}
+
+	allRegistryTypes := []string{
+		"aliyun-acr",
+		"cloudevents",
+		"docker.io",
+		"ghcr.io",
+		"harbor",
+		"quay.io",
+	}
+
+	t.Run("require-secrets=false registers all handlers regardless of secrets", func(t *testing.T) {
+		cfg := &WebhookConfig{
+			RequireSecrets: false,
+			Port:           8080,
+			// No secrets configured at all
+		}
+		server := SetupWebhookServer(context.Background(), cfg, reconciler)
+		require.NotNil(t, server)
+		assert.ElementsMatch(t, allRegistryTypes, server.Handler.RegisteredTypes())
+	})
+
+	t.Run("require-secrets=false registers all handlers even when secrets are set", func(t *testing.T) {
+		cfg := &WebhookConfig{
+			RequireSecrets: false,
+			Port:           8080,
+			DockerSecret:   "docker-secret",
+			GHCRSecret:     "ghcr-secret",
+		}
+		server := SetupWebhookServer(context.Background(), cfg, reconciler)
+		require.NotNil(t, server)
+		assert.ElementsMatch(t, allRegistryTypes, server.Handler.RegisteredTypes())
+	})
+
+	t.Run("require-secrets=true with no secrets registers no handlers", func(t *testing.T) {
+		cfg := &WebhookConfig{
+			RequireSecrets: true,
+			Port:           8080,
+		}
+		server := SetupWebhookServer(context.Background(), cfg, reconciler)
+		require.NotNil(t, server)
+		assert.Empty(t, server.Handler.RegisteredTypes())
+	})
+
+	t.Run("require-secrets=true only registers handlers that have a secret", func(t *testing.T) {
+		cfg := &WebhookConfig{
+			RequireSecrets: true,
+			Port:           8080,
+			DockerSecret:   "docker-secret",
+			HarborSecret:   "harbor-secret",
+		}
+		server := SetupWebhookServer(context.Background(), cfg, reconciler)
+		require.NotNil(t, server)
+		assert.ElementsMatch(t, []string{"docker.io", "harbor"}, server.Handler.RegisteredTypes())
+	})
+
+	t.Run("require-secrets=true with all secrets registers all handlers", func(t *testing.T) {
+		cfg := &WebhookConfig{
+			RequireSecrets:    true,
+			Port:              8080,
+			DockerSecret:      "docker-secret",
+			GHCRSecret:        "ghcr-secret",
+			HarborSecret:      "harbor-secret",
+			QuaySecret:        "quay-secret",
+			AliyunACRSecret:   "aliyun-secret",
+			CloudEventsSecret: "cloudevents-secret",
+		}
+		server := SetupWebhookServer(context.Background(), cfg, reconciler)
+		require.NotNil(t, server)
+		assert.ElementsMatch(t, allRegistryTypes, server.Handler.RegisteredTypes())
+	})
+
+	t.Run("require-secrets=true with only GHCR secret registers only GHCR handler", func(t *testing.T) {
+		cfg := &WebhookConfig{
+			RequireSecrets: true,
+			Port:           8080,
+			GHCRSecret:     "ghcr-secret",
+		}
+		server := SetupWebhookServer(context.Background(), cfg, reconciler)
+		require.NotNil(t, server)
+		assert.ElementsMatch(t, []string{"ghcr.io"}, server.Handler.RegisteredTypes())
 	})
 }
 

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -91,8 +91,8 @@ func TestSetupWebhookServer_HandlerRegistration(t *testing.T) {
 
 	t.Run("require-secrets=false registers all handlers regardless of secrets", func(t *testing.T) {
 		cfg := &WebhookConfig{
-			RequireSecrets: false,
-			Port:           8080,
+			RequireSecret: false,
+			Port:          8080,
 			// No secrets configured at all
 		}
 		server := SetupWebhookServer(context.Background(), cfg, reconciler)
@@ -102,10 +102,10 @@ func TestSetupWebhookServer_HandlerRegistration(t *testing.T) {
 
 	t.Run("require-secrets=false registers all handlers even when secrets are set", func(t *testing.T) {
 		cfg := &WebhookConfig{
-			RequireSecrets: false,
-			Port:           8080,
-			DockerSecret:   "docker-secret",
-			GHCRSecret:     "ghcr-secret",
+			RequireSecret: false,
+			Port:          8080,
+			DockerSecret:  "docker-secret",
+			GHCRSecret:    "ghcr-secret",
 		}
 		server := SetupWebhookServer(context.Background(), cfg, reconciler)
 		require.NotNil(t, server)
@@ -114,8 +114,8 @@ func TestSetupWebhookServer_HandlerRegistration(t *testing.T) {
 
 	t.Run("require-secrets=true with no secrets registers no handlers", func(t *testing.T) {
 		cfg := &WebhookConfig{
-			RequireSecrets: true,
-			Port:           8080,
+			RequireSecret: true,
+			Port:          8080,
 		}
 		server := SetupWebhookServer(context.Background(), cfg, reconciler)
 		require.NotNil(t, server)
@@ -124,10 +124,10 @@ func TestSetupWebhookServer_HandlerRegistration(t *testing.T) {
 
 	t.Run("require-secrets=true only registers handlers that have a secret", func(t *testing.T) {
 		cfg := &WebhookConfig{
-			RequireSecrets: true,
-			Port:           8080,
-			DockerSecret:   "docker-secret",
-			HarborSecret:   "harbor-secret",
+			RequireSecret: true,
+			Port:          8080,
+			DockerSecret:  "docker-secret",
+			HarborSecret:  "harbor-secret",
 		}
 		server := SetupWebhookServer(context.Background(), cfg, reconciler)
 		require.NotNil(t, server)
@@ -136,7 +136,7 @@ func TestSetupWebhookServer_HandlerRegistration(t *testing.T) {
 
 	t.Run("require-secrets=true with all secrets registers all handlers", func(t *testing.T) {
 		cfg := &WebhookConfig{
-			RequireSecrets:    true,
+			RequireSecret:     true,
 			Port:              8080,
 			DockerSecret:      "docker-secret",
 			GHCRSecret:        "ghcr-secret",
@@ -152,9 +152,9 @@ func TestSetupWebhookServer_HandlerRegistration(t *testing.T) {
 
 	t.Run("require-secrets=true with only GHCR secret registers only GHCR handler", func(t *testing.T) {
 		cfg := &WebhookConfig{
-			RequireSecrets: true,
-			Port:           8080,
-			GHCRSecret:     "ghcr-secret",
+			RequireSecret: true,
+			Port:          8080,
+			GHCRSecret:    "ghcr-secret",
 		}
 		server := SetupWebhookServer(context.Background(), cfg, reconciler)
 		require.NotNil(t, server)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -327,7 +327,7 @@ This enables a CRD-driven approach to automated image updates with Argo CD.
 
 	// Webhook flags
 	controllerCmd.Flags().BoolVar(&cfg.EnableWebhook, "enable-webhook", env.GetBoolVal("ENABLE_WEBHOOK", false), "Enable webhook server for receiving registry events")
-	controllerCmd.Flags().BoolVar(&webhookCfg.RequireSecrets, "webhook-require-secrets", env.GetBoolVal("WEBHOOK_REQUIRE_SECRETS", true), "Require webhook secrets by default")
+	controllerCmd.Flags().BoolVar(&webhookCfg.RequireSecret, "webhook-require-secret", env.GetBoolVal("WEBHOOK_REQUIRE_SECRET", true), "Require webhook secrets by default")
 	controllerCmd.Flags().IntVar(&webhookCfg.Port, "webhook-port", env.ParseNumFromEnv("WEBHOOK_PORT", 8082, 0, 65535), "Port to listen on for webhook events")
 	controllerCmd.Flags().StringVar(&webhookCfg.DockerSecret, "docker-webhook-secret", env.GetStringVal("DOCKER_WEBHOOK_SECRET", ""), "Secret for validating Docker Hub webhooks")
 	controllerCmd.Flags().StringVar(&webhookCfg.GHCRSecret, "ghcr-webhook-secret", env.GetStringVal("GHCR_WEBHOOK_SECRET", ""), "Secret for validating GitHub Container Registry webhooks")

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -327,6 +327,7 @@ This enables a CRD-driven approach to automated image updates with Argo CD.
 
 	// Webhook flags
 	controllerCmd.Flags().BoolVar(&cfg.EnableWebhook, "enable-webhook", env.GetBoolVal("ENABLE_WEBHOOK", false), "Enable webhook server for receiving registry events")
+	controllerCmd.Flags().BoolVar(&webhookCfg.RequireSecrets, "webhook-require-secrets", env.GetBoolVal("WEBHOOK_REQUIRE_SECRETS", true), "Require webhook secrets by default")
 	controllerCmd.Flags().IntVar(&webhookCfg.Port, "webhook-port", env.ParseNumFromEnv("WEBHOOK_PORT", 8082, 0, 65535), "Port to listen on for webhook events")
 	controllerCmd.Flags().StringVar(&webhookCfg.DockerSecret, "docker-webhook-secret", env.GetStringVal("DOCKER_WEBHOOK_SECRET", ""), "Secret for validating Docker Hub webhooks")
 	controllerCmd.Flags().StringVar(&webhookCfg.GHCRSecret, "ghcr-webhook-secret", env.GetStringVal("GHCR_WEBHOOK_SECRET", ""), "Secret for validating GitHub Container Registry webhooks")
@@ -450,7 +451,7 @@ func (ws *WebhookServerRunnable) Start(ctx context.Context) error {
 	})
 	ctx = log.ContextWithLogger(ctx, webhookLogger)
 
-	ws.webhookServer = SetupWebhookServer(ws.WebhookConfig, ws.Reconciler)
+	ws.webhookServer = SetupWebhookServer(ctx, ws.WebhookConfig, ws.Reconciler)
 
 	// Start webhook server in goroutine with context handling
 	return ws.webhookServer.Start(ctx)

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -65,6 +65,7 @@ func TestNewRunCommand(t *testing.T) {
 	asser.Equal(common.DefaultCommitTemplatePath, controllerCommand.Flag("git-commit-message-path").Value.String())
 	asser.Equal(env.GetStringVal("IMAGE_UPDATER_KUBE_EVENTS", "false"), controllerCommand.Flag("disable-kube-events").Value.String())
 	asser.Equal(env.GetStringVal("ENABLE_WEBHOOK", "false"), controllerCommand.Flag("enable-webhook").Value.String())
+	asser.Equal(env.GetStringVal("WEBHOOK_REQUIRE_SECRETS", "true"), controllerCommand.Flag("webhook-require-secrets").Value.String())
 	asser.Equal(strconv.Itoa(env.ParseNumFromEnv("WEBHOOK_PORT", 8082, 0, 65535)), controllerCommand.Flag("webhook-port").Value.String())
 	asser.Equal(env.GetStringVal("DOCKER_WEBHOOK_SECRET", ""), controllerCommand.Flag("docker-webhook-secret").Value.String())
 	asser.Equal(env.GetStringVal("GHCR_WEBHOOK_SECRET", ""), controllerCommand.Flag("ghcr-webhook-secret").Value.String())

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -65,7 +65,7 @@ func TestNewRunCommand(t *testing.T) {
 	asser.Equal(common.DefaultCommitTemplatePath, controllerCommand.Flag("git-commit-message-path").Value.String())
 	asser.Equal(env.GetStringVal("IMAGE_UPDATER_KUBE_EVENTS", "false"), controllerCommand.Flag("disable-kube-events").Value.String())
 	asser.Equal(env.GetStringVal("ENABLE_WEBHOOK", "false"), controllerCommand.Flag("enable-webhook").Value.String())
-	asser.Equal(env.GetStringVal("WEBHOOK_REQUIRE_SECRETS", "true"), controllerCommand.Flag("webhook-require-secrets").Value.String())
+	asser.Equal(env.GetStringVal("WEBHOOK_REQUIRE_SECRET", "true"), controllerCommand.Flag("webhook-require-secret").Value.String())
 	asser.Equal(strconv.Itoa(env.ParseNumFromEnv("WEBHOOK_PORT", 8082, 0, 65535)), controllerCommand.Flag("webhook-port").Value.String())
 	asser.Equal(env.GetStringVal("DOCKER_WEBHOOK_SECRET", ""), controllerCommand.Flag("docker-webhook-secret").Value.String())
 	asser.Equal(env.GetStringVal("GHCR_WEBHOOK_SECRET", ""), controllerCommand.Flag("ghcr-webhook-secret").Value.String())

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -91,7 +91,7 @@ Supported registries:
 	webhookCmd.Flags().StringVar(&commitMessagePath, "git-commit-message-path", common.DefaultCommitTemplatePath, "Path to a template to use for Git commit messages")
 	webhookCmd.Flags().BoolVar(&cfg.DisableKubeEvents, "disable-kube-events", env.GetBoolVal("IMAGE_UPDATER_KUBE_EVENTS", false), "Disable kubernetes events")
 
-	webhookCmd.Flags().BoolVar(&webhookCfg.RequireSecrets, "webhook-require-secrets", env.GetBoolVal("WEBHOOK_REQUIRE_SECRETS", true), "Require webhook secrets by default")
+	webhookCmd.Flags().BoolVar(&webhookCfg.RequireSecret, "webhook-require-secret", env.GetBoolVal("WEBHOOK_REQUIRE_SECRET", true), "Require webhook secrets by default")
 	webhookCmd.Flags().IntVar(&webhookCfg.Port, "webhook-port", env.ParseNumFromEnv("WEBHOOK_PORT", 8080, 0, 65535), "Port to listen on for webhook events")
 	webhookCmd.Flags().StringVar(&webhookCfg.DockerSecret, "docker-webhook-secret", env.GetStringVal("DOCKER_WEBHOOK_SECRET", ""), "Secret for validating Docker Hub webhooks")
 	webhookCmd.Flags().StringVar(&webhookCfg.GHCRSecret, "ghcr-webhook-secret", env.GetStringVal("GHCR_WEBHOOK_SECRET", ""), "Secret for validating GitHub Container Registry webhooks")

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -91,6 +91,7 @@ Supported registries:
 	webhookCmd.Flags().StringVar(&commitMessagePath, "git-commit-message-path", common.DefaultCommitTemplatePath, "Path to a template to use for Git commit messages")
 	webhookCmd.Flags().BoolVar(&cfg.DisableKubeEvents, "disable-kube-events", env.GetBoolVal("IMAGE_UPDATER_KUBE_EVENTS", false), "Disable kubernetes events")
 
+	webhookCmd.Flags().BoolVar(&webhookCfg.RequireSecrets, "webhook-require-secrets", env.GetBoolVal("WEBHOOK_REQUIRE_SECRETS", true), "Require webhook secrets by default")
 	webhookCmd.Flags().IntVar(&webhookCfg.Port, "webhook-port", env.ParseNumFromEnv("WEBHOOK_PORT", 8080, 0, 65535), "Port to listen on for webhook events")
 	webhookCmd.Flags().StringVar(&webhookCfg.DockerSecret, "docker-webhook-secret", env.GetStringVal("DOCKER_WEBHOOK_SECRET", ""), "Secret for validating Docker Hub webhooks")
 	webhookCmd.Flags().StringVar(&webhookCfg.GHCRSecret, "ghcr-webhook-secret", env.GetStringVal("GHCR_WEBHOOK_SECRET", ""), "Secret for validating GitHub Container Registry webhooks")
@@ -136,7 +137,7 @@ func runWebhook(ctx context.Context, cfg *controller.ImageUpdaterConfig, webhook
 		MaxConcurrentReconciles: maxConcurrentUpdaters,
 	}
 
-	server := SetupWebhookServer(webhookCfg, reconciler)
+	server := SetupWebhookServer(ctx, webhookCfg, reconciler)
 
 	// Create a context that is cancelled on an interrupt signal
 	ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)

--- a/cmd/webhook_test.go
+++ b/cmd/webhook_test.go
@@ -37,6 +37,7 @@ func TestNewWebhookCommand(t *testing.T) {
 	asser.Equal(env.GetStringVal("GIT_COMMIT_SIGN_OFF", "false"), controllerCommand.Flag("git-commit-sign-off").Value.String())
 	asser.Equal(common.DefaultCommitTemplatePath, controllerCommand.Flag("git-commit-message-path").Value.String())
 	asser.Equal(env.GetStringVal("IMAGE_UPDATER_KUBE_EVENTS", "false"), controllerCommand.Flag("disable-kube-events").Value.String())
+	asser.Equal(env.GetStringVal("WEBHOOK_REQUIRE_SECRETS", "true"), controllerCommand.Flag("webhook-require-secrets").Value.String())
 	asser.Equal(strconv.Itoa(env.ParseNumFromEnv("WEBHOOK_PORT", 8080, 0, 65535)), controllerCommand.Flag("webhook-port").Value.String())
 	asser.Equal(env.GetStringVal("DOCKER_WEBHOOK_SECRET", ""), controllerCommand.Flag("docker-webhook-secret").Value.String())
 	asser.Equal(env.GetStringVal("GHCR_WEBHOOK_SECRET", ""), controllerCommand.Flag("ghcr-webhook-secret").Value.String())

--- a/cmd/webhook_test.go
+++ b/cmd/webhook_test.go
@@ -37,7 +37,7 @@ func TestNewWebhookCommand(t *testing.T) {
 	asser.Equal(env.GetStringVal("GIT_COMMIT_SIGN_OFF", "false"), controllerCommand.Flag("git-commit-sign-off").Value.String())
 	asser.Equal(common.DefaultCommitTemplatePath, controllerCommand.Flag("git-commit-message-path").Value.String())
 	asser.Equal(env.GetStringVal("IMAGE_UPDATER_KUBE_EVENTS", "false"), controllerCommand.Flag("disable-kube-events").Value.String())
-	asser.Equal(env.GetStringVal("WEBHOOK_REQUIRE_SECRETS", "true"), controllerCommand.Flag("webhook-require-secrets").Value.String())
+	asser.Equal(env.GetStringVal("WEBHOOK_REQUIRE_SECRET", "true"), controllerCommand.Flag("webhook-require-secret").Value.String())
 	asser.Equal(strconv.Itoa(env.ParseNumFromEnv("WEBHOOK_PORT", 8080, 0, 65535)), controllerCommand.Flag("webhook-port").Value.String())
 	asser.Equal(env.GetStringVal("DOCKER_WEBHOOK_SECRET", ""), controllerCommand.Flag("docker-webhook-secret").Value.String())
 	asser.Equal(env.GetStringVal("GHCR_WEBHOOK_SECRET", ""), controllerCommand.Flag("ghcr-webhook-secret").Value.String())

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -984,6 +984,12 @@ spec:
               key: webhook.enable
               name: argocd-image-updater-config
               optional: true
+        - name: WEBHOOK_REQUIRE_SECRETS
+          valueFrom:
+            configMapKeyRef:
+              key: webhook.require-secrets
+              name: argocd-image-updater-config
+              optional: true
         - name: WEBHOOK_PORT
           valueFrom:
             configMapKeyRef:

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -984,10 +984,10 @@ spec:
               key: webhook.enable
               name: argocd-image-updater-config
               optional: true
-        - name: WEBHOOK_REQUIRE_SECRETS
+        - name: WEBHOOK_REQUIRE_SECRET
           valueFrom:
             configMapKeyRef:
-              key: webhook.require-secrets
+              key: webhook.require-secret
               name: argocd-image-updater-config
               optional: true
         - name: WEBHOOK_PORT

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -138,11 +138,11 @@ spec:
                 name: argocd-image-updater-config
                 key: webhook.enable
                 optional: true
-          - name: WEBHOOK_REQUIRE_SECRETS
+          - name: WEBHOOK_REQUIRE_SECRET
             valueFrom:
               configMapKeyRef:
                 name: argocd-image-updater-config
-                key: webhook.require-secrets
+                key: webhook.require-secret
                 optional: true
           - name: WEBHOOK_PORT
             valueFrom:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -138,6 +138,12 @@ spec:
                 name: argocd-image-updater-config
                 key: webhook.enable
                 optional: true
+          - name: WEBHOOK_REQUIRE_SECRETS
+            valueFrom:
+              configMapKeyRef:
+                name: argocd-image-updater-config
+                key: webhook.require-secrets
+                optional: true
           - name: WEBHOOK_PORT
             valueFrom:
               configMapKeyRef:

--- a/docs/configuration/webhook.md
+++ b/docs/configuration/webhook.md
@@ -6,6 +6,14 @@
     `--disable-tls` flag or the `DISABLE_TLS` environment variable. For details, see
     [TLS Configuration](#tls-configuration) below.
 
+!!!warning "Breaking Change"
+    Starting with this release, **webhook secrets are required by default**
+    (`--webhook-require-secrets=true`). If you previously ran the webhook server
+    without any secrets configured, all incoming webhook requests will now be
+    rejected. To restore the previous behavior, set `--webhook-require-secrets=false`
+    or the `WEBHOOK_REQUIRE_SECRETS=false` environment variable. If you already
+    had secrets configured, no changes are required.
+
 Image Updater can be configured to respond to webhook notifications from 
 various container registries. 
 

--- a/docs/configuration/webhook.md
+++ b/docs/configuration/webhook.md
@@ -272,6 +272,22 @@ Supported Registries That Use This:
 Also be aware that if the container registry has a built-in secrets method you will
 not be able to use this method.
 
+### Requiring Secrets (default behaviour)
+
+By default (`--webhook-require-secrets=true`), only registry handlers that have
+a secret configured are registered. A registry with no secret set will have its
+handler skipped entirely — the server will return an error for those webhook
+types rather than accepting unauthenticated requests.
+
+Set `--webhook-require-secrets=false` to register all handlers regardless of
+whether a secret is present. Use this only in local development or
+network-isolated environments.
+
+!!!warning
+    `--webhook-require-secrets=false` disables authentication on every handler
+    that has no secret configured. Any source can send fake webhook payloads to
+    those endpoints.
+
 ## Exposing the Server
 
 To expose the webhook server we have provided a service and ingress to get
@@ -410,6 +426,7 @@ environment variables. Below is the list of which variables correspond to which 
 |Environment Variable|Corresponding Flag|
 |--------|--------|
 |`ENABLE_WEBHOOK`|`--enable-webhook`|
+|`WEBHOOK_REQUIRE_SECRETS`|`--webhook-require-secrets`|
 |`WEBHOOK_PORT`|`--webhook-port`|
 |`DOCKER_WEBHOOK_SECRET` |`--docker-webhook-secret`|
 |`GHCR_WEBHOOK_SECRET` |`--ghcr-webhook-secret`|
@@ -461,7 +478,7 @@ else. If this continuously occurs please open an issue with the error informatio
 Make sure you included the `type` query parameter for the type of webhook
 handler and ensure that it is correct. 
 
-**Missing/incorrect webhook secret**
+**Missing/invalid webhook secret**
 
 If you are seeing this message make sure that you have secrets configured
 properly in your container registry whether it is through their service

--- a/docs/configuration/webhook.md
+++ b/docs/configuration/webhook.md
@@ -8,10 +8,10 @@
 
 !!!warning "Breaking Change"
     Starting with this release, **webhook secrets are required by default**
-    (`--webhook-require-secrets=true`). If you previously ran the webhook server
+    (`--webhook-require-secret=true`). If you previously ran the webhook server
     without any secrets configured, all incoming webhook requests will now be
-    rejected. To restore the previous behavior, set `--webhook-require-secrets=false`
-    or the `WEBHOOK_REQUIRE_SECRETS=false` environment variable. If you already
+    rejected. To restore the previous behavior, set `--webhook-require-secret=false`
+    or the `WEBHOOK_REQUIRE_SECRET=false` environment variable. If you already
     had secrets configured, no changes are required.
 
 Image Updater can be configured to respond to webhook notifications from 
@@ -282,17 +282,17 @@ not be able to use this method.
 
 ### Requiring Secrets (default behaviour)
 
-By default (`--webhook-require-secrets=true`), only registry handlers that have
+By default (`--webhook-require-secret=true`), only registry handlers that have
 a secret configured are registered. A registry with no secret set will have its
 handler skipped entirely — the server will return an error for those webhook
 types rather than accepting unauthenticated requests.
 
-Set `--webhook-require-secrets=false` to register all handlers regardless of
+Set `--webhook-require-secret=false` to register all handlers regardless of
 whether a secret is present. Use this only in local development or
 network-isolated environments.
 
 !!!warning
-    `--webhook-require-secrets=false` disables authentication on every handler
+    `--webhook-require-secret=false` disables authentication on every handler
     that has no secret configured. Any source can send fake webhook payloads to
     those endpoints.
 
@@ -434,7 +434,7 @@ environment variables. Below is the list of which variables correspond to which 
 |Environment Variable|Corresponding Flag|
 |--------|--------|
 |`ENABLE_WEBHOOK`|`--enable-webhook`|
-|`WEBHOOK_REQUIRE_SECRETS`|`--webhook-require-secrets`|
+|`WEBHOOK_REQUIRE_SECRET`|`--webhook-require-secret`|
 |`WEBHOOK_PORT`|`--webhook-port`|
 |`DOCKER_WEBHOOK_SECRET` |`--docker-webhook-secret`|
 |`GHCR_WEBHOOK_SECRET` |`--ghcr-webhook-secret`|

--- a/docs/install/cmd/run.md
+++ b/docs/install/cmd/run.md
@@ -270,7 +270,7 @@ means that the rate limiting is disabled.
 
 Can also be set with the `WEBHOOK_RATELIMIT_ALLOWED` environment variable.
 
-**--webhook-require-secrets *bool***
+**--webhook-require-secret *bool***
 
 When set to `true` (the default), only registry webhook handlers that have a
 secret configured are registered. Requests arriving for a registry with no
@@ -278,10 +278,10 @@ secret will be rejected. Set to `false` to register all handlers regardless
 of whether a secret is present — this disables authentication on those
 endpoints and is strongly discouraged in production.
 
-Can also be set with the `WEBHOOK_REQUIRE_SECRETS` environment variable.
+Can also be set with the `WEBHOOK_REQUIRE_SECRET` environment variable.
 
 !!!warning
-    Setting `--webhook-require-secrets=false` means the webhook endpoint will
+    Setting `--webhook-require-secret=false` means the webhook endpoint will
     accept unauthenticated requests from any source for registries that have no
     secret configured. Only use this during local development or in a fully
     network-isolated environment.

--- a/docs/install/cmd/run.md
+++ b/docs/install/cmd/run.md
@@ -270,4 +270,20 @@ means that the rate limiting is disabled.
 
 Can also be set with the `WEBHOOK_RATELIMIT_ALLOWED` environment variable.
 
+**--webhook-require-secrets *bool***
+
+When set to `true` (the default), only registry webhook handlers that have a
+secret configured are registered. Requests arriving for a registry with no
+secret will be rejected. Set to `false` to register all handlers regardless
+of whether a secret is present — this disables authentication on those
+endpoints and is strongly discouraged in production.
+
+Can also be set with the `WEBHOOK_REQUIRE_SECRETS` environment variable.
+
+!!!warning
+    Setting `--webhook-require-secrets=false` means the webhook endpoint will
+    accept unauthenticated requests from any source for registries that have no
+    secret configured. Only use this during local development or in a fully
+    network-isolated environment.
+
 [label selector syntax]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors

--- a/docs/install/cmd/webhook.md
+++ b/docs/install/cmd/webhook.md
@@ -183,4 +183,20 @@ means that the rate limiting is disabled.
 
 Can also be set with the `WEBHOOK_RATELIMIT_ALLOWED` environment variable.
 
+**--webhook-require-secrets *bool***
+
+When set to `true` (the default), only registry webhook handlers that have a
+secret configured are registered. Requests arriving for a registry with no
+secret will be rejected. Set to `false` to register all handlers regardless
+of whether a secret is present — this disables authentication on those
+endpoints and is strongly discouraged in production.
+
+Can also be set with the `WEBHOOK_REQUIRE_SECRETS` environment variable.
+
+!!!warning
+    Setting `--webhook-require-secrets=false` means the webhook endpoint will
+    accept unauthenticated requests from any source for registries that have no
+    secret configured. Only use this during local development or in a fully
+    network-isolated environment.
+
 [label selector syntax]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors

--- a/docs/install/cmd/webhook.md
+++ b/docs/install/cmd/webhook.md
@@ -183,7 +183,7 @@ means that the rate limiting is disabled.
 
 Can also be set with the `WEBHOOK_RATELIMIT_ALLOWED` environment variable.
 
-**--webhook-require-secrets *bool***
+**--webhook-require-secret *bool***
 
 When set to `true` (the default), only registry webhook handlers that have a
 secret configured are registered. Requests arriving for a registry with no
@@ -191,10 +191,10 @@ secret will be rejected. Set to `false` to register all handlers regardless
 of whether a secret is present — this disables authentication on those
 endpoints and is strongly discouraged in production.
 
-Can also be set with the `WEBHOOK_REQUIRE_SECRETS` environment variable.
+Can also be set with the `WEBHOOK_REQUIRE_SECRET` environment variable.
 
 !!!warning
-    Setting `--webhook-require-secrets=false` means the webhook endpoint will
+    Setting `--webhook-require-secret=false` means the webhook endpoint will
     accept unauthenticated requests from any source for registries that have no
     secret configured. Only use this during local development or in a fully
     network-isolated environment.

--- a/pkg/webhook/docker.go
+++ b/pkg/webhook/docker.go
@@ -1,6 +1,7 @@
 package webhook
 
 import (
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -40,7 +41,7 @@ func (d *DockerHubWebhook) Validate(r *http.Request) error {
 			return fmt.Errorf("missing webhook secret")
 		}
 
-		if secret != d.secret {
+		if subtle.ConstantTimeCompare([]byte(secret), []byte(d.secret)) != 1 {
 			return fmt.Errorf("invalid webhook secret")
 		}
 	}

--- a/pkg/webhook/harbor.go
+++ b/pkg/webhook/harbor.go
@@ -51,7 +51,7 @@ func (h *HarborWebhook) Validate(r *http.Request) error {
 
 		// Harbor sends plain secret value directly in Authorization header for external webhooks
 		if subtle.ConstantTimeCompare([]byte(authHeader), []byte(h.secret)) != 1 {
-			return fmt.Errorf("incorrect webhook secret")
+			return fmt.Errorf("invalid webhook secret")
 		}
 	}
 

--- a/pkg/webhook/harbor_test.go
+++ b/pkg/webhook/harbor_test.go
@@ -91,7 +91,7 @@ func TestHarborWebhook_Validate(t *testing.T) {
 			body:           `{"test": "data"}`,
 			authHeader:     "wrong-secret",
 			expectError:    true,
-			expectedErrMsg: "incorrect webhook secret",
+			expectedErrMsg: "invalid webhook secret",
 		},
 	}
 

--- a/pkg/webhook/quay.go
+++ b/pkg/webhook/quay.go
@@ -1,6 +1,7 @@
 package webhook
 
 import (
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -38,8 +39,8 @@ func (q *QuayWebhook) Validate(r *http.Request) error {
 			return fmt.Errorf("missing webhook secret")
 		}
 
-		if secret != q.secret {
-			return fmt.Errorf("incorrect webhook secret")
+		if subtle.ConstantTimeCompare([]byte(secret), []byte(q.secret)) != 1 {
+			return fmt.Errorf("invalid webhook secret")
 		}
 	}
 

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -49,6 +49,11 @@ func (h *WebhookHandler) ProcessWebhook(r *http.Request) (*argocd.WebhookEvent, 
 	// Get list of supported registry types from registered handlers
 	registryTypes := h.getSupportedRegistryTypes()
 
+	// No handlers at all — most likely --webhook-require-secrets=true with no secrets configured.
+	if len(registryTypes) == 0 {
+		return nil, fmt.Errorf("no webhook handlers are registered; configure at least one *-webhook-secret or set --webhook-require-secrets=false")
+	}
+
 	// Registry type is required
 	if registryType == "" {
 		return nil, fmt.Errorf("missing registry type parameter. Supported types: %s", strings.Join(registryTypes, ", "))
@@ -65,6 +70,12 @@ func (h *WebhookHandler) ProcessWebhook(r *http.Request) (*argocd.WebhookEvent, 
 		return nil, err
 	}
 	return handler.Parse(r)
+}
+
+// RegisteredTypes returns a sorted list of registry types that have a handler registered.
+// Primarily used in tests to assert which handlers were wired up.
+func (h *WebhookHandler) RegisteredTypes() []string {
+	return h.getSupportedRegistryTypes()
 }
 
 // getSupportedRegistryTypes returns a list of all supported registry types from registered handlers

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -49,9 +49,9 @@ func (h *WebhookHandler) ProcessWebhook(r *http.Request) (*argocd.WebhookEvent, 
 	// Get list of supported registry types from registered handlers
 	registryTypes := h.getSupportedRegistryTypes()
 
-	// No handlers at all — most likely --webhook-require-secrets=true with no secrets configured.
+	// No handlers at all — most likely --webhook-require-secret=true with no secrets configured.
 	if len(registryTypes) == 0 {
-		return nil, fmt.Errorf("no webhook handlers are registered; configure at least one *-webhook-secret or set --webhook-require-secrets=false")
+		return nil, fmt.Errorf("no webhook handlers are registered; configure at least one *-webhook-secret or set --webhook-require-secret=false")
 	}
 
 	// Registry type is required

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -217,7 +217,7 @@ func TestWebhookHandler_ProcessWebhook(t *testing.T) {
 
 func TestWebhookHandler_ProcessWebhook_NoHandlersRegistered(t *testing.T) {
 	handler := NewWebhookHandler()
-	// No handlers registered — simulates --webhook-require-secrets=true with no secrets configured.
+	// No handlers registered — simulates --webhook-require-secret=true with no secrets configured.
 
 	req := httptest.NewRequest("POST", "/webhook?type=quay.io", strings.NewReader(`{}`))
 	_, err := handler.ProcessWebhook(req)

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -215,6 +215,21 @@ func TestWebhookHandler_ProcessWebhook(t *testing.T) {
 	}
 }
 
+func TestWebhookHandler_ProcessWebhook_NoHandlersRegistered(t *testing.T) {
+	handler := NewWebhookHandler()
+	// No handlers registered — simulates --webhook-require-secrets=true with no secrets configured.
+
+	req := httptest.NewRequest("POST", "/webhook?type=quay.io", strings.NewReader(`{}`))
+	_, err := handler.ProcessWebhook(req)
+
+	if err == nil {
+		t.Fatal("expected error but got none")
+	}
+	if !strings.Contains(err.Error(), "no webhook handlers are registered") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
 func TestWebhookHandler_ProcessWebhookWithHeader(t *testing.T) {
 	handler := NewWebhookHandler()
 


### PR DESCRIPTION
- Add a startup validation check that refuses to start the webhook server (or refuses to register a handler) when its corresponding secret is empty or unset. Log a clear error message identifying which handler(s) lack secrets.

- Replace the != string comparison in docker.go:44 and quay.go:40 with crypto/subtle.ConstantTimeCompare, matching the pattern already used by GHCR, Harbor, and other handlers.

- Add a global --require-webhook-secrets flag (default true) that enforces secret presence for all registered handlersat startup.

> Migrate Docker Hub and Quay handlers from query-parameter-based secret transmission to header-based validation (e.g., HMAC signature in a custom header), or clearly document that query parameter secrets are deprecated and will be removed.

This is already documented at `docs/configuration/webhook.md`, see `### Parameter Secrets`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --webhook-require-secret flag (env WEBHOOK_REQUIRE_SECRET, default: true) to control which webhook endpoints are registered.
  * Improved secret validation to use constant-time comparisons for relevant webhook providers.

* **Bug Fixes**
  * Returns a clear error when no webhook handlers are registered.

* **Documentation**
  * Updated webhook and run command docs with flag details and security guidance.

* **Tests**
  * Added tests covering handler registration behavior and related cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->