### PR TITLE
fix(git-write): Thread/Goroutine leak due to un-reaped informer factories during Git write-back

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/argoproj/argo-cd/v3/util/askpass"
+	"github.com/argoproj/argo-cd/v3/util/db"
+	"github.com/argoproj/argo-cd/v3/util/settings"
 	"github.com/go-logr/logr"
 	"go.uber.org/ratelimit"
 
@@ -111,6 +113,18 @@ func SetupCommon(ctx context.Context, cfg *controller.ImageUpdaterConfig, setupL
 		setupLogger.Error(err, "could not create K8s client")
 		return err
 	}
+
+	// Create a shared Argo CD settings manager and database so that informers
+	// are started once and reused for the lifetime of the controller. Previously,
+	// every Git credential lookup created its own SettingsManager, leaking
+	// informer goroutines (GITOPS-9938).
+	settingsMgr := settings.NewSettingsManager(ctx,
+		cfg.KubeClient.KubeClient.Clientset,
+		cfg.KubeClient.KubeClient.Namespace)
+	cfg.ArgocdDB = db.NewDB(
+		cfg.KubeClient.KubeClient.Namespace,
+		settingsMgr,
+		cfg.KubeClient.KubeClient.Clientset)
 
 	// Start up the credentials store server
 	cs := askpass.NewServer(askpass.SocketPath)

--- a/internal/controller/imageupdater_controller.go
+++ b/internal/controller/imageupdater_controller.go
@@ -32,6 +32,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
+	"github.com/argoproj/argo-cd/v3/util/db"
+
 	api "github.com/argoproj-labs/argocd-image-updater/api/v1alpha1"
 	"github.com/argoproj-labs/argocd-image-updater/ext/git"
 	"github.com/argoproj-labs/argocd-image-updater/pkg/argocd"
