### PR TITLE
fix(git-write): Thread/Goroutine leak due to un-reaped informer factories during Git write-back (#1679)

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/argoproj/argo-cd/v3/util/askpass"
+	"github.com/argoproj/argo-cd/v3/util/db"
+	"github.com/argoproj/argo-cd/v3/util/settings"
 	"github.com/go-logr/logr"
 	"go.uber.org/ratelimit"
 
@@ -105,6 +107,18 @@ func SetupCommon(ctx context.Context, cfg *controller.ImageUpdaterConfig, setupL
 		setupLogger.Error(err, "could not create K8s client")
 		return err
 	}
+
+	// Create a shared Argo CD settings manager and database so that informers
+	// are started once and reused for the lifetime of the controller. Previously,
+	// every Git credential lookup created its own SettingsManager, leaking
+	// informer goroutines (GITOPS-9938).
+	settingsMgr := settings.NewSettingsManager(ctx,
+		cfg.KubeClient.KubeClient.Clientset,
+		cfg.KubeClient.KubeClient.Namespace)
+	cfg.ArgocdDB = db.NewDB(
+		cfg.KubeClient.KubeClient.Namespace,
+		settingsMgr,
+		cfg.KubeClient.KubeClient.Clientset)
 
 	// Start up the credentials store server
 	cs := askpass.NewServer(askpass.SocketPath)

--- a/internal/controller/imageupdater_controller.go
+++ b/internal/controller/imageupdater_controller.go
@@ -32,6 +32,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
+	"github.com/argoproj/argo-cd/v3/util/db"
+
 	api "github.com/argoproj-labs/argocd-image-updater/api/v1alpha1"
 	"github.com/argoproj-labs/argocd-image-updater/ext/git"
 	"github.com/argoproj-labs/argocd-image-updater/pkg/argocd"
@@ -50,6 +52,7 @@ type ImageUpdaterConfig struct {
 	LogLevel               string
 	LogFormat              string
 	KubeClient             *kube.ImageUpdaterKubernetesClient
+	ArgocdDB               db.ArgoDB
 	MaxConcurrentApps      int
 	RegistriesConf         string
 	GitCommitUser          string

--- a/internal/controller/reconcile.go
+++ b/internal/controller/reconcile.go
@@ -29,7 +29,7 @@ func (r *ImageUpdaterReconciler) RunImageUpdater(ctx context.Context, cr *iuapi.
 	r.Config.ArgoClient = argoClient
 
 	// Get the list of applications that are allowed for updates.
-	appList, err := argocd.FilterApplicationsForUpdate(ctx, argoClient, r.Config.KubeClient, cr, webhookEvent)
+	appList, err := argocd.FilterApplicationsForUpdate(ctx, argoClient, r.Config.KubeClient, r.Config.ArgocdDB, cr, webhookEvent)
 	if err != nil {
 		return result, err
 	}
@@ -85,6 +85,7 @@ func (r *ImageUpdaterReconciler) RunImageUpdater(ctx context.Context, cr *iuapi.
 				NewRegFN:               registry.NewClient,
 				ArgoClient:             r.Config.ArgoClient,
 				KubeClient:             r.Config.KubeClient,
+				ArgocdDB:               r.Config.ArgocdDB,
 				UpdateApp:              &curApplication,
 				DryRun:                 dryRun,
 				GitCommitUser:          r.Config.GitCommitUser,

--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/argoproj/argo-cd/v3/pkg/apiclient/application"
 	argocdapi "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v3/util/db"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -228,7 +229,7 @@ func sortApplicationRefs(applicationRefs []iuapi.ApplicationRef) []iuapi.Applica
 
 // FilterApplicationsForUpdate Retrieve a list of applications from ArgoCD that qualify for image updates
 // Application needs either to be of type Kustomize or Helm.
-func FilterApplicationsForUpdate(ctx context.Context, ctrlClient *ArgoCDK8sClient, kubeClient *kube.ImageUpdaterKubernetesClient, cr *iuapi.ImageUpdater, webhookEvent *WebhookEvent) (map[string]ApplicationImages, error) {
+func FilterApplicationsForUpdate(ctx context.Context, ctrlClient *ArgoCDK8sClient, kubeClient *kube.ImageUpdaterKubernetesClient, argocdDB db.ArgoDB, cr *iuapi.ImageUpdater, webhookEvent *WebhookEvent) (map[string]ApplicationImages, error) {
 	baseLogger := log.LoggerFromContext(ctx)
 
 	// Validate CR configuration
@@ -299,7 +300,7 @@ func FilterApplicationsForUpdate(ctx context.Context, ctrlClient *ArgoCDK8sClien
 					}
 
 					appRefWBC := getWriteBackConfigFromAnnotations(&app)
-					appWBCSettings, err = newWBCFromSettings(appCtx, &app, kubeClient, appRefWBC)
+					appWBCSettings, err = newWBCFromSettings(appCtx, &app, kubeClient, argocdDB, appRefWBC)
 					if err != nil {
 						appLogger.Warnf("Could not create write-back config, skipping: %v", err)
 						continue
@@ -322,7 +323,7 @@ func FilterApplicationsForUpdate(ctx context.Context, ctrlClient *ArgoCDK8sClien
 					appLogger.Debugf("Read settings from Image Updater CR")
 					mergedCommonUpdateSettings = mergeCommonUpdateSettings(globalUpdateSettings, applicationRef.CommonUpdateSettings)
 					mergedWBCSettings = mergeWBCSettings(cr.Spec.WriteBackConfig, applicationRef.WriteBackConfig)
-					appWBCSettings, err = newWBCFromSettings(appCtx, &app, kubeClient, mergedWBCSettings)
+					appWBCSettings, err = newWBCFromSettings(appCtx, &app, kubeClient, argocdDB, mergedWBCSettings)
 					if err != nil {
 						appLogger.Warnf("Could not create write-back config, skipping: %v", err)
 						continue
@@ -489,10 +490,11 @@ func mergeWBCSettings(global *iuapi.WriteBackConfig, appWBC *iuapi.WriteBackConf
 // newWBCFromSettings creates a new WriteBackConfig from a given, final set of
 // settings within the context of a specific application. It is responsible for
 // resolving all app-dependent fields, like target paths.
-func newWBCFromSettings(ctx context.Context, app *argocdapi.Application, kubeClient *kube.ImageUpdaterKubernetesClient, settings *iuapi.WriteBackConfig) (*WriteBackConfig, error) {
+func newWBCFromSettings(ctx context.Context, app *argocdapi.Application, kubeClient *kube.ImageUpdaterKubernetesClient, argocdDB db.ArgoDB, settings *iuapi.WriteBackConfig) (*WriteBackConfig, error) {
 	wbc := &WriteBackConfig{
 		Method:                 WriteBackApplication,
 		ArgoClient:             nil,
+		ArgocdDB:               argocdDB,
 		GitClient:              nil,
 		GetCreds:               nil,
 		GitBranch:              "",

--- a/pkg/argocd/argocd_test.go
+++ b/pkg/argocd/argocd_test.go
@@ -2067,7 +2067,7 @@ func Test_newWBCFromSettings(t *testing.T) {
 	t.Run("should return argocd method and default file path target when settings are empty", func(t *testing.T) {
 		app, kubeClient := createTestAppAndClient()
 		settings := &api.WriteBackConfig{}
-		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, nil, settings)
 		assert.NoError(t, err)
 		assert.NotNil(t, wbc)
 		assert.Equal(t, WriteBackApplication, wbc.Method)
@@ -2077,7 +2077,7 @@ func Test_newWBCFromSettings(t *testing.T) {
 	t.Run("should return argocd method and default file path target when settings are nil", func(t *testing.T) {
 		app, kubeClient := createTestAppAndClient()
 		var settings *api.WriteBackConfig = nil
-		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, nil, settings)
 		assert.NoError(t, err)
 		assert.NotNil(t, wbc)
 		assert.Equal(t, WriteBackApplication, wbc.Method)
@@ -2089,7 +2089,7 @@ func Test_newWBCFromSettings(t *testing.T) {
 		settings := &api.WriteBackConfig{
 			Method: strPtr("git"),
 		}
-		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, nil, settings)
 		assert.NoError(t, err)
 		assert.Equal(t, WriteBackGit, wbc.Method)
 		assert.Equal(t, "some/path/.argocd-source-argocd-test_my-app.yaml", wbc.Target)
@@ -2103,7 +2103,7 @@ func Test_newWBCFromSettings(t *testing.T) {
 				WriteBackTarget: strPtr("helmvalues:another/values.yaml"),
 			},
 		}
-		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, nil, settings)
 		assert.NoError(t, err)
 		assert.Equal(t, WriteBackGit, wbc.Method)
 		assert.Equal(t, "some/path/another/values.yaml", wbc.Target)
@@ -2117,7 +2117,7 @@ func Test_newWBCFromSettings(t *testing.T) {
 				WriteBackTarget: strPtr("kustomization:overlays/prod"),
 			},
 		}
-		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, nil, settings)
 		assert.NoError(t, err)
 		assert.Equal(t, WriteBackGit, wbc.Method)
 		assert.Equal(t, "some/path/overlays/prod", wbc.KustomizeBase)
@@ -2132,7 +2132,7 @@ func Test_newWBCFromSettings(t *testing.T) {
 				Branch: strPtr("main:feature-branch"),
 			},
 		}
-		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, nil, settings)
 		assert.NoError(t, err)
 		assert.Equal(t, WriteBackGit, wbc.Method)
 		assert.Equal(t, "main", wbc.GitBranch)
@@ -2144,7 +2144,7 @@ func Test_newWBCFromSettings(t *testing.T) {
 		settings := &api.WriteBackConfig{
 			Method: strPtr("unsupported"),
 		}
-		_, err := newWBCFromSettings(context.Background(), app, kubeClient, settings)
+		_, err := newWBCFromSettings(context.Background(), app, kubeClient, nil, settings)
 		assert.Error(t, err)
 	})
 
@@ -2157,7 +2157,7 @@ func Test_newWBCFromSettings(t *testing.T) {
 				PullRequest: &api.PullRequest{GitHub: &api.PullRequestGitHub{}},
 			},
 		}
-		_, err := newWBCFromSettings(context.Background(), app, kubeClient, settings)
+		_, err := newWBCFromSettings(context.Background(), app, kubeClient, nil, settings)
 		assert.ErrorContains(t, err, "pullRequest mode does not support colon branch format")
 	})
 
@@ -2170,7 +2170,7 @@ func Test_newWBCFromSettings(t *testing.T) {
 				PullRequest: &api.PullRequest{GitHub: &api.PullRequestGitHub{}},
 			},
 		}
-		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, nil, settings)
 		assert.NoError(t, err)
 		assert.Equal(t, PRProviderGitHub, wbc.PRProvider)
 	})
@@ -2183,7 +2183,7 @@ func Test_newWBCFromSettings(t *testing.T) {
 				PullRequest: &api.PullRequest{GitHub: &api.PullRequestGitHub{}},
 			},
 		}
-		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, nil, settings)
 		assert.NoError(t, err)
 		assert.Equal(t, PRProviderGitHub, wbc.PRProvider)
 	})
