### PR TITLE
fix(webhook-quay): Self-hosted Quay images redirect to quay.io, not self-hosted URL

### DIFF
--- a/pkg/webhook/quay.go
+++ b/pkg/webhook/quay.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/argoproj-labs/argocd-image-updater/pkg/argocd"
 )
@@ -76,9 +78,32 @@ func (q *QuayWebhook) Parse(r *http.Request) (*argocd.WebhookEvent, error) {
 	}
 	tag = payload.UpdatedTags[0]
 
+	registryURL := "quay.io"
+	if payload.DockerUrl != "" {
+		registryURL = extractRegistryFromDockerURL(payload.DockerUrl)
+	}
+
 	return &argocd.WebhookEvent{
-		RegistryURL: "quay.io",
+		RegistryURL: registryURL,
 		Repository:  payload.Repository,
 		Tag:         tag,
 	}, nil
+}
+
+// extractRegistryFromDockerURL extracts the registry hostname from a docker_url
+// field such as "quay.apps.example.com/namespace/repo"
+func extractRegistryFromDockerURL(dockerURL string) string {
+	raw := dockerURL
+	if !strings.HasPrefix(dockerURL, "http://") && !strings.HasPrefix(dockerURL, "https://") {
+		dockerURL = "https://" + dockerURL
+	}
+	if parsed, err := url.Parse(dockerURL); err == nil && parsed.Host != "" {
+		return parsed.Host
+	}
+	// Fallback: try to extract host manually by splitting on the first '/'
+	parts := strings.Split(raw, "/")
+	if len(parts) > 0 && strings.Contains(parts[0], ".") {
+		return parts[0]
+	}
+	return "quay.io"
 }

--- a/pkg/webhook/quay_test.go
+++ b/pkg/webhook/quay_test.go
@@ -92,14 +92,15 @@ func TestQuayWebhook_Parse(t *testing.T) {
 	webhook := NewQuayWebhook("")
 
 	tests := []struct {
-		name         string
-		payload      string
-		expectedRepo string
-		expectedTag  string
-		expectError  bool
+		name             string
+		payload          string
+		expectedRegistry string
+		expectedRepo     string
+		expectedTag      string
+		expectError      bool
 	}{
 		{
-			name: "valid payload",
+			name: "valid payload with quay.io docker_url",
 			payload: `{
 				"name": "repository",
 				"repository": "mynamespace/repository",
@@ -110,9 +111,75 @@ func TestQuayWebhook_Parse(t *testing.T) {
 					"latest"
 				]
 			}`,
-			expectedRepo: "mynamespace/repository",
-			expectedTag:  "latest",
-			expectError:  false,
+			expectedRegistry: "quay.io",
+			expectedRepo:     "mynamespace/repository",
+			expectedTag:      "latest",
+			expectError:      false,
+		},
+		{
+			name: "private quay registry in docker_url",
+			payload: `{
+				"name": "repository",
+				"repository": "mynamespace/repository",
+				"namespace": "mynamespace",
+				"docker_url": "quay.apps.example.com/mynamespace/repository",
+				"homepage": "https://quay.apps.example.com/repository/mynamespace/repository",
+				"updated_tags": [
+					"dev"
+				]
+			}`,
+			expectedRegistry: "quay.apps.example.com",
+			expectedRepo:     "mynamespace/repository",
+			expectedTag:      "dev",
+			expectError:      false,
+		},
+		{
+			name: "private quay registry with https scheme in docker_url",
+			payload: `{
+				"name": "repository",
+				"repository": "ariss/alrl",
+				"namespace": "ariss",
+				"docker_url": "https://quay.internal.corp/ariss/alrl",
+				"homepage": "https://quay.internal.corp/repository/ariss/alrl",
+				"updated_tags": [
+					"v1.0"
+				]
+			}`,
+			expectedRegistry: "quay.internal.corp",
+			expectedRepo:     "ariss/alrl",
+			expectedTag:      "v1.0",
+			expectError:      false,
+		},
+		{
+			name: "empty docker_url falls back to quay.io",
+			payload: `{
+				"name": "repository",
+				"repository": "mynamespace/repository",
+				"namespace": "mynamespace",
+				"docker_url": "",
+				"updated_tags": [
+					"latest"
+				]
+			}`,
+			expectedRegistry: "quay.io",
+			expectedRepo:     "mynamespace/repository",
+			expectedTag:      "latest",
+			expectError:      false,
+		},
+		{
+			name: "missing docker_url falls back to quay.io",
+			payload: `{
+				"name": "repository",
+				"repository": "mynamespace/repository",
+				"namespace": "mynamespace",
+				"updated_tags": [
+					"latest"
+				]
+			}`,
+			expectedRegistry: "quay.io",
+			expectedRepo:     "mynamespace/repository",
+			expectedTag:      "latest",
+			expectError:      false,
 		},
 		{
 			name: "valid payload with multiple tags",
@@ -127,9 +194,10 @@ func TestQuayWebhook_Parse(t *testing.T) {
 					"v1.0"
 				]
 			}`,
-			expectedRepo: "mynamespace/repository",
-			expectedTag:  "latest",
-			expectError:  false,
+			expectedRegistry: "quay.io",
+			expectedRepo:     "mynamespace/repository",
+			expectedTag:      "latest",
+			expectError:      false,
 		},
 		{
 			name: "valid payload with no tags",
@@ -186,9 +254,33 @@ func TestQuayWebhook_Parse(t *testing.T) {
 			}
 
 			assert.NotNil(t, event, "Event was nil")
-			assert.Equal(t, "quay.io", event.RegistryURL, "Expected repository url to be %s, but got %s", "quay.io", event.RegistryURL)
-			assert.Equal(t, tt.expectedRepo, event.Repository, "Expect repository to be %s, but got %s", tt.expectedRepo, event.Repository)
-			assert.Equal(t, tt.expectedTag, event.Tag, "Expected tag to be %s, but got %s", tt.expectedTag, event.Tag)
+			assert.Equal(t, tt.expectedRegistry, event.RegistryURL)
+			assert.Equal(t, tt.expectedRepo, event.Repository)
+			assert.Equal(t, tt.expectedTag, event.Tag)
+		})
+	}
+}
+
+func TestExtractRegistryFromDockerURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"public quay.io", "quay.io/ns/repo", "quay.io"},
+		{"private hostname", "quay.apps.example.com/ns/repo", "quay.apps.example.com"},
+		{"with https scheme", "https://quay.internal.corp/ns/repo", "quay.internal.corp"},
+		{"with http scheme", "http://quay.internal.corp/ns/repo", "quay.internal.corp"},
+		{"hostname with port", "quay.internal.corp:8443/ns/repo", "quay.internal.corp:8443"},
+		{"bare hostname no path", "quay.apps.example.com", "quay.apps.example.com"},
+		{"manual split fallback", "quay.custom.io:bad:port/ns/repo", "quay.custom.io:bad:port"},
+		{"unparseable url falls back to quay.io", "/ns/repo", "quay.io"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractRegistryFromDockerURL(tt.input)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Quay webhooks now derive registry URL from the docker_url field when present, falling back to quay.io if unavailable.

* **Tests**
  * Enhanced test coverage for Quay webhook registry URL parsing, including scenarios with various hostname formats and fallback cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->