### PR TITLE
feat(webhook): add Azure Container Registry (ACR) webhook handler

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -41,6 +41,8 @@ type WebhookConfig struct {
 	HarborSecret string
 	// AliyunACRSecret is the secret for validating Aliyun ACR webhooks
 	AliyunACRSecret string
+	// ACRSecret is the secret for validating Azure ACR webhooks
+	ACRSecret string
 	// CloudEventsSecret is the secret for validating CloudEvents webhooks
 	CloudEventsSecret string
 	// RateLimitNumAllowedRequests is the number of allowed requests per hour for rate limiting (0 disables rate limiting)
@@ -163,6 +165,7 @@ func SetupWebhookServer(ctx context.Context, webhookCfg *WebhookConfig, reconcil
 		handler.RegisterHandler(webhook.NewHarborWebhook(webhookCfg.HarborSecret))
 		handler.RegisterHandler(webhook.NewQuayWebhook(webhookCfg.QuaySecret))
 		handler.RegisterHandler(webhook.NewAliyunACRWebhook(webhookCfg.AliyunACRSecret))
+		handler.RegisterHandler(webhook.NewACRWebhook(webhookCfg.ACRSecret))
 		handler.RegisterHandler(webhook.NewCloudEventsWebhook(webhookCfg.CloudEventsSecret))
 	} else {
 		// Secure mode (default): only register handlers for which a secret has been
@@ -192,6 +195,11 @@ func SetupWebhookServer(ctx context.Context, webhookCfg *WebhookConfig, reconcil
 		if webhookCfg.AliyunACRSecret != "" {
 			handler.RegisterHandler(webhook.NewAliyunACRWebhook(webhookCfg.AliyunACRSecret))
 			log.Infof("Registered Aliyun ACR webhook handler")
+			registered++
+		}
+		if webhookCfg.ACRSecret != "" {
+			handler.RegisterHandler(webhook.NewACRWebhook(webhookCfg.ACRSecret))
+			log.Infof("Registered Azure ACR webhook handler")
 			registered++
 		}
 		if webhookCfg.CloudEventsSecret != "" {

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -81,6 +81,7 @@ func TestSetupWebhookServer_HandlerRegistration(t *testing.T) {
 	reconciler := &controller.ImageUpdaterReconciler{}
 
 	allRegistryTypes := []string{
+		"acr",
 		"aliyun-acr",
 		"cloudevents",
 		"docker.io",
@@ -143,6 +144,7 @@ func TestSetupWebhookServer_HandlerRegistration(t *testing.T) {
 			HarborSecret:      "harbor-secret",
 			QuaySecret:        "quay-secret",
 			AliyunACRSecret:   "aliyun-secret",
+			ACRSecret:         "acr-secret",
 			CloudEventsSecret: "cloudevents-secret",
 		}
 		server := SetupWebhookServer(context.Background(), cfg, reconciler)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -334,6 +334,7 @@ This enables a CRD-driven approach to automated image updates with Argo CD.
 	controllerCmd.Flags().StringVar(&webhookCfg.QuaySecret, "quay-webhook-secret", env.GetStringVal("QUAY_WEBHOOK_SECRET", ""), "Secret for validating Quay webhooks")
 	controllerCmd.Flags().StringVar(&webhookCfg.HarborSecret, "harbor-webhook-secret", env.GetStringVal("HARBOR_WEBHOOK_SECRET", ""), "Secret for validating Harbor webhooks")
 	controllerCmd.Flags().StringVar(&webhookCfg.AliyunACRSecret, "aliyun-acr-webhook-secret", env.GetStringVal("ALIYUN_ACR_WEBHOOK_SECRET", ""), "Secret for validating Aliyun ACR webhooks")
+	controllerCmd.Flags().StringVar(&webhookCfg.ACRSecret, "acr-webhook-secret", env.GetStringVal("ACR_WEBHOOK_SECRET", ""), "Secret for validating Azure ACR webhooks")
 	controllerCmd.Flags().StringVar(&webhookCfg.CloudEventsSecret, "cloudevents-webhook-secret", env.GetStringVal("CLOUDEVENTS_WEBHOOK_SECRET", ""), "Secret for validating CloudEvents webhooks")
 	controllerCmd.Flags().IntVar(&webhookCfg.RateLimitNumAllowedRequests, "webhook-ratelimit-allowed", env.ParseNumFromEnv("WEBHOOK_RATELIMIT_ALLOWED", 0, 0, math.MaxInt), "The number of allowed requests in an hour for webhook rate limiting, setting to 0 disables ratelimiting")
 

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -73,6 +73,7 @@ func TestNewRunCommand(t *testing.T) {
 	asser.Equal(env.GetStringVal("HARBOR_WEBHOOK_SECRET", ""), controllerCommand.Flag("harbor-webhook-secret").Value.String())
 	asser.Equal(env.GetStringVal("CLOUDEVENTS_WEBHOOK_SECRET", ""), controllerCommand.Flag("cloudevents-webhook-secret").Value.String())
 	asser.Equal(env.GetStringVal("ALIYUN_ACR_WEBHOOK_SECRET", ""), controllerCommand.Flag("aliyun-acr-webhook-secret").Value.String())
+	asser.Equal(env.GetStringVal("ACR_WEBHOOK_SECRET", ""), controllerCommand.Flag("acr-webhook-secret").Value.String())
 	asser.Equal(strconv.Itoa(env.ParseNumFromEnv("WEBHOOK_RATELIMIT_ALLOWED", 0, 0, math.MaxInt)), controllerCommand.Flag("webhook-ratelimit-allowed").Value.String())
 
 	// TLS flags

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -98,6 +98,7 @@ Supported registries:
 	webhookCmd.Flags().StringVar(&webhookCfg.QuaySecret, "quay-webhook-secret", env.GetStringVal("QUAY_WEBHOOK_SECRET", ""), "Secret for validating Quay webhooks")
 	webhookCmd.Flags().StringVar(&webhookCfg.HarborSecret, "harbor-webhook-secret", env.GetStringVal("HARBOR_WEBHOOK_SECRET", ""), "Secret for validating Harbor webhooks")
 	webhookCmd.Flags().StringVar(&webhookCfg.AliyunACRSecret, "aliyun-acr-webhook-secret", env.GetStringVal("ALIYUN_ACR_WEBHOOK_SECRET", ""), "Secret for validating Aliyun ACR webhooks")
+	webhookCmd.Flags().StringVar(&webhookCfg.ACRSecret, "acr-webhook-secret", env.GetStringVal("ACR_WEBHOOK_SECRET", ""), "Secret for validating Azure ACR webhooks")
 	webhookCmd.Flags().StringVar(&webhookCfg.CloudEventsSecret, "cloudevents-webhook-secret", env.GetStringVal("CLOUDEVENTS_WEBHOOK_SECRET", ""), "Secret for validating CloudEvents webhooks")
 	webhookCmd.Flags().IntVar(&webhookCfg.RateLimitNumAllowedRequests, "webhook-ratelimit-allowed", env.ParseNumFromEnv("WEBHOOK_RATELIMIT_ALLOWED", 0, 0, math.MaxInt), "The number of allowed requests in an hour for webhook rate limiting, setting to 0 disables ratelimiting")
 

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -44,6 +44,7 @@ Supported registries:
 - Quay
 - Harbor
 - Aliyun ACR
+- Azure Container Registry (ACR)
 - AWS ECR (via EventBridge CloudEvents)
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/webhook_test.go
+++ b/cmd/webhook_test.go
@@ -45,6 +45,7 @@ func TestNewWebhookCommand(t *testing.T) {
 	asser.Equal(env.GetStringVal("HARBOR_WEBHOOK_SECRET", ""), controllerCommand.Flag("harbor-webhook-secret").Value.String())
 	asser.Equal(env.GetStringVal("CLOUDEVENTS_WEBHOOK_SECRET", ""), controllerCommand.Flag("cloudevents-webhook-secret").Value.String())
 	asser.Equal(env.GetStringVal("ALIYUN_ACR_WEBHOOK_SECRET", ""), controllerCommand.Flag("aliyun-acr-webhook-secret").Value.String())
+	asser.Equal(env.GetStringVal("ACR_WEBHOOK_SECRET", ""), controllerCommand.Flag("acr-webhook-secret").Value.String())
 	asser.Equal(strconv.Itoa(env.ParseNumFromEnv("WEBHOOK_RATELIMIT_ALLOWED", 0, 0, math.MaxInt)), controllerCommand.Flag("webhook-ratelimit-allowed").Value.String())
 
 	// TLS flags

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -1026,6 +1026,12 @@ spec:
               key: webhook.aliyun-acr-secret
               name: argocd-image-updater-secret
               optional: true
+        - name: ACR_WEBHOOK_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: webhook.acr-secret
+              name: argocd-image-updater-secret
+              optional: true
         - name: CLOUDEVENTS_WEBHOOK_SECRET
           valueFrom:
             secretKeyRef:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -180,6 +180,12 @@ spec:
                 name: argocd-image-updater-secret
                 key: webhook.aliyun-acr-secret
                 optional: true
+          - name: ACR_WEBHOOK_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: argocd-image-updater-secret
+                key: webhook.acr-secret
+                optional: true
           - name: CLOUDEVENTS_WEBHOOK_SECRET
             valueFrom:
               secretKeyRef:

--- a/docs/configuration/webhook.md
+++ b/docs/configuration/webhook.md
@@ -24,6 +24,7 @@ Currently Supported Registries:
 - Harbor
 - Quay
 - Aliyun ACR
+- Azure Container Registry (ACR)
 - AWS ECR (via EventBridge CloudEvents)
 
 Using webhooks can help reduce some of the stress that is put on the 
@@ -101,6 +102,7 @@ can be found here:
 - [Harbor](https://goharbor.io/docs/2.2.0/working-with-projects/project-configuration/configure-webhooks/)
 - [Quay](https://docs.quay.io/guides/notifications.html)
 - [Aliyun ACR](https://www.alibabacloud.com/help/en/acr/user-guide/manage-webhooks)
+- [Azure Container Registry](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-webhook)
 - [AWS ECR via EventBridge](#aws-ecr-via-eventbridge-cloudevents) (see below)
 
 For the URL that you set for the webhook, your link should go as the following:
@@ -113,6 +115,7 @@ https://app1.example.com/webhook?type=<YOUR_REGISTRY_TYPE>
 # Harbor = harbor
 # Quay = quay.io
 # Aliyun ACR = aliyun-acr
+# Azure Container Registry (ACR) = acr
 # AWS ECR (via CloudEvents) = cloudevents
 ```
 
@@ -123,6 +126,23 @@ Aliyun ACR (especially Enterprise Edition) uses various registry endpoints (e.g.
 ```text
 https://app1.example.com/webhook?type=aliyun-acr&registry_url=my-instance-registry.cn-shanghai.cr.aliyuncs.com
 ```
+
+### Azure Container Registry (ACR) Specifics
+
+Azure Container Registry has **no built-in HMAC signing** for webhooks. The webhook
+creation form in the Azure portal only exposes a Service URI and free-form custom
+headers, neither of which can be used for signing. ACR therefore uses the
+[parameter secret](#parameter-secrets) pattern: include the secret as a query
+parameter in the Service URI you configure in Azure.
+
+```text
+https://app1.example.com/webhook?type=acr&secret=<YOUR_SECRET>
+```
+
+The registry hostname, repository, tag and digest are taken directly from the
+payload (`request.host`, `target.repository`, `target.tag`, `target.digest`). Only
+events with `action: push` are processed; other actions (e.g. `delete`) are ignored.
+A push that carries an empty `target.tag` (digest-only push) is handled gracefully.
 
 ### AWS ECR via EventBridge CloudEvents
 
@@ -237,6 +257,7 @@ stringData:
   webhook.harbor-secret: <YOUR_SECRET>
   webhook.quay-secret: <YOUR_SECRET>
   webhook.aliyun-acr-secret: <YOUR_SECRET>
+  webhook.acr-secret: <YOUR_SECRET>
   webhook.cloudevents-secret: <YOUR_SECRET>
 ```
 
@@ -275,6 +296,7 @@ Supported Registries That Use This:
 - Docker Hub
 - Quay
 - Aliyun ACR
+- Azure Container Registry (ACR)
 - AWS ECR (via CloudEvents/EventBridge)
 
 Also be aware that if the container registry has a built-in secrets method you will
@@ -441,6 +463,7 @@ environment variables. Below is the list of which variables correspond to which 
 |`HARBOR_WEBHOOK_SECRET` |`--harbor-webhook-secret`|
 |`QUAY_WEBHOOK_SECRET` |`--quay-webhook-secret`|
 |`ALIYUN_ACR_WEBHOOK_SECRET` |`--aliyun-acr-webhook-secret`|
+|`ACR_WEBHOOK_SECRET` |`--acr-webhook-secret`|
 |`CLOUDEVENTS_WEBHOOK_SECRET` |`--cloudevents-webhook-secret`|
 |`WEBHOOK_RATELIMIT_ALLOWED`|`--webhook-ratelimit-allowed`|
 |`DISABLE_TLS`|`--disable-tls`|
@@ -468,6 +491,7 @@ registries supported.
 - [Quay](https://docs.quay.io/guides/notifications.html)
 (View Repository Push Section)
 - [Aliyun ACR](https://www.alibabacloud.com/help/en/acr/user-guide/manage-webhooks)
+- [Azure Container Registry](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-webhook)
 - [CloudEvents](#aws-ecr-via-eventbridge-cloudevents) (AWS ECR via EventBridge)
 
 ## Troubleshooting

--- a/docs/configuration/webhook.md
+++ b/docs/configuration/webhook.md
@@ -129,14 +129,26 @@ https://app1.example.com/webhook?type=aliyun-acr&registry_url=my-instance-regist
 
 ### Azure Container Registry (ACR) Specifics
 
-Azure Container Registry has **no built-in HMAC signing** for webhooks. The webhook
-creation form in the Azure portal only exposes a Service URI and free-form custom
-headers, neither of which can be used for signing. ACR therefore uses the
-[parameter secret](#parameter-secrets) pattern: include the secret as a query
-parameter in the Service URI you configure in Azure.
+Azure Container Registry has **no built-in HMAC signing** for webhooks, but it lets
+you attach arbitrary [custom HTTP headers](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-webhook-reference#http-headers)
+to its notifications. ACR therefore uses the same mechanism as the registries with
+[preexisting secret support](#registries-with-preexisting-support-for-secrets):
+configure an `Authorization` header on the webhook, and the handler validates it
+against the configured secret (constant-time comparison).
+
+Set the header when creating or updating the webhook with the Azure CLI
+([reference](https://learn.microsoft.com/en-us/cli/azure/acr/webhook?view=azure-cli-latest#az-acr-webhook-update-examples)):
+
+```bash
+az acr webhook update -n <webhook> -r <registry> --headers "Authorization=<YOUR_SECRET>"
+```
+
+The value you set for the `Authorization` header must match the secret configured in
+`argocd-image-updater-secret` (`webhook.acr-secret`) / the `--acr-webhook-secret`
+flag. The webhook URL itself only needs the registry type:
 
 ```text
-https://app1.example.com/webhook?type=acr&secret=<YOUR_SECRET>
+https://app1.example.com/webhook?type=acr
 ```
 
 The registry hostname, repository, tag and digest are taken directly from the
@@ -274,6 +286,7 @@ Supported Registries That Use This:
 
 - GitHub Container Registry
 - Harbor
+- Azure Container Registry (ACR)
 
 ### Parameter Secrets
 
@@ -296,7 +309,6 @@ Supported Registries That Use This:
 - Docker Hub
 - Quay
 - Aliyun ACR
-- Azure Container Registry (ACR)
 - AWS ECR (via CloudEvents/EventBridge)
 
 Also be aware that if the container registry has a built-in secrets method you will

--- a/docs/install/cmd/run.md
+++ b/docs/install/cmd/run.md
@@ -10,6 +10,14 @@ Runs the Argo CD Image Updater in a reconciliation loop with a set of options.
 
 ### Flags
 
+**--acr-webhook-secret *secret***
+
+Secret for validating Azure ACR webhooks. ACR has no built-in signing, so the
+secret is sent as the `Authorization` header value, which you configure on the
+webhook with `az acr webhook update --headers "Authorization=<secret>"`.
+
+Can also be set with the `ACR_WEBHOOK_SECRET` environment variable.
+
 **--aliyun-acr-webhook-secret *secret***
 
 Secret for validating Aliyun ACR webhooks.

--- a/docs/install/cmd/webhook.md
+++ b/docs/install/cmd/webhook.md
@@ -15,9 +15,18 @@ Supported Registries:
 - Quay
 - Harbor
 - Aliyun ACR (Alibaba Cloud Container Registry)
+- Azure Container Registry (ACR)
 - AWS EventBridge (CloudEvents)
 
 ### Flags
+
+**--acr-webhook-secret *secret***
+
+Secret for validating Azure ACR webhooks. ACR has no built-in signing, so the
+secret is sent as the `Authorization` header value, which you configure on the
+webhook with `az acr webhook update --headers "Authorization=<secret>"`.
+
+Can also be set with the `ACR_WEBHOOK_SECRET` environment variable.
 
 **--aliyun-acr-webhook-secret *secret***
 

--- a/pkg/webhook/acr.go
+++ b/pkg/webhook/acr.go
@@ -55,7 +55,7 @@ func (a *ACRWebhook) Validate(r *http.Request) error {
 		}
 
 		if subtle.ConstantTimeCompare([]byte(authHeader), []byte(a.secret)) != 1 {
-			return fmt.Errorf("incorrect webhook secret")
+			return fmt.Errorf("invalid webhook secret")
 		}
 	}
 

--- a/pkg/webhook/acr.go
+++ b/pkg/webhook/acr.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/argoproj-labs/argocd-image-updater/pkg/argocd"
 )
@@ -33,17 +34,28 @@ func (a *ACRWebhook) Validate(r *http.Request) error {
 		return fmt.Errorf("invalid HTTP method: %s", r.Method)
 	}
 
-	// Azure ACR has no built-in HMAC signing. If a secret is configured, validate
-	// it from the query parameter (parameter secret pattern).
-	// !! This query param method is NOT secure, use at own risk
+	// ACR sends a Content-Type of application/json unless a custom Content-Type
+	// header is configured for the webhook.
+	// See: https://learn.microsoft.com/en-us/azure/container-registry/container-registry-webhook-reference#http-headers
+	contentType := r.Header.Get("Content-Type")
+	if !strings.Contains(contentType, "application/json") {
+		return fmt.Errorf("invalid content type: %s", contentType)
+	}
+
+	// ACR has no built-in HMAC signing, but it lets you attach arbitrary custom
+	// headers to webhook notifications via the Azure CLI, e.g.:
+	//   az acr webhook update -n <webhook> -r <registry> --headers "Authorization=Basic <token>"
+	// We therefore validate the configured secret against the Authorization
+	// header value. The secret configured in argocd-image-updater must match the full Authorization header value.
+	// See: https://learn.microsoft.com/en-us/cli/azure/acr/webhook?view=azure-cli-latest#az-acr-webhook-update-examples
 	if a.secret != "" {
-		secret := r.URL.Query().Get("secret")
-		if secret == "" {
-			return fmt.Errorf("missing webhook secret")
+		authHeader := r.Header.Get("Authorization")
+		if authHeader == "" {
+			return fmt.Errorf("missing Authorization header when secret is configured")
 		}
 
-		if subtle.ConstantTimeCompare([]byte(secret), []byte(a.secret)) != 1 {
-			return fmt.Errorf("invalid webhook secret")
+		if subtle.ConstantTimeCompare([]byte(authHeader), []byte(a.secret)) != 1 {
+			return fmt.Errorf("incorrect webhook secret")
 		}
 	}
 

--- a/pkg/webhook/acr.go
+++ b/pkg/webhook/acr.go
@@ -1,0 +1,99 @@
+package webhook
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/argoproj-labs/argocd-image-updater/pkg/argocd"
+)
+
+// ACRWebhook handles Azure Container Registry webhook events
+type ACRWebhook struct {
+	secret string
+}
+
+// NewACRWebhook creates a new Azure ACR webhook handler
+func NewACRWebhook(secret string) *ACRWebhook {
+	return &ACRWebhook{
+		secret: secret,
+	}
+}
+
+// GetRegistryType returns the registry type this handler supports
+func (a *ACRWebhook) GetRegistryType() string {
+	return "acr"
+}
+
+// Validate validates the Azure ACR webhook payload
+func (a *ACRWebhook) Validate(r *http.Request) error {
+	if r.Method != http.MethodPost {
+		return fmt.Errorf("invalid HTTP method: %s", r.Method)
+	}
+
+	// Azure ACR has no built-in HMAC signing. If a secret is configured, validate
+	// it from the query parameter (parameter secret pattern).
+	// !! This query param method is NOT secure, use at own risk
+	if a.secret != "" {
+		secret := r.URL.Query().Get("secret")
+		if secret == "" {
+			return fmt.Errorf("missing webhook secret")
+		}
+
+		if subtle.ConstantTimeCompare([]byte(secret), []byte(a.secret)) != 1 {
+			return fmt.Errorf("invalid webhook secret")
+		}
+	}
+
+	return nil
+}
+
+// Parse processes the Azure ACR webhook payload and returns a WebhookEvent
+func (a *ACRWebhook) Parse(r *http.Request) (*argocd.WebhookEvent, error) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read request body: %w", err)
+	}
+
+	// Azure ACR payload structure for push events. reference: https://learn.microsoft.com/en-us/azure/container-registry/container-registry-webhook
+	var payload struct {
+		Action string `json:"action"`
+		Target struct {
+			MediaType  string `json:"mediaType"`
+			Size       int64  `json:"size"`
+			Digest     string `json:"digest"`
+			Length     int64  `json:"length"`
+			Repository string `json:"repository"`
+			Tag        string `json:"tag"`
+		} `json:"target"`
+		Request struct {
+			ID     string `json:"id"`
+			Host   string `json:"host"`
+			Method string `json:"method"`
+		} `json:"request"`
+	}
+
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, fmt.Errorf("failed to parse webhook payload: %w", err)
+	}
+
+	// Only process push events
+	if payload.Action != "push" {
+		return nil, fmt.Errorf("ignoring action: %s", payload.Action)
+	}
+
+	if payload.Target.Repository == "" {
+		return nil, fmt.Errorf("repository name not found in webhook payload")
+	}
+
+	// A tag may be empty for a digest-only push. Handle this gracefully by
+	// returning the event with the digest set instead of erroring out.
+	return &argocd.WebhookEvent{
+		RegistryURL: payload.Request.Host,
+		Repository:  payload.Target.Repository,
+		Tag:         payload.Target.Tag,
+		Digest:      payload.Target.Digest,
+	}, nil
+}

--- a/pkg/webhook/acr_test.go
+++ b/pkg/webhook/acr_test.go
@@ -31,38 +31,51 @@ func TestACRWebhook_Validate(t *testing.T) {
 	tests := []struct {
 		name        string
 		method      string
-		secret      string
+		contentType string
+		authHeader  string
 		noSecret    bool
 		expectError bool
 	}{
 		{
 			name:        "valid POST request with correct secret",
 			method:      "POST",
-			secret:      "test-secret",
+			contentType: "application/json",
+			authHeader:  "test-secret",
 			expectError: false,
 		},
 		{
 			name:        "valid POST request without secret",
 			method:      "POST",
+			contentType: "application/json",
 			noSecret:    true,
 			expectError: false,
 		},
 		{
 			name:        "invalid HTTP method",
 			method:      "GET",
-			secret:      "test-secret",
+			contentType: "application/json",
+			authHeader:  "test-secret",
 			expectError: true,
 		},
 		{
-			name:        "missing secret when secret is configured",
+			name:        "invalid content type",
 			method:      "POST",
-			secret:      "",
+			contentType: "text/plain",
+			authHeader:  "test-secret",
 			expectError: true,
 		},
 		{
-			name:        "invalid secret",
+			name:        "missing Authorization header when secret is configured",
 			method:      "POST",
-			secret:      "not-the-secret",
+			contentType: "application/json",
+			authHeader:  "",
+			expectError: true,
+		},
+		{
+			name:        "incorrect secret",
+			method:      "POST",
+			contentType: "application/json",
+			authHeader:  "not-the-secret",
 			expectError: true,
 		},
 	}
@@ -75,10 +88,11 @@ func TestACRWebhook_Validate(t *testing.T) {
 			}
 
 			req := httptest.NewRequest(tt.method, "/webhook", nil)
-			if tt.secret != "" {
-				query := req.URL.Query()
-				query.Set("secret", tt.secret)
-				req.URL.RawQuery = query.Encode()
+			if tt.contentType != "" {
+				req.Header.Set("Content-Type", tt.contentType)
+			}
+			if tt.authHeader != "" {
+				req.Header.Set("Authorization", tt.authHeader)
 			}
 
 			err := testWebhook.Validate(req)

--- a/pkg/webhook/acr_test.go
+++ b/pkg/webhook/acr_test.go
@@ -1,0 +1,210 @@
+package webhook
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewACRWebhook(t *testing.T) {
+	secret := "test-secret"
+	webhook := NewACRWebhook(secret)
+
+	assert.NotNil(t, webhook, "webhook was nil")
+	assert.Equal(t, secret, webhook.secret, "Secret is not the same expected %s but got %s", secret, webhook.secret)
+}
+
+func TestACRWebhook_GetRegistryType(t *testing.T) {
+	webhook := NewACRWebhook("")
+	registryType := webhook.GetRegistryType()
+
+	assert.NotNil(t, webhook, "Webhook was nil")
+	assert.Equal(t, "acr", registryType, "Registry type is not acr got: %s", registryType)
+}
+
+func TestACRWebhook_Validate(t *testing.T) {
+	secret := "test-secret"
+	webhook := NewACRWebhook(secret)
+
+	tests := []struct {
+		name        string
+		method      string
+		secret      string
+		noSecret    bool
+		expectError bool
+	}{
+		{
+			name:        "valid POST request with correct secret",
+			method:      "POST",
+			secret:      "test-secret",
+			expectError: false,
+		},
+		{
+			name:        "valid POST request without secret",
+			method:      "POST",
+			noSecret:    true,
+			expectError: false,
+		},
+		{
+			name:        "invalid HTTP method",
+			method:      "GET",
+			secret:      "test-secret",
+			expectError: true,
+		},
+		{
+			name:        "missing secret when secret is configured",
+			method:      "POST",
+			secret:      "",
+			expectError: true,
+		},
+		{
+			name:        "invalid secret",
+			method:      "POST",
+			secret:      "not-the-secret",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testWebhook := webhook
+			if tt.noSecret {
+				testWebhook = NewACRWebhook("")
+			}
+
+			req := httptest.NewRequest(tt.method, "/webhook", nil)
+			if tt.secret != "" {
+				query := req.URL.Query()
+				query.Set("secret", tt.secret)
+				req.URL.RawQuery = query.Encode()
+			}
+
+			err := testWebhook.Validate(req)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			}
+			if !tt.expectError {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestACRWebhook_Parse(t *testing.T) {
+	tests := []struct {
+		name                string
+		payload             string
+		expectedRepo        string
+		expectedTag         string
+		expectedDigest      string
+		expectedRegistryURL string
+		expectError         bool
+	}{
+		{
+			name: "valid push payload",
+			payload: `{
+				"id": "ea889308-3834-4a1d-a631-cadc572dab91",
+				"timestamp": "2026-06-01T12:22:07.0958813Z",
+				"action": "push",
+				"target": {
+					"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+					"size": 524,
+					"digest": "sha256:c766679d161d4ffe3dc4503b4c9f90b978f0d363fcedb02d1ae0cd271e645c0a",
+					"length": 524,
+					"repository": "hello-world",
+					"tag": "test-v1"
+				},
+				"request": {
+					"id": "9ad4af4e-95b2-4787-8f28-7f817b05a56a",
+					"host": "mojrodevops.azurecr.io",
+					"method": "PUT"
+				}
+			}`,
+			expectedRepo:        "hello-world",
+			expectedTag:         "test-v1",
+			expectedDigest:      "sha256:c766679d161d4ffe3dc4503b4c9f90b978f0d363fcedb02d1ae0cd271e645c0a",
+			expectedRegistryURL: "mojrodevops.azurecr.io",
+			expectError:         false,
+		},
+		{
+			name: "digest-only push with empty tag",
+			payload: `{
+				"action": "push",
+				"target": {
+					"digest": "sha256:c766679d161d4ffe3dc4503b4c9f90b978f0d363fcedb02d1ae0cd271e645c0a",
+					"repository": "hello-world",
+					"tag": ""
+				},
+				"request": {
+					"host": "mojrodevops.azurecr.io"
+				}
+			}`,
+			expectedRepo:        "hello-world",
+			expectedTag:         "",
+			expectedDigest:      "sha256:c766679d161d4ffe3dc4503b4c9f90b978f0d363fcedb02d1ae0cd271e645c0a",
+			expectedRegistryURL: "mojrodevops.azurecr.io",
+			expectError:         false,
+		},
+		{
+			name: "non-push action is ignored",
+			payload: `{
+				"action": "delete",
+				"target": {
+					"repository": "hello-world",
+					"tag": "test-v1"
+				},
+				"request": {
+					"host": "mojrodevops.azurecr.io"
+				}
+			}`,
+			expectError: true,
+		},
+		{
+			name: "missing repository",
+			payload: `{
+				"action": "push",
+				"target": {
+					"tag": "test-v1"
+				},
+				"request": {
+					"host": "mojrodevops.azurecr.io"
+				}
+			}`,
+			expectError: true,
+		},
+		{
+			name:        "malformed JSON",
+			payload:     `{"action": "push", "target": }`,
+			expectError: true,
+		},
+		{
+			name:        "empty payload",
+			payload:     ``,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			webhook := NewACRWebhook("")
+			req := httptest.NewRequest("POST", "/webhook", strings.NewReader(tt.payload))
+
+			event, err := webhook.Parse(req)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, event, "Event was nil")
+			assert.Equal(t, tt.expectedRegistryURL, event.RegistryURL, "Expected registry url to be %s, but got %s", tt.expectedRegistryURL, event.RegistryURL)
+			assert.Equal(t, tt.expectedRepo, event.Repository, "Expected repository to be %s, but got %s", tt.expectedRepo, event.Repository)
+			assert.Equal(t, tt.expectedTag, event.Tag, "Expected tag to be %s, but got %s", tt.expectedTag, event.Tag)
+			assert.Equal(t, tt.expectedDigest, event.Digest, "Expected digest to be %s, but got %s", tt.expectedDigest, event.Digest)
+		})
+	}
+}

--- a/pkg/webhook/acr_test.go
+++ b/pkg/webhook/acr_test.go
@@ -29,12 +29,13 @@ func TestACRWebhook_Validate(t *testing.T) {
 	webhook := NewACRWebhook(secret)
 
 	tests := []struct {
-		name        string
-		method      string
-		contentType string
-		authHeader  string
-		noSecret    bool
-		expectError bool
+		name           string
+		method         string
+		contentType    string
+		authHeader     string
+		noSecret       bool
+		expectError    bool
+		expectedErrMsg string
 	}{
 		{
 			name:        "valid POST request with correct secret",
@@ -65,18 +66,20 @@ func TestACRWebhook_Validate(t *testing.T) {
 			expectError: true,
 		},
 		{
-			name:        "missing Authorization header when secret is configured",
-			method:      "POST",
-			contentType: "application/json",
-			authHeader:  "",
-			expectError: true,
+			name:           "missing Authorization header when secret is configured",
+			method:         "POST",
+			contentType:    "application/json",
+			authHeader:     "",
+			expectError:    true,
+			expectedErrMsg: "missing Authorization header when secret is configured",
 		},
 		{
-			name:        "incorrect secret",
-			method:      "POST",
-			contentType: "application/json",
-			authHeader:  "not-the-secret",
-			expectError: true,
+			name:           "incorrect secret",
+			method:         "POST",
+			contentType:    "application/json",
+			authHeader:     "not-the-secret",
+			expectError:    true,
+			expectedErrMsg: "invalid webhook secret",
 		},
 	}
 
@@ -99,8 +102,10 @@ func TestACRWebhook_Validate(t *testing.T) {
 
 			if tt.expectError {
 				assert.Error(t, err)
-			}
-			if !tt.expectError {
+				if tt.expectedErrMsg != "" {
+					assert.EqualError(t, err, tt.expectedErrMsg)
+				}
+			} else {
 				assert.NoError(t, err)
 			}
 		})


### PR DESCRIPTION
## Summary

Adds a native webhook handler for Azure Container Registry (ACR). Closes #1680.

The webhook server previously supported Docker Hub, GHCR, Harbor, Quay, Aliyun ACR,
and AWS ECR (via CloudEvents), but not Azure Container Registry. This adds an `acr`
handler so ACR users can trigger image updates on push events.

## What's included

- `pkg/webhook/acr.go` — handler that validates the request and parses ACR's native
  push payload (registry host, repository, tag, digest)
- `pkg/webhook/acr_test.go` — table-driven tests (valid push, digest-only/empty tag,
  non-push action, missing repository, malformed JSON, empty body, secret validation)
- Handler registration in `cmd/common.go` (wired into both the secure and insecure
  registration paths introduced in #1678)
- `cmd/common_test.go` — added `acr` to the expected handler set in
  `TestSetupWebhookServer_HandlerRegistration`
- `--acr-webhook-secret` flag (env `ACR_WEBHOOK_SECRET`) in `cmd/run.go` and `cmd/webhook.go`
- `webhook.acr-secret` mapping in `config/install.yaml` and `config/manager/manager.yaml`
- Documentation in `docs/configuration/webhook.md`

## Design notes

- **No HMAC signing:** ACR webhooks have no built-in signing mechanism (the Azure portal
  only exposes a Service URI and free-form custom headers). The handler uses the
  parameter-secret pattern (`?secret=`) with a constant-time comparison, matching the
  Docker Hub and Quay handlers.
- **Non-push actions** return an error (HTTP 400, logged), consistent with the existing
  GHCR handler's "ignoring action" behavior.
- **Empty tag** (digest-only push) is handled gracefully rather than erroring.

## Testing

Implemented against a real captured ACR payload and verified end-to-end against a live
Azure Container Registry: `docker push` → ACR webhook → handler parses payload →
image-updater queries ACR, selects newest tag → commits the updated tag to git.

Webhook handler (live ACR push):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Azure Container Registry (ACR) webhook support (`type=acr`) to process push events for automated updates.
  * Added `--acr-webhook-secret` / `ACR_WEBHOOK_SECRET` for optional secure request validation via the webhook `Authorization` header.
* **Documentation**
  * Updated webhook setup docs and installation/run command docs with ACR support, payload handling, and secret configuration details.
  * Updated Kubernetes manifests to provide `ACR_WEBHOOK_SECRET`.
* **Tests**
  * Added ACR webhook handler tests and updated webhook registration/run command tests for the new flag behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->