@@ -2196,7 +2196,7 @@ func Test_newWBCFromSettings(t *testing.T) {
 				PullRequest: &api.PullRequest{GitLab: &api.PullRequestGitLab{}},
 			},
 		}
-		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, nil, settings)
 		assert.NoError(t, err)
 		assert.Equal(t, PRProviderGitLab, wbc.PRProvider)
 	})
@@ -2209,7 +2209,7 @@ func Test_newWBCFromSettings(t *testing.T) {
 				PullRequest: &api.PullRequest{},
 			},
 		}
-		_, err := newWBCFromSettings(context.Background(), app, kubeClient, settings)
+		_, err := newWBCFromSettings(context.Background(), app, kubeClient, nil, settings)
 		assert.ErrorContains(t, err, "pullRequest must have exactly one provider configured, got 0")
 	})
 
@@ -2224,7 +2224,7 @@ func Test_newWBCFromSettings(t *testing.T) {
 				},
 			},
 		}
-		_, err := newWBCFromSettings(context.Background(), app, kubeClient, settings)
+		_, err := newWBCFromSettings(context.Background(), app, kubeClient, nil, settings)
 		assert.ErrorContains(t, err, "pullRequest must have exactly one provider configured, got 2")
 	})
 
@@ -2233,7 +2233,7 @@ func Test_newWBCFromSettings(t *testing.T) {
 		settings := &api.WriteBackConfig{
 			Method: strPtr("git"),
 		}
-		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), app, kubeClient, nil, settings)
 		assert.NoError(t, err)
 		assert.Equal(t, PRProviderUnsupported, wbc.PRProvider)
 	})