@@ -50,6 +52,7 @@ type ImageUpdaterConfig struct {
 	LogLevel               string
 	LogFormat              string
 	KubeClient             *kube.ImageUpdaterKubernetesClient
+	ArgocdDB               db.ArgoDB
 	MaxConcurrentApps      int
 	RegistriesConf         string
 	GitCommitUser          string

--- a/internal/controller/reconcile.go
+++ b/internal/controller/reconcile.go
@@ -29,7 +29,7 @@ func (r *ImageUpdaterReconciler) RunImageUpdater(ctx context.Context, cr *iuapi.
 	r.Config.ArgoClient = argoClient
 
 	// Get the list of applications that are allowed for updates.
-	appList, err := argocd.FilterApplicationsForUpdate(ctx, argoClient, r.Config.KubeClient, cr, webhookEvent)
+	appList, err := argocd.FilterApplicationsForUpdate(ctx, argoClient, r.Config.KubeClient, r.Config.ArgocdDB, cr, webhookEvent)
 	if err != nil {
 		return result, err
 	}
@@ -85,6 +85,7 @@ func (r *ImageUpdaterReconciler) RunImageUpdater(ctx context.Context, cr *iuapi.
 				NewRegFN:               registry.NewClient,
 				ArgoClient:             r.Config.ArgoClient,
 				KubeClient:             r.Config.KubeClient,
+				ArgocdDB:               r.Config.ArgocdDB,
 				UpdateApp:              &curApplication,
 				DryRun:                 dryRun,
 				GitCommitUser:          r.Config.GitCommitUser,

--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/argoproj/argo-cd/v3/pkg/apiclient/application"
 	argocdapi "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v3/util/db"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -228,7 +229,7 @@ func sortApplicationRefs(applicationRefs []iuapi.ApplicationRef) []iuapi.Applica
 
 // FilterApplicationsForUpdate Retrieve a list of applications from ArgoCD that qualify for image updates
 // Application needs either to be of type Kustomize or Helm.
-func FilterApplicationsForUpdate(ctx context.Context, ctrlClient *ArgoCDK8sClient, kubeClient *kube.ImageUpdaterKubernetesClient, cr *iuapi.ImageUpdater, webhookEvent *WebhookEvent) (map[string]ApplicationImages, error) {
+func FilterApplicationsForUpdate(ctx context.Context, ctrlClient *ArgoCDK8sClient, kubeClient *kube.ImageUpdaterKubernetesClient, argocdDB db.ArgoDB, cr *iuapi.ImageUpdater, webhookEvent *WebhookEvent) (map[string]ApplicationImages, error) {
 	baseLogger := log.LoggerFromContext(ctx)
 
 	// Validate CR configuration
@@ -299,7 +300,7 @@ func FilterApplicationsForUpdate(ctx context.Context, ctrlClient *ArgoCDK8sClien
 					}
 
 					appRefWBC := getWriteBackConfigFromAnnotations(&app)
-					appWBCSettings, err = newWBCFromSettings(appCtx, &app, kubeClient, appRefWBC)
+					appWBCSettings, err = newWBCFromSettings(appCtx, &app, kubeClient, argocdDB, appRefWBC)
 					if err != nil {
 						appLogger.Warnf("Could not create write-back config, skipping: %v", err)
 						continue
@@ -322,7 +323,7 @@ func FilterApplicationsForUpdate(ctx context.Context, ctrlClient *ArgoCDK8sClien
 					appLogger.Debugf("Read settings from Image Updater CR")
 					mergedCommonUpdateSettings = mergeCommonUpdateSettings(globalUpdateSettings, applicationRef.CommonUpdateSettings)
 					mergedWBCSettings = mergeWBCSettings(cr.Spec.WriteBackConfig, applicationRef.WriteBackConfig)
-					appWBCSettings, err = newWBCFromSettings(appCtx, &app, kubeClient, mergedWBCSettings)
+					appWBCSettings, err = newWBCFromSettings(appCtx, &app, kubeClient, argocdDB, mergedWBCSettings)
 					if err != nil {
 						appLogger.Warnf("Could not create write-back config, skipping: %v", err)
 						continue
@@ -491,10 +492,11 @@ func mergeWBCSettings(global *iuapi.WriteBackConfig, appWBC *iuapi.WriteBackConf
 // newWBCFromSettings creates a new WriteBackConfig from a given, final set of
 // settings within the context of a specific application. It is responsible for
 // resolving all app-dependent fields, like target paths.
-func newWBCFromSettings(ctx context.Context, app *argocdapi.Application, kubeClient *kube.ImageUpdaterKubernetesClient, settings *iuapi.WriteBackConfig) (*WriteBackConfig, error) {
+func newWBCFromSettings(ctx context.Context, app *argocdapi.Application, kubeClient *kube.ImageUpdaterKubernetesClient, argocdDB db.ArgoDB, settings *iuapi.WriteBackConfig) (*WriteBackConfig, error) {
 	wbc := &WriteBackConfig{
 		Method:                 WriteBackApplication,
 		ArgoClient:             nil,
+		ArgocdDB:               argocdDB,
 		GitClient:              nil,
 		GetCreds:               nil,
 		GitBranch:              "",

--- a/pkg/argocd/argocd_test.go
+++ b/pkg/argocd/argocd_test.go
@@ -2364,7 +2364,7 @@ func Test_newWBCFromSettings(t *testing.T) {
 	t.Run("should return argocd method and default file path target when settings are empty", func(t *testing.T) {
 		app, kubeClient := createTestAppAndClient()
 		settings := &api.WriteBackConfig{}
-		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, nil, settings)
 		assert.NoError(t, err)
 		assert.NotNil(t, wbc)
 		assert.Equal(t, WriteBackApplication, wbc.Method)
@@ -2374,7 +2374,7 @@ func Test_newWBCFromSettings(t *testing.T) {
 	t.Run("should return argocd method and default file path target when settings are nil", func(t *testing.T) {
 		app, kubeClient := createTestAppAndClient()
 		var settings *api.WriteBackConfig = nil
-		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, nil, settings)
 		assert.NoError(t, err)
 		assert.NotNil(t, wbc)
 		assert.Equal(t, WriteBackApplication, wbc.Method)
@@ -2386,7 +2386,7 @@ func Test_newWBCFromSettings(t *testing.T) {
 		settings := &api.WriteBackConfig{
 			Method: strPtr("git"),
 		}
-		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, nil, settings)
 		assert.NoError(t, err)
 		assert.Equal(t, WriteBackGit, wbc.Method)
 		assert.Equal(t, "some/path/.argocd-source-argocd-test_my-app.yaml", wbc.Target)
@@ -2400,7 +2400,7 @@ func Test_newWBCFromSettings(t *testing.T) {
 				WriteBackTarget: strPtr("helmvalues:another/values.yaml"),
 			},
 		}
-		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, nil, settings)
 		assert.NoError(t, err)
 		assert.Equal(t, WriteBackGit, wbc.Method)
 		assert.Equal(t, "some/path/another/values.yaml", wbc.Target)
@@ -2414,7 +2414,7 @@ func Test_newWBCFromSettings(t *testing.T) {
 				WriteBackTarget: strPtr("kustomization:overlays/prod"),
 			},
 		}
-		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, nil, settings)
 		assert.NoError(t, err)
 		assert.Equal(t, WriteBackGit, wbc.Method)
 		assert.Equal(t, "some/path/overlays/prod", wbc.KustomizeBase)
@@ -2429,7 +2429,7 @@ func Test_newWBCFromSettings(t *testing.T) {
 				Branch: strPtr("main:feature-branch"),
 			},
 		}
-		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, nil, settings)
 		assert.NoError(t, err)
 		assert.Equal(t, WriteBackGit, wbc.Method)
 		assert.Equal(t, "main", wbc.GitBranch)
@@ -2441,7 +2441,7 @@ func Test_newWBCFromSettings(t *testing.T) {
 		settings := &api.WriteBackConfig{
 			Method: strPtr("unsupported"),
 		}
-		_, err := newWBCFromSettings(context.Background(), app, kubeClient, settings)
+		_, err := newWBCFromSettings(context.Background(), app, kubeClient, nil, settings)
 		assert.Error(t, err)
 	})
 
@@ -2454,7 +2454,7 @@ func Test_newWBCFromSettings(t *testing.T) {
 				PullRequest: &api.PullRequest{GitHub: &api.PullRequestGitHub{}},
 			},
 		}
-		_, err := newWBCFromSettings(context.Background(), app, kubeClient, settings)
+		_, err := newWBCFromSettings(context.Background(), app, kubeClient, nil, settings)
 		assert.ErrorContains(t, err, "pullRequest mode does not support colon branch format")
 	})
 
@@ -2467,7 +2467,7 @@ func Test_newWBCFromSettings(t *testing.T) {
 				PullRequest: &api.PullRequest{GitHub: &api.PullRequestGitHub{}},
 			},
 		}
-		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, nil, settings)
 		assert.NoError(t, err)
 		assert.Equal(t, PRProviderGitHub, wbc.PRProvider)
 	})
@@ -2480,7 +2480,7 @@ func Test_newWBCFromSettings(t *testing.T) {
 				PullRequest: &api.PullRequest{GitHub: &api.PullRequestGitHub{}},
 			},
 		}
-		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, nil, settings)
 		assert.NoError(t, err)
 		assert.Equal(t, PRProviderGitHub, wbc.PRProvider)
 	})
@@ -2493,7 +2493,7 @@ func Test_newWBCFromSettings(t *testing.T) {
 				PullRequest: &api.PullRequest{GitLab: &api.PullRequestGitLab{}},
 			},
 		}
-		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, nil, settings)
 		assert.NoError(t, err)
 		assert.Equal(t, PRProviderGitLab, wbc.PRProvider)
 	})
@@ -2506,7 +2506,7 @@ func Test_newWBCFromSettings(t *testing.T) {
 				PullRequest: &api.PullRequest{},
 			},
 		}
-		_, err := newWBCFromSettings(context.Background(), app, kubeClient, settings)
+		_, err := newWBCFromSettings(context.Background(), app, kubeClient, nil, settings)
 		assert.ErrorContains(t, err, "pullRequest must have exactly one provider configured, got 0")
 	})
 
@@ -2521,7 +2521,7 @@ func Test_newWBCFromSettings(t *testing.T) {
 				},
 			},
 		}
-		_, err := newWBCFromSettings(context.Background(), app, kubeClient, settings)
+		_, err := newWBCFromSettings(context.Background(), app, kubeClient, nil, settings)
 		assert.ErrorContains(t, err, "pullRequest must have exactly one provider configured, got 2")
 	})
 
@@ -2530,7 +2530,7 @@ func Test_newWBCFromSettings(t *testing.T) {
 		settings := &api.WriteBackConfig{
 			Method: strPtr("git"),
 		}
-		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, nil, settings)
 		assert.NoError(t, err)
 		assert.Equal(t, PRProviderUnsupported, wbc.PRProvider)
 	})
@@ -3896,7 +3896,7 @@ func Test_FilterApplicationsForUpdate(t *testing.T) {
 				},
 			}
 			// Execute