@@ -3599,7 +3599,7 @@ func Test_FilterApplicationsForUpdate(t *testing.T) {
 				},
 			}
 			// Execute
-			appsForUpdate, err := FilterApplicationsForUpdate(ctx, client, &kubeClient, tc.imageUpdaterCR, nil)
+			appsForUpdate, err := FilterApplicationsForUpdate(ctx, client, &kubeClient, nil, tc.imageUpdaterCR, nil)
 
 			// Assert
 			if tc.expectError {

--- a/pkg/argocd/gitcreds.go
+++ b/pkg/argocd/gitcreds.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v3/util/cert"
-	"github.com/argoproj/argo-cd/v3/util/db"
-	"github.com/argoproj/argo-cd/v3/util/settings"
 
 	"github.com/argoproj-labs/argocd-image-updater/ext/git"
 	"github.com/argoproj-labs/argocd-image-updater/pkg/kube"
@@ -22,7 +20,7 @@ func getGitCredsSource(ctx context.Context, creds string, kubeClient *kube.Image
 	switch {
 	case creds == "repocreds":
 		return func(app *v1alpha1.Application) (git.Creds, error) {
-			return getCredsFromArgoCD(ctx, wbc, kubeClient, app.Spec.Project)
+			return getCredsFromArgoCD(ctx, wbc, app.Spec.Project)
 		}, nil
 	case strings.HasPrefix(creds, "secret:"):
 		return func(app *v1alpha1.Application) (git.Creds, error) {
@@ -33,13 +31,12 @@ func getGitCredsSource(ctx context.Context, creds string, kubeClient *kube.Image
 }
 
 // getCredsFromArgoCD loads repository credentials from Argo CD settings
-func getCredsFromArgoCD(ctx context.Context, wbc *WriteBackConfig, kubeClient *kube.ImageUpdaterKubernetesClient, project string) (git.Creds, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	settingsMgr := settings.NewSettingsManager(ctx, kubeClient.KubeClient.Clientset, kubeClient.KubeClient.Namespace)
-	argocdDB := db.NewDB(kubeClient.KubeClient.Namespace, settingsMgr, kubeClient.KubeClient.Clientset)
-	repo, err := argocdDB.GetRepository(ctx, wbc.GitRepo, project)
+// using the shared ArgocdDB instance to avoid creating per-call informer goroutines.
+func getCredsFromArgoCD(ctx context.Context, wbc *WriteBackConfig, project string) (git.Creds, error) {
+	if wbc.ArgocdDB == nil {
+		return nil, fmt.Errorf("argocd database not configured for repository credential lookup")
+	}
+	repo, err := wbc.ArgocdDB.GetRepository(ctx, wbc.GitRepo, project)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/argocd/gitcreds_test.go
+++ b/pkg/argocd/gitcreds_test.go
@@ -11,8 +11,11 @@ import (
 	"github.com/argoproj-labs/argocd-image-updater/test/fixture"
 
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v3/util/db"
+	"github.com/argoproj/argo-cd/v3/util/settings"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetCredsFromSecret(t *testing.T) {
@@ -252,4 +255,63 @@ func TestGetGitCreds(t *testing.T) {
 	expectedNopCreds := git.NopCreds{}
 	nopCreds := GetGitCreds(ctx, nil, store)
 	assert.Equal(t, expectedNopCreds, nopCreds)
+}
+
+func TestGetCredsFromArgoCD(t *testing.T) {
+	t.Run("nil ArgocdDB returns error", func(t *testing.T) {
+		wbc := &WriteBackConfig{
+			GitRepo:  "https://github.com/example/repo.git",
+			GitCreds: git.NoopCredsStore{},
+		}
+		creds, err := getCredsFromArgoCD(context.Background(), wbc, "default")
+		require.Error(t, err)
+		assert.Nil(t, creds)
+		assert.Contains(t, err.Error(), "argocd database not configured")
+	})
+
+	t.Run("repository with no credentials returns error", func(t *testing.T) {
+		clientset := fake.NewFakeClientsetWithResources()
+		settingsMgr := settings.NewSettingsManager(context.Background(), clientset, "argocd")
+		argocdDB := db.NewDB("argocd", settingsMgr, clientset)
+
+		wbc := &WriteBackConfig{
+			GitRepo:  "https://github.com/example/repo.git",
+			GitCreds: git.NoopCredsStore{},
+			ArgocdDB: argocdDB,
+		}
+		creds, err := getCredsFromArgoCD(context.Background(), wbc, "default")
+		require.Error(t, err)
+		assert.Nil(t, creds)
+		assert.Contains(t, err.Error(), "credentials for 'https://github.com/example/repo.git' are not configured")
+	})
+
+	t.Run("HTTPS credentials found", func(t *testing.T) {
+		repoSecret := fixture.NewSecret("argocd", "repo-creds", map[string][]byte{
+			"type":     []byte("git"),
+			"url":      []byte("https://github.com/example/repo.git"),
+			"username": []byte("myuser"),
+			"password": []byte("mypass"),
+		})
+		repoSecret.Labels = map[string]string{
+			"argocd.argoproj.io/secret-type": "repository",
+		}
+		fixture.AddPartOfArgoCDLabel(repoSecret)
+
+		clientset := fake.NewFakeClientsetWithResources(repoSecret)
+		settingsMgr := settings.NewSettingsManager(context.Background(), clientset, "argocd")
+		argocdDB := db.NewDB("argocd", settingsMgr, clientset)
+
+		wbc := &WriteBackConfig{
+			GitRepo:  "https://github.com/example/repo.git",
+			GitCreds: git.NoopCredsStore{},
+			ArgocdDB: argocdDB,
+		}
+		creds, err := getCredsFromArgoCD(context.Background(), wbc, "")
+		require.NoError(t, err)
+		require.NotNil(t, creds)
+		assert.Equal(t,
+			git.NewHTTPSCreds("myuser", "mypass", "", "", false, "", git.NoopCredsStore{}, false),
+			creds,
+		)
+	})
 }

--- a/pkg/argocd/types.go
+++ b/pkg/argocd/types.go
@@ -5,6 +5,7 @@ import (
 	"text/template"
 
 	argocdapi "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v3/util/db"
 
 	"github.com/argoproj-labs/argocd-image-updater/ext/git"
 	"github.com/argoproj-labs/argocd-image-updater/pkg/kube"
@@ -29,6 +30,7 @@ type UpdateConfiguration struct {
 	NewRegFN               registry.NewRegistryClient
 	ArgoClient             ArgoCD
 	KubeClient             *kube.ImageUpdaterKubernetesClient
+	ArgocdDB               db.ArgoDB
 	UpdateApp              *ApplicationImages
 	DryRun                 bool
 	GitCommitUser          string
@@ -66,6 +68,7 @@ const (
 type WriteBackConfig struct {
 	Method     WriteBackMethod
 	ArgoClient ArgoCD
+	ArgocdDB   db.ArgoDB
 	// If GitClient is not nil, the client will be used for updates. Otherwise, a new client will be created.
 	GitClient              git.Client
 	GetCreds               GitCredsSource

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -30,12 +30,20 @@ import (
 
 	"github.com/argoproj/argo-cd/v3/pkg/apiclient/application"
 	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/argo-cd/v3/util/db"
+	"github.com/argoproj/argo-cd/v3/util/settings"
 	"github.com/distribution/distribution/v3/manifest/schema1" //nolint:staticcheck
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
+
+func newTestArgoDB(clientset kubernetes.Interface, namespace string) db.ArgoDB {
+	settingsMgr := settings.NewSettingsManager(context.Background(), clientset, namespace)
+	return db.NewDB(namespace, settingsMgr, clientset)
+}
 
 func Test_UpdateApplication(t *testing.T) {
 	t.Run("Test kustomize w/ multiple images w/ different registry w/ different tags", func(t *testing.T) {
@@ -4653,7 +4661,7 @@ func Test_GetWriteBackConfig(t *testing.T) {
 			},
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, nil, settings)
 		require.NoError(t, err)
 		require.NotNil(t, wbc)
 		assert.Equal(t, wbc.Method, WriteBackGit)
@@ -4691,7 +4699,7 @@ func Test_GetWriteBackConfig(t *testing.T) {
 			},
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, nil, settings)
 		require.NoError(t, err)
 		require.NotNil(t, wbc)
 		assert.Equal(t, "", wbc.GitBranch)
@@ -4728,7 +4736,7 @@ func Test_GetWriteBackConfig(t *testing.T) {
 			},
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, nil, settings)
 		require.NoError(t, err)
 		require.NotNil(t, wbc)
 		assert.Equal(t, "mybranch", wbc.GitBranch)
@@ -4765,7 +4773,7 @@ func Test_GetWriteBackConfig(t *testing.T) {
 			Method: stringPtr("argocd"),
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, nil, settings)
 		require.NoError(t, err)
 		require.NotNil(t, wbc)
 		assert.Equal(t, wbc.Method, WriteBackApplication)
@@ -4806,7 +4814,7 @@ func Test_GetWriteBackConfig(t *testing.T) {
 			},
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, nil, settings)
 		require.NoError(t, err)
 		require.NotNil(t, wbc)
 		assert.Equal(t, wbc.Method, WriteBackGit)
@@ -4848,7 +4856,7 @@ func Test_GetWriteBackConfig(t *testing.T) {
 			},
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, nil, settings)
 		require.NoError(t, err)
 		require.NotNil(t, wbc)
 		assert.Equal(t, wbc.Method, WriteBackGit)
@@ -4890,7 +4898,7 @@ func Test_GetWriteBackConfig(t *testing.T) {
 			},
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, nil, settings)
 		require.NoError(t, err)
 		require.NotNil(t, wbc)
 		assert.Equal(t, wbc.Method, WriteBackGit)
@@ -4932,7 +4940,7 @@ func Test_GetWriteBackConfig(t *testing.T) {
 			},
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, nil, settings)
 		require.NoError(t, err)
 		require.NotNil(t, wbc)
 		assert.Equal(t, wbc.Method, WriteBackGit)
@@ -4974,7 +4982,7 @@ func Test_GetWriteBackConfig(t *testing.T) {
 			},
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, nil, settings)
 		require.NoError(t, err)
 		require.NotNil(t, wbc)
 		assert.Equal(t, wbc.Method, WriteBackGit)
@@ -5015,7 +5023,7 @@ func Test_GetWriteBackConfig(t *testing.T) {
 			},
 		}
 
-		_, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		_, err := newWBCFromSettings(context.Background(), &app, &kubeClient, nil, settings)
 		assert.Error(t, err)
 	})
 
@@ -5052,7 +5060,7 @@ func Test_GetWriteBackConfig(t *testing.T) {
 			},
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, nil, settings)
 		require.NoError(t, err)
 		require.NotNil(t, wbc)
 		assert.Equal(t, wbc.Method, WriteBackApplication)
@@ -5091,7 +5099,7 @@ func Test_GetWriteBackConfig(t *testing.T) {
 			},
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, nil, settings)
 		require.Error(t, err)
 		require.Nil(t, wbc)
 	})
@@ -5133,7 +5141,7 @@ func Test_GetGitCreds(t *testing.T) {
 			},
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, nil, settings)
 		require.NoError(t, err)
 
 		creds, err := wbc.GetCreds(&app)
@@ -5179,7 +5187,7 @@ func Test_GetGitCreds(t *testing.T) {
 			},
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, nil, settings)
 		require.NoError(t, err)
 
 		creds, err := wbc.GetCreds(&app)
@@ -5219,13 +5227,13 @@ func Test_GetGitCreds(t *testing.T) {
 			}
 			// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 			settings := &iuapi.WriteBackConfig{
-				Method: stringPtr("git"),
+				Method: stringPtr("git:secret:argocd-image-updater/git-creds"),
 				GitConfig: &iuapi.GitConfig{
 					Branch: stringPtr("mybranch:mytargetbranch"),
 				},
 			}
 
-			wbc, err = newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+			wbc, err = newWBCFromSettings(context.Background(), &app, &kubeClient, nil, settings)
 			require.NoError(t, err)
 			_, err = wbc.GetCreds(&app)
 			require.Error(t, err)
@@ -5265,7 +5273,7 @@ func Test_GetGitCreds(t *testing.T) {
 			},
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, nil, settings)
 		require.NoError(t, err)
 
 		creds, err := wbc.GetCreds(&app)
@@ -5294,12 +5302,14 @@ func Test_GetGitCreds(t *testing.T) {
 		}
 		fixture.AddPartOfArgoCDLabel(secret, repoSecret)
 