-			appsForUpdate, err := FilterApplicationsForUpdate(ctx, client, &kubeClient, tc.imageUpdaterCR, nil)
+			appsForUpdate, err := FilterApplicationsForUpdate(ctx, client, &kubeClient, nil, tc.imageUpdaterCR, nil)
 
 			// Assert
 			if tc.expectError {

--- a/pkg/argocd/gitcreds.go
+++ b/pkg/argocd/gitcreds.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v3/util/cert"
-	"github.com/argoproj/argo-cd/v3/util/db"
 
 	"github.com/argoproj-labs/argocd-image-updater/ext/git"
 	"github.com/argoproj-labs/argocd-image-updater/pkg/kube"
@@ -21,7 +20,7 @@ func getGitCredsSource(ctx context.Context, creds string, kubeClient *kube.Image
 	switch {
 	case creds == "repocreds":
 		return func(app *v1alpha1.Application) (git.Creds, error) {
-			return getCredsFromArgoCD(ctx, wbc, wbc.ArgocdDB, app.Spec.Project)
+			return getCredsFromArgoCD(ctx, wbc, app.Spec.Project)
 		}, nil
 	case strings.HasPrefix(creds, "secret:"):
 		return func(app *v1alpha1.Application) (git.Creds, error) {
@@ -33,11 +32,11 @@ func getGitCredsSource(ctx context.Context, creds string, kubeClient *kube.Image
 
 // getCredsFromArgoCD loads repository credentials from Argo CD settings
 // using the shared ArgocdDB instance to avoid creating per-call informer goroutines.
-func getCredsFromArgoCD(ctx context.Context, wbc *WriteBackConfig, argocdDB db.ArgoDB, project string) (git.Creds, error) {
-	if argocdDB == nil {
+func getCredsFromArgoCD(ctx context.Context, wbc *WriteBackConfig, project string) (git.Creds, error) {
+	if wbc.ArgocdDB == nil {
 		return nil, fmt.Errorf("argocd database not configured for repository credential lookup")
 	}
-	repo, err := argocdDB.GetRepository(ctx, wbc.GitRepo, project)
+	repo, err := wbc.ArgocdDB.GetRepository(ctx, wbc.GitRepo, project)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/argocd/gitcreds.go
+++ b/pkg/argocd/gitcreds.go
@@ -10,7 +10,6 @@ import (
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v3/util/cert"
 	"github.com/argoproj/argo-cd/v3/util/db"
-	"github.com/argoproj/argo-cd/v3/util/settings"
 
 	"github.com/argoproj-labs/argocd-image-updater/ext/git"
 	"github.com/argoproj-labs/argocd-image-updater/pkg/kube"
@@ -22,7 +21,7 @@ func getGitCredsSource(ctx context.Context, creds string, kubeClient *kube.Image
 	switch {
 	case creds == "repocreds":
 		return func(app *v1alpha1.Application) (git.Creds, error) {
-			return getCredsFromArgoCD(ctx, wbc, kubeClient, app.Spec.Project)
+			return getCredsFromArgoCD(ctx, wbc, wbc.ArgocdDB, app.Spec.Project)
 		}, nil
 	case strings.HasPrefix(creds, "secret:"):
 		return func(app *v1alpha1.Application) (git.Creds, error) {
@@ -33,12 +32,11 @@ func getGitCredsSource(ctx context.Context, creds string, kubeClient *kube.Image
 }
 
 // getCredsFromArgoCD loads repository credentials from Argo CD settings
-func getCredsFromArgoCD(ctx context.Context, wbc *WriteBackConfig, kubeClient *kube.ImageUpdaterKubernetesClient, project string) (git.Creds, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	settingsMgr := settings.NewSettingsManager(ctx, kubeClient.KubeClient.Clientset, kubeClient.KubeClient.Namespace)
-	argocdDB := db.NewDB(kubeClient.KubeClient.Namespace, settingsMgr, kubeClient.KubeClient.Clientset)
+// using the shared ArgocdDB instance to avoid creating per-call informer goroutines.
+func getCredsFromArgoCD(ctx context.Context, wbc *WriteBackConfig, argocdDB db.ArgoDB, project string) (git.Creds, error) {
+	if argocdDB == nil {
+		return nil, fmt.Errorf("argocd database not configured for repository credential lookup")
+	}
 	repo, err := argocdDB.GetRepository(ctx, wbc.GitRepo, project)
 	if err != nil {
 		return nil, err

--- a/pkg/argocd/gitcreds_test.go
+++ b/pkg/argocd/gitcreds_test.go
@@ -11,8 +11,11 @@ import (
 	"github.com/argoproj-labs/argocd-image-updater/test/fixture"
 
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v3/util/db"
+	"github.com/argoproj/argo-cd/v3/util/settings"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetCredsFromSecret(t *testing.T) {
@@ -252,4 +255,61 @@ func TestGetGitCreds(t *testing.T) {
 	expectedNopCreds := git.NopCreds{}
 	nopCreds := GetGitCreds(ctx, nil, store)
 	assert.Equal(t, expectedNopCreds, nopCreds)
+}
+
+func TestGetCredsFromArgoCD(t *testing.T) {
+	t.Run("nil ArgocdDB returns error", func(t *testing.T) {
+		wbc := &WriteBackConfig{
+			GitRepo:  "https://github.com/example/repo.git",
+			GitCreds: git.NoopCredsStore{},
+		}
+		creds, err := getCredsFromArgoCD(context.Background(), wbc, "default")
+		require.Error(t, err)
+		assert.Nil(t, creds)
+		assert.Contains(t, err.Error(), "argocd database not configured")
+	})
+
+	t.Run("repository with no credentials returns error", func(t *testing.T) {
+		clientset := fake.NewFakeClientsetWithResources()
+		settingsMgr := settings.NewSettingsManager(context.Background(), clientset, "argocd")
+		argocdDB := db.NewDB("argocd", settingsMgr, clientset)
+
+		wbc := &WriteBackConfig{
+			GitRepo:  "https://github.com/example/repo.git",
+			GitCreds: git.NoopCredsStore{},
+			ArgocdDB: argocdDB,
+		}
+		creds, err := getCredsFromArgoCD(context.Background(), wbc, "default")
+		require.Error(t, err)
+		assert.Nil(t, creds)
+		assert.Contains(t, err.Error(), "credentials for 'https://github.com/example/repo.git' are not configured")
+	})
+
+	t.Run("HTTPS credentials found", func(t *testing.T) {
+		repoSecret := fixture.NewSecret("argocd", "repo-creds", map[string][]byte{
+			"type":     []byte("git"),
+			"url":      []byte("https://github.com/example/repo.git"),
+			"username": []byte("myuser"),
+			"password": []byte("mypass"),
+		})
+		repoSecret.Labels = map[string]string{
+			"argocd.argoproj.io/secret-type": "repository",
+		}
+		fixture.AddPartOfArgoCDLabel(repoSecret)
+
+		clientset := fake.NewFakeClientsetWithResources(repoSecret)
+		settingsMgr := settings.NewSettingsManager(context.Background(), clientset, "argocd")
+		argocdDB := db.NewDB("argocd", settingsMgr, clientset)
+
+		wbc := &WriteBackConfig{
+			GitRepo:  "https://github.com/example/repo.git",
+			GitCreds: git.NoopCredsStore{},
+			ArgocdDB: argocdDB,
+		}
+		creds, err := getCredsFromArgoCD(context.Background(), wbc, "")
+		require.NoError(t, err)
+		require.NotNil(t, creds)
+		_, ok := creds.(git.HTTPSCreds)
+		assert.True(t, ok)
+	})
 }

--- a/pkg/argocd/gitcreds_test.go
+++ b/pkg/argocd/gitcreds_test.go
@@ -309,7 +309,9 @@ func TestGetCredsFromArgoCD(t *testing.T) {
 		creds, err := getCredsFromArgoCD(context.Background(), wbc, "")
 		require.NoError(t, err)
 		require.NotNil(t, creds)
-		_, ok := creds.(git.HTTPSCreds)
-		assert.True(t, ok)
+		assert.Equal(t,
+			git.NewHTTPSCreds("myuser", "mypass", "", "", false, "", git.NoopCredsStore{}, false),
+			creds,
+		)
 	})
 }

--- a/pkg/argocd/types.go
+++ b/pkg/argocd/types.go
@@ -5,6 +5,7 @@ import (
 	"text/template"
 
 	argocdapi "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v3/util/db"
 
 	"github.com/argoproj-labs/argocd-image-updater/ext/git"
 	"github.com/argoproj-labs/argocd-image-updater/pkg/kube"
@@ -29,6 +30,7 @@ type UpdateConfiguration struct {
 	NewRegFN               registry.NewRegistryClient
 	ArgoClient             ArgoCD
 	KubeClient             *kube.ImageUpdaterKubernetesClient
+	ArgocdDB               db.ArgoDB
 	UpdateApp              *ApplicationImages
 	DryRun                 bool
 	GitCommitUser          string
@@ -70,6 +72,7 @@ const (
 type WriteBackConfig struct {
 	Method     WriteBackMethod
 	ArgoClient ArgoCD
+	ArgocdDB   db.ArgoDB
 	// If GitClient is not nil, the client will be used for updates. Otherwise, a new client will be created.
 	GitClient              git.Client
 	GetCreds               GitCredsSource

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -27,13 +27,21 @@ import (
 
 	"github.com/argoproj/argo-cd/v3/pkg/apiclient/application"
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v3/util/db"
+	"github.com/argoproj/argo-cd/v3/util/settings"
 	"github.com/distribution/distribution/v3/manifest/schema2"
 	"github.com/distribution/distribution/v3/registry/api/errcode"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
+
+func newTestArgoDB(clientset kubernetes.Interface, namespace string) db.ArgoDB {
+	settingsMgr := settings.NewSettingsManager(context.Background(), clientset, namespace)
+	return db.NewDB(namespace, settingsMgr, clientset)
+}
 
 func Test_UpdateApplication(t *testing.T) {
 	t.Run("Test kustomize w/ multiple images w/ different registry w/ different tags", func(t *testing.T) {
@@ -4693,7 +4701,7 @@ func Test_GetWriteBackConfig(t *testing.T) {
 			},
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, nil, settings)
 		require.NoError(t, err)
 		require.NotNil(t, wbc)
 		assert.Equal(t, wbc.Method, WriteBackGit)
@@ -4731,7 +4739,7 @@ func Test_GetWriteBackConfig(t *testing.T) {
 			},
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, nil, settings)
 		require.NoError(t, err)
 		require.NotNil(t, wbc)
 		assert.Equal(t, "", wbc.GitBranch)
@@ -4768,7 +4776,7 @@ func Test_GetWriteBackConfig(t *testing.T) {
 			},
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, nil, settings)
 		require.NoError(t, err)
 		require.NotNil(t, wbc)
 		assert.Equal(t, "mybranch", wbc.GitBranch)
@@ -4805,7 +4813,7 @@ func Test_GetWriteBackConfig(t *testing.T) {
 			Method: stringPtr("argocd"),
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, nil, settings)
 		require.NoError(t, err)
 		require.NotNil(t, wbc)
 		assert.Equal(t, wbc.Method, WriteBackApplication)
@@ -4846,7 +4854,7 @@ func Test_GetWriteBackConfig(t *testing.T) {
 			},
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, nil, settings)
 		require.NoError(t, err)
 		require.NotNil(t, wbc)
 		assert.Equal(t, wbc.Method, WriteBackGit)
@@ -4888,7 +4896,7 @@ func Test_GetWriteBackConfig(t *testing.T) {
 			},
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, nil, settings)
 		require.NoError(t, err)
 		require.NotNil(t, wbc)
 		assert.Equal(t, wbc.Method, WriteBackGit)
@@ -4930,7 +4938,7 @@ func Test_GetWriteBackConfig(t *testing.T) {
 			},
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, nil, settings)
 		require.NoError(t, err)
 		require.NotNil(t, wbc)
 		assert.Equal(t, wbc.Method, WriteBackGit)
@@ -4972,7 +4980,7 @@ func Test_GetWriteBackConfig(t *testing.T) {
 			},
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, nil, settings)
 		require.NoError(t, err)
 		require.NotNil(t, wbc)
 		assert.Equal(t, wbc.Method, WriteBackGit)
@@ -5014,7 +5022,7 @@ func Test_GetWriteBackConfig(t *testing.T) {
 			},
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, nil, settings)
 		require.NoError(t, err)
 		require.NotNil(t, wbc)
 		assert.Equal(t, wbc.Method, WriteBackGit)
@@ -5055,7 +5063,7 @@ func Test_GetWriteBackConfig(t *testing.T) {
 			},
 		}
 
-		_, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		_, err := newWBCFromSettings(context.Background(), &app, &kubeClient, nil, settings)
 		assert.Error(t, err)
 	})
 
@@ -5092,7 +5100,7 @@ func Test_GetWriteBackConfig(t *testing.T) {
 			},
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, nil, settings)
 		require.NoError(t, err)
 		require.NotNil(t, wbc)
 		assert.Equal(t, wbc.Method, WriteBackApplication)
@@ -5131,7 +5139,7 @@ func Test_GetWriteBackConfig(t *testing.T) {
 			},
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, nil, settings)
 		require.Error(t, err)
 		require.Nil(t, wbc)
 	})
@@ -5173,7 +5181,7 @@ func Test_GetGitCreds(t *testing.T) {
 			},
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, nil, settings)
 		require.NoError(t, err)
 
 		creds, err := wbc.GetCreds(&app)
@@ -5219,7 +5227,7 @@ func Test_GetGitCreds(t *testing.T) {
 			},
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, nil, settings)
 		require.NoError(t, err)
 
 		creds, err := wbc.GetCreds(&app)
@@ -5259,13 +5267,13 @@ func Test_GetGitCreds(t *testing.T) {
 			}
 			// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 			settings := &iuapi.WriteBackConfig{
-				Method: stringPtr("git"),
+				Method: stringPtr("git:secret:argocd-image-updater/git-creds"),
 				GitConfig: &iuapi.GitConfig{
 					Branch: stringPtr("mybranch:mytargetbranch"),
 				},
 			}
 
-			wbc, err = newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+			wbc, err = newWBCFromSettings(context.Background(), &app, &kubeClient, nil, settings)
 			require.NoError(t, err)
 			_, err = wbc.GetCreds(&app)
 			require.Error(t, err)
@@ -5305,7 +5313,7 @@ func Test_GetGitCreds(t *testing.T) {
 			},
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, nil, settings)
 		require.NoError(t, err)
 
 		creds, err := wbc.GetCreds(&app)
@@ -5334,12 +5342,14 @@ func Test_GetGitCreds(t *testing.T) {
 		}
 		fixture.AddPartOfArgoCDLabel(secret, repoSecret)
 
+		clientset := fake.NewFakeClientsetWithResources(secret, repoSecret)
 		kubeClient := kube.ImageUpdaterKubernetesClient{
 			KubeClient: &registryKube.KubernetesClient{
-				Clientset: fake.NewFakeClientsetWithResources(secret, repoSecret),
+				Clientset: clientset,
 				Namespace: "argocd",
 			},
 		}
+		argocdDB := newTestArgoDB(clientset, "argocd")
 		app := v1alpha1.Application{
 			ObjectMeta: v1.ObjectMeta{
 				Name: "testapp",
@@ -5362,7 +5372,7 @@ func Test_GetGitCreds(t *testing.T) {
 			},
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, argocdDB, settings)
 		require.NoError(t, err)
 
 		creds, err := wbc.GetCreds(&app)
@@ -5379,11 +5389,13 @@ func Test_GetGitCreds(t *testing.T) {
 		secret := fixture.NewSecret("argocd-image-updater", "git-creds", map[string][]byte{
 			"sshPrivateKex": []byte("foo"),
 		})
+		clientset := fake.NewFakeClientsetWithResources(secret)
 		kubeClient := kube.ImageUpdaterKubernetesClient{
 			KubeClient: &registryKube.KubernetesClient{
-				Clientset: fake.NewFakeClientsetWithResources(secret),
+				Clientset: clientset,
 			},
 		}
+		argocdDB := newTestArgoDB(clientset, "")
 		app := v1alpha1.Application{
 			ObjectMeta: v1.ObjectMeta{
 				Name: "testapp",
@@ -5406,7 +5418,7 @@ func Test_GetGitCreds(t *testing.T) {
 			},
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, argocdDB, settings)
 		require.NoError(t, err)
 
 		creds, err := wbc.GetCreds(&app)
@@ -5420,11 +5432,13 @@ func Test_GetGitCreds(t *testing.T) {
 		secret := fixture.NewSecret("argocd-image-updater", "git-creds", map[string][]byte{
 			"sshPrivateKey": []byte("foo"),
 		})
+		clientset := fake.NewFakeClientsetWithResources(secret)
 		kubeClient := kube.ImageUpdaterKubernetesClient{
 			KubeClient: &registryKube.KubernetesClient{
-				Clientset: fake.NewFakeClientsetWithResources(secret),
+				Clientset: clientset,
 			},
 		}
+		argocdDB := newTestArgoDB(clientset, "")
 		app := v1alpha1.Application{
 			ObjectMeta: v1.ObjectMeta{
 				Name: "testapp",
@@ -5447,7 +5461,7 @@ func Test_GetGitCreds(t *testing.T) {
 			},
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, argocdDB, settings)
 		require.NoError(t, err)
 
 		creds, err := wbc.GetCreds(&app)
@@ -5461,11 +5475,13 @@ func Test_GetGitCreds(t *testing.T) {
 		secret := fixture.NewSecret("argocd-image-updater", "git-creds", map[string][]byte{
 			"sshPrivateKey": []byte("foo"),
 		})
+		clientset := fake.NewFakeClientsetWithResources(secret)
 		kubeClient := kube.ImageUpdaterKubernetesClient{
 			KubeClient: &registryKube.KubernetesClient{
-				Clientset: fake.NewFakeClientsetWithResources(secret),
+				Clientset: clientset,
 			},
 		}
+		argocdDB := newTestArgoDB(clientset, "")
 		app := v1alpha1.Application{
 			ObjectMeta: v1.ObjectMeta{
 				Name: "testapp",
@@ -5488,7 +5504,7 @@ func Test_GetGitCreds(t *testing.T) {
 			},
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, argocdDB, settings)
 		require.NoError(t, err)
 
 		creds, err := wbc.GetCreds(&app)
@@ -5532,7 +5548,7 @@ func Test_GetGitCreds(t *testing.T) {
 			},
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, nil, settings)
 		require.NoError(t, err)
 		require.Equal(t, wbc.GitRepo, "git@github.com:example/example.git")
 
@@ -5551,9 +5567,11 @@ func Test_CommitUpdates(t *testing.T) {
 	secret := fixture.NewSecret("argocd-image-updater", "git-creds", map[string][]byte{
 		"sshPrivateKey": []byte("foo"),
 	})
+	clientset := fake.NewFakeClientsetWithResources(secret)
+	commitTestArgoDB := newTestArgoDB(clientset, "")
 	kubeClient := kube.ImageUpdaterKubernetesClient{
 		KubeClient: &registryKube.KubernetesClient{
-			Clientset: fake.NewFakeClientsetWithResources(secret),
+			Clientset: clientset,
 		},
 	}
 	app := v1alpha1.Application{
@@ -5583,7 +5601,7 @@ func Test_CommitUpdates(t *testing.T) {
 		ctx := context.Background()
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		// Pass nil settings to test the default target revision fallback
-		wbc, err := newWBCFromSettings(ctx, &app, &kubeClient, nil)
+		wbc, err := newWBCFromSettings(ctx, &app, &kubeClient, nil, nil)
 		require.NoError(t, err)
 		wbc.Method = WriteBackGit
 		wbc.GetCreds = func(app *v1alpha1.Application) (git.Creds, error) {
@@ -5612,7 +5630,7 @@ func Test_CommitUpdates(t *testing.T) {
 		gitMock.On("SymRefToBranch", mock.Anything).Return("mydefaultbranch", nil)
 
 		ctx := context.Background()
-		wbc, err := newWBCFromSettings(ctx, &app, &kubeClient, nil)
+		wbc, err := newWBCFromSettings(ctx, &app, &kubeClient, nil, nil)
 		require.NoError(t, err)
 		wbc.Method = WriteBackGit
 		wbc.GetCreds = func(app *v1alpha1.Application) (git.Creds, error) {
@@ -5643,7 +5661,7 @@ func Test_CommitUpdates(t *testing.T) {
 		gitMock.On("SymRefToBranch", mock.Anything).Return("mydefaultbranch", nil)
 
 		ctx := context.Background()
-		wbc, err := newWBCFromSettings(ctx, app, &kubeClient, nil)
+		wbc, err := newWBCFromSettings(ctx, app, &kubeClient, nil, nil)
 		require.NoError(t, err)
 		wbc.Method = WriteBackGit
 		wbc.GetCreds = func(app *v1alpha1.Application) (git.Creds, error) {
@@ -5672,7 +5690,7 @@ func Test_CommitUpdates(t *testing.T) {
 		gitMock.On("Push", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		gitMock.On("SymRefToBranch", mock.Anything).Return("mydefaultbranch", nil)
 		ctx := context.Background()
-		wbc, err := newWBCFromSettings(ctx, &app, &kubeClient, nil)
+		wbc, err := newWBCFromSettings(ctx, &app, &kubeClient, nil, nil)
 		require.NoError(t, err)
 		wbc.Method = WriteBackGit
 		wbc.GetCreds = func(app *v1alpha1.Application) (git.Creds, error) {
@@ -5728,7 +5746,7 @@ helm:
 		gitMock.On("SymRefToBranch", mock.Anything).Return("mydefaultbranch", nil)
 
 		ctx := context.Background()
-		wbc, err := newWBCFromSettings(ctx, app, &kubeClient, nil)
+		wbc, err := newWBCFromSettings(ctx, app, &kubeClient, nil, nil)
 		wbc.Method = WriteBackGit
 		wbc.GetCreds = func(app *v1alpha1.Application) (git.Creds, error) {
 			return git.NopCreds{}, nil
@@ -5791,7 +5809,7 @@ helm:
 		gitMock.On("SymRefToBranch", mock.Anything).Return("mydefaultbranch", nil)
 
 		ctx := context.Background()
-		wbc, err := newWBCFromSettings(ctx, app, &kubeClient, nil)
+		wbc, err := newWBCFromSettings(ctx, app, &kubeClient, nil, nil)
 		wbc.Method = WriteBackGit
 		wbc.GetCreds = func(app *v1alpha1.Application) (git.Creds, error) {
 			return git.NopCreds{}, nil
@@ -5854,7 +5872,7 @@ helm:
 		gitMock.On("SymRefToBranch", mock.Anything).Return("mydefaultbranch", nil)
 
 		ctx := context.Background()
-		wbc, err := newWBCFromSettings(ctx, app, &kubeClient, nil)
+		wbc, err := newWBCFromSettings(ctx, app, &kubeClient, nil, nil)
 		require.NoError(t, err)
 		wbc.Method = WriteBackGit
 		wbc.GetCreds = func(app *v1alpha1.Application) (git.Creds, error) {
@@ -5910,7 +5928,7 @@ replacements: []
 		gitMock.On("SymRefToBranch", mock.Anything).Return("mydefaultbranch", nil)
 
 		ctx := context.Background()
-		wbc, err := newWBCFromSettings(ctx, app, &kubeClient, nil)
+		wbc, err := newWBCFromSettings(ctx, app, &kubeClient, nil, nil)
 		require.NoError(t, err)
 		wbc.Method = WriteBackGit
 		wbc.GetCreds = func(app *v1alpha1.Application) (git.Creds, error) {
@@ -5984,7 +6002,7 @@ replacements: []
 		}).Return(nil)
 
 		ctx := context.Background()
-		wbc, err := newWBCFromSettings(ctx, app, &kubeClient, nil)
+		wbc, err := newWBCFromSettings(ctx, app, &kubeClient, nil, nil)
 		wbc.Method = WriteBackGit
 		wbc.GetCreds = func(app *v1alpha1.Application) (git.Creds, error) {
 			return git.NopCreds{}, nil
@@ -6030,7 +6048,7 @@ replacements: []
 		}
 
 		ctx := context.Background()
-		wbc, err := newWBCFromSettings(ctx, app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(ctx, app, &kubeClient, commitTestArgoDB, settings)
 		require.NoError(t, err)
 		wbc.GitClient = gitMock
 		app.Spec.Source.TargetRevision = "HEAD"
@@ -6062,7 +6080,7 @@ replacements: []
 			},
 		}
 		ctx := context.Background()
-		wbc, err := newWBCFromSettings(ctx, &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(ctx, &app, &kubeClient, commitTestArgoDB, settings)
 		require.NoError(t, err)
 		wbc.GitClient = gitMock
 
@@ -6090,7 +6108,7 @@ replacements: []
 			},
 		}
 		ctx := context.Background()
-		wbc, err := newWBCFromSettings(ctx, &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(ctx, &app, &kubeClient, commitTestArgoDB, settings)
 		require.NoError(t, err)
 		wbc.GitClient = gitMock
 
@@ -6117,7 +6135,7 @@ replacements: []
 			},
 		}
 		ctx := context.Background()
-		wbc, err := newWBCFromSettings(ctx, &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(ctx, &app, &kubeClient, commitTestArgoDB, settings)
 		require.NoError(t, err)
 		wbc.GitClient = gitMock
 
@@ -6145,7 +6163,7 @@ replacements: []
 			},
 		}
 		ctx := context.Background()
-		wbc, err := newWBCFromSettings(ctx, &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(ctx, &app, &kubeClient, commitTestArgoDB, settings)
 		require.NoError(t, err)
 		wbc.GitClient = gitMock
 
@@ -6173,7 +6191,7 @@ replacements: []
 			},
 		}
 		ctx := context.Background()
-		wbc, err := newWBCFromSettings(ctx, &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(ctx, &app, &kubeClient, commitTestArgoDB, settings)
 		require.NoError(t, err)
 		wbc.GitClient = gitMock
 
@@ -6204,7 +6222,7 @@ replacements: []
 		}
 
 		ctx := context.Background()
-		wbc, err := newWBCFromSettings(ctx, app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(ctx, app, &kubeClient, commitTestArgoDB, settings)
 		require.NoError(t, err)
 		wbc.GitClient = gitMock
 		app.Spec.Source.TargetRevision = "HEAD"


### PR DESCRIPTION
This fix should be backported to `release-1.1` and `release-1.2` branches to be included in next z-stream releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of Argo CD–backed image updates by reusing a shared Argo CD settings manager and database for credential lookups, preventing background resource leaks and redundant initialization.
  * Repository credential resolution now fails with clear errors when the Argo CD DB is not configured.
* **Tests**
  * Added and updated tests and helpers to validate Argo CD DB integration and credential lookup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->