+		clientset := fake.NewFakeClientsetWithResources(secret, repoSecret)
 		kubeClient := kube.ImageUpdaterKubernetesClient{
 			KubeClient: &registryKube.KubernetesClient{
-				Clientset: fake.NewFakeClientsetWithResources(secret, repoSecret),
+				Clientset: clientset,
 				Namespace: "argocd",
 			},
 		}
+		argocdDB := newTestArgoDB(clientset, "argocd")
 		app := v1alpha1.Application{
 			ObjectMeta: v1.ObjectMeta{
 				Name: "testapp",
@@ -5322,7 +5332,7 @@ func Test_GetGitCreds(t *testing.T) {
 			},
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, argocdDB, settings)
 		require.NoError(t, err)
 
 		creds, err := wbc.GetCreds(&app)
@@ -5339,11 +5349,13 @@ func Test_GetGitCreds(t *testing.T) {
 		secret := fixture.NewSecret("argocd-image-updater", "git-creds", map[string][]byte{
 			"sshPrivateKex": []byte("foo"),
 		})
+		clientset := fake.NewFakeClientsetWithResources(secret)
 		kubeClient := kube.ImageUpdaterKubernetesClient{
 			KubeClient: &registryKube.KubernetesClient{
-				Clientset: fake.NewFakeClientsetWithResources(secret),
+				Clientset: clientset,
 			},
 		}
+		argocdDB := newTestArgoDB(clientset, "")
 		app := v1alpha1.Application{
 			ObjectMeta: v1.ObjectMeta{
 				Name: "testapp",
@@ -5366,7 +5378,7 @@ func Test_GetGitCreds(t *testing.T) {
 			},
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, argocdDB, settings)
 		require.NoError(t, err)
 
 		creds, err := wbc.GetCreds(&app)
@@ -5380,11 +5392,13 @@ func Test_GetGitCreds(t *testing.T) {
 		secret := fixture.NewSecret("argocd-image-updater", "git-creds", map[string][]byte{
 			"sshPrivateKey": []byte("foo"),
 		})
+		clientset := fake.NewFakeClientsetWithResources(secret)
 		kubeClient := kube.ImageUpdaterKubernetesClient{
 			KubeClient: &registryKube.KubernetesClient{
-				Clientset: fake.NewFakeClientsetWithResources(secret),
+				Clientset: clientset,
 			},
 		}
+		argocdDB := newTestArgoDB(clientset, "")
 		app := v1alpha1.Application{
 			ObjectMeta: v1.ObjectMeta{
 				Name: "testapp",
@@ -5407,7 +5421,7 @@ func Test_GetGitCreds(t *testing.T) {
 			},
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, argocdDB, settings)
 		require.NoError(t, err)
 
 		creds, err := wbc.GetCreds(&app)
@@ -5421,11 +5435,13 @@ func Test_GetGitCreds(t *testing.T) {
 		secret := fixture.NewSecret("argocd-image-updater", "git-creds", map[string][]byte{
 			"sshPrivateKey": []byte("foo"),
 		})
+		clientset := fake.NewFakeClientsetWithResources(secret)
 		kubeClient := kube.ImageUpdaterKubernetesClient{
 			KubeClient: &registryKube.KubernetesClient{
-				Clientset: fake.NewFakeClientsetWithResources(secret),
+				Clientset: clientset,
 			},
 		}
+		argocdDB := newTestArgoDB(clientset, "")
 		app := v1alpha1.Application{
 			ObjectMeta: v1.ObjectMeta{
 				Name: "testapp",
@@ -5448,7 +5464,7 @@ func Test_GetGitCreds(t *testing.T) {
 			},
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, argocdDB, settings)
 		require.NoError(t, err)
 
 		creds, err := wbc.GetCreds(&app)
@@ -5492,7 +5508,7 @@ func Test_GetGitCreds(t *testing.T) {
 			},
 		}
 
-		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, nil, settings)
 		require.NoError(t, err)
 		require.Equal(t, wbc.GitRepo, "git@github.com:example/example.git")
 
@@ -5511,9 +5527,11 @@ func Test_CommitUpdates(t *testing.T) {
 	secret := fixture.NewSecret("argocd-image-updater", "git-creds", map[string][]byte{
 		"sshPrivateKey": []byte("foo"),
 	})
+	clientset := fake.NewFakeClientsetWithResources(secret)
+	commitTestArgoDB := newTestArgoDB(clientset, "")
 	kubeClient := kube.ImageUpdaterKubernetesClient{
 		KubeClient: &registryKube.KubernetesClient{
-			Clientset: fake.NewFakeClientsetWithResources(secret),
+			Clientset: clientset,
 		},
 	}
 	app := v1alpha1.Application{
@@ -5543,7 +5561,7 @@ func Test_CommitUpdates(t *testing.T) {
 		ctx := context.Background()
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		// Pass nil settings to test the default target revision fallback
-		wbc, err := newWBCFromSettings(ctx, &app, &kubeClient, nil)
+		wbc, err := newWBCFromSettings(ctx, &app, &kubeClient, nil, nil)
 		require.NoError(t, err)
 		wbc.Method = WriteBackGit
 		wbc.GetCreds = func(app *v1alpha1.Application) (git.Creds, error) {
@@ -5572,7 +5590,7 @@ func Test_CommitUpdates(t *testing.T) {
 		gitMock.On("SymRefToBranch", mock.Anything).Return("mydefaultbranch", nil)
 
 		ctx := context.Background()
-		wbc, err := newWBCFromSettings(ctx, &app, &kubeClient, nil)
+		wbc, err := newWBCFromSettings(ctx, &app, &kubeClient, nil, nil)
 		require.NoError(t, err)
 		wbc.Method = WriteBackGit
 		wbc.GetCreds = func(app *v1alpha1.Application) (git.Creds, error) {
@@ -5603,7 +5621,7 @@ func Test_CommitUpdates(t *testing.T) {
 		gitMock.On("SymRefToBranch", mock.Anything).Return("mydefaultbranch", nil)
 
 		ctx := context.Background()
-		wbc, err := newWBCFromSettings(ctx, app, &kubeClient, nil)
+		wbc, err := newWBCFromSettings(ctx, app, &kubeClient, nil, nil)
 		require.NoError(t, err)
 		wbc.Method = WriteBackGit
 		wbc.GetCreds = func(app *v1alpha1.Application) (git.Creds, error) {
@@ -5632,7 +5650,7 @@ func Test_CommitUpdates(t *testing.T) {
 		gitMock.On("Push", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		gitMock.On("SymRefToBranch", mock.Anything).Return("mydefaultbranch", nil)
 		ctx := context.Background()
-		wbc, err := newWBCFromSettings(ctx, &app, &kubeClient, nil)
+		wbc, err := newWBCFromSettings(ctx, &app, &kubeClient, nil, nil)
 		require.NoError(t, err)
 		wbc.Method = WriteBackGit
 		wbc.GetCreds = func(app *v1alpha1.Application) (git.Creds, error) {
@@ -5688,7 +5706,7 @@ helm:
 		gitMock.On("SymRefToBranch", mock.Anything).Return("mydefaultbranch", nil)
 
 		ctx := context.Background()
-		wbc, err := newWBCFromSettings(ctx, app, &kubeClient, nil)
+		wbc, err := newWBCFromSettings(ctx, app, &kubeClient, nil, nil)
 		wbc.Method = WriteBackGit
 		wbc.GetCreds = func(app *v1alpha1.Application) (git.Creds, error) {
 			return git.NopCreds{}, nil
@@ -5751,7 +5769,7 @@ helm:
 		gitMock.On("SymRefToBranch", mock.Anything).Return("mydefaultbranch", nil)
 
 		ctx := context.Background()
-		wbc, err := newWBCFromSettings(ctx, app, &kubeClient, nil)
+		wbc, err := newWBCFromSettings(ctx, app, &kubeClient, nil, nil)
 		wbc.Method = WriteBackGit
 		wbc.GetCreds = func(app *v1alpha1.Application) (git.Creds, error) {
 			return git.NopCreds{}, nil
@@ -5814,7 +5832,7 @@ helm:
 		gitMock.On("SymRefToBranch", mock.Anything).Return("mydefaultbranch", nil)
 
 		ctx := context.Background()
-		wbc, err := newWBCFromSettings(ctx, app, &kubeClient, nil)
+		wbc, err := newWBCFromSettings(ctx, app, &kubeClient, nil, nil)
 		require.NoError(t, err)
 		wbc.Method = WriteBackGit
 		wbc.GetCreds = func(app *v1alpha1.Application) (git.Creds, error) {
@@ -5870,7 +5888,7 @@ replacements: []
 		gitMock.On("SymRefToBranch", mock.Anything).Return("mydefaultbranch", nil)
 
 		ctx := context.Background()
-		wbc, err := newWBCFromSettings(ctx, app, &kubeClient, nil)
+		wbc, err := newWBCFromSettings(ctx, app, &kubeClient, nil, nil)
 		require.NoError(t, err)
 		wbc.Method = WriteBackGit
 		wbc.GetCreds = func(app *v1alpha1.Application) (git.Creds, error) {
@@ -5944,7 +5962,7 @@ replacements: []
 		}).Return(nil)
 
 		ctx := context.Background()
-		wbc, err := newWBCFromSettings(ctx, app, &kubeClient, nil)
+		wbc, err := newWBCFromSettings(ctx, app, &kubeClient, nil, nil)
 		wbc.Method = WriteBackGit
 		wbc.GetCreds = func(app *v1alpha1.Application) (git.Creds, error) {
 			return git.NopCreds{}, nil
@@ -5990,7 +6008,7 @@ replacements: []
 		}
 
 		ctx := context.Background()
-		wbc, err := newWBCFromSettings(ctx, app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(ctx, app, &kubeClient, commitTestArgoDB, settings)
 		require.NoError(t, err)
 		wbc.GitClient = gitMock
 		app.Spec.Source.TargetRevision = "HEAD"
@@ -6022,7 +6040,7 @@ replacements: []
 			},
 		}
 		ctx := context.Background()
-		wbc, err := newWBCFromSettings(ctx, &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(ctx, &app, &kubeClient, commitTestArgoDB, settings)
 		require.NoError(t, err)
 		wbc.GitClient = gitMock
 
@@ -6050,7 +6068,7 @@ replacements: []
 			},
 		}
 		ctx := context.Background()
-		wbc, err := newWBCFromSettings(ctx, &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(ctx, &app, &kubeClient, commitTestArgoDB, settings)
 		require.NoError(t, err)
 		wbc.GitClient = gitMock
 
@@ -6077,7 +6095,7 @@ replacements: []
 			},
 		}
 		ctx := context.Background()
-		wbc, err := newWBCFromSettings(ctx, &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(ctx, &app, &kubeClient, commitTestArgoDB, settings)
 		require.NoError(t, err)
 		wbc.GitClient = gitMock
 
@@ -6105,7 +6123,7 @@ replacements: []
 			},
 		}
 		ctx := context.Background()
-		wbc, err := newWBCFromSettings(ctx, &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(ctx, &app, &kubeClient, commitTestArgoDB, settings)
 		require.NoError(t, err)
 		wbc.GitClient = gitMock
 
@@ -6133,7 +6151,7 @@ replacements: []
 			},
 		}
 		ctx := context.Background()
-		wbc, err := newWBCFromSettings(ctx, &app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(ctx, &app, &kubeClient, commitTestArgoDB, settings)
 		require.NoError(t, err)
 		wbc.GitClient = gitMock
 
@@ -6164,7 +6182,7 @@ replacements: []
 		}
 
 		ctx := context.Background()
-		wbc, err := newWBCFromSettings(ctx, app, &kubeClient, settings)
+		wbc, err := newWBCFromSettings(ctx, app, &kubeClient, commitTestArgoDB, settings)
 		require.NoError(t, err)
 		wbc.GitClient = gitMock
 		app.Spec.Source.TargetRevision = "HEAD"


### PR DESCRIPTION
backport the fix to informer goroutine/thread leak bug from master to release-1.2 branch