### PR TITLE
chore(deps): bump argocd from 3.4.3 to 3.4.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 require (
 	github.com/argoproj-labs/argocd-image-updater/registry-scanner v1.2.1
 	github.com/argoproj/argo-cd/gitops-engine v0.7.1-0.20250908182407-97ad5b59a627
-	github.com/argoproj/argo-cd/v3 v3.4.3
+	github.com/argoproj/argo-cd/v3 v3.4.4
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bombsimon/logrusr/v2 v2.0.1
 	github.com/bradleyfalzon/ghinstallation/v2 v2.18.0
@@ -212,10 +212,10 @@ replace (
 	// Uncomment for development and local testing, and comment out for releases
 	github.com/argoproj-labs/argocd-image-updater/registry-scanner => ./registry-scanner/
 
-	// argo-cd v3.4.3 declares gitops-engine at a pseudo-version where go.mod
+	// argo-cd v3.4.4 declares gitops-engine at a pseudo-version where go.mod
 	// didn't exist yet, then overrides with replace => ./gitops-engine locally.
-	// Downstream consumers must resolve it themselves; pin to the v3.4.3 commit.
-	github.com/argoproj/argo-cd/gitops-engine => github.com/argoproj/argo-cd/gitops-engine v0.0.0-20260528113041-1801122b4391
+	// Downstream consumers must resolve it themselves; pin to the v3.4.4 commit.
+	github.com/argoproj/argo-cd/gitops-engine => github.com/argoproj/argo-cd/gitops-engine v0.0.0-20260618084203-443415b5527a
 
 	github.com/golang/protobuf => github.com/golang/protobuf v1.5.4
 	github.com/grpc-ecosystem/grpc-gateway => github.com/grpc-ecosystem/grpc-gateway v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -43,10 +43,10 @@ github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuW
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
-github.com/argoproj/argo-cd/gitops-engine v0.0.0-20260528113041-1801122b4391 h1:YyEJnb9DiPR+mdcojPTu81KBzapC9l/BCIc5ayNPh/g=
-github.com/argoproj/argo-cd/gitops-engine v0.0.0-20260528113041-1801122b4391/go.mod h1:6Q1KZzkeKlnCpzzZ1Fu72+WPMAt+ZeMD9KOO6aMjW68=
-github.com/argoproj/argo-cd/v3 v3.4.3 h1:JiVWV6WfA0SlLhN+9ppMMutKDBEnf283YLmZEQq1ivc=
-github.com/argoproj/argo-cd/v3 v3.4.3/go.mod h1:fWDp6ko+Pug6pCEmhZxd35V/Pd9QJgYhky3pJNnsuKE=
+github.com/argoproj/argo-cd/gitops-engine v0.0.0-20260618084203-443415b5527a h1:SJc7T9iblzEkvl9Ori/OZL6gZgDFxMnC5icqGg0rvWc=
+github.com/argoproj/argo-cd/gitops-engine v0.0.0-20260618084203-443415b5527a/go.mod h1:6Q1KZzkeKlnCpzzZ1Fu72+WPMAt+ZeMD9KOO6aMjW68=
+github.com/argoproj/argo-cd/v3 v3.4.4 h1:PmYfvrLRecuOXjoUjBVx0nRwtJv/Wc9a3jaWs37EyyI=
+github.com/argoproj/argo-cd/v3 v3.4.4/go.mod h1:fWDp6ko+Pug6pCEmhZxd35V/Pd9QJgYhky3pJNnsuKE=
 github.com/argoproj/pkg v0.13.7-0.20230627120311-a4dd357b057e h1:kuLQvJqwwRMQTheT4MFyKVM8Txncu21CHT4yBWUl1Mk=
 github.com/argoproj/pkg v0.13.7-0.20230627120311-a4dd357b057e/go.mod h1:xBN5PLx2MoK63dmPfMo/PGBvd77K1Y0m/rzZOe4cs1s=
 github.com/argoproj/pkg/v2 v2.0.1 h1:O/gCETzB/3+/hyFL/7d/VM/6pSOIRWIiBOTb2xqAHvc=

--- a/test/ginkgo/go.mod
+++ b/test/ginkgo/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/argoproj-labs/argocd-image-updater v1.2.1
 	github.com/argoproj-labs/argocd-operator v0.18.0
 	github.com/argoproj/argo-cd/gitops-engine v0.7.1-0.20250908182407-97ad5b59a627
-	github.com/argoproj/argo-cd/v3 v3.4.3
+	github.com/argoproj/argo-cd/v3 v3.4.4
 	github.com/google/go-github/v69 v69.2.0
 	github.com/onsi/ginkgo/v2 v2.29.0
 	github.com/onsi/gomega v1.40.0
@@ -177,10 +177,10 @@ replace (
 	// Use local image-updater module to ensure tests use the latest API types from master
 	github.com/argoproj-labs/argocd-image-updater => ../../
 
-	// argo-cd v3.4.3 declares gitops-engine at a pseudo-version where go.mod
+	// argo-cd v3.4.4 declares gitops-engine at a pseudo-version where go.mod
 	// didn't exist yet, then overrides with replace => ./gitops-engine locally.
-	// Downstream consumers must resolve it themselves; pin to the v3.4.3 commit.
-	github.com/argoproj/argo-cd/gitops-engine => github.com/argoproj/argo-cd/gitops-engine v0.0.0-20260528113041-1801122b4391
+	// Downstream consumers must resolve it themselves; pin to the v3.4.4 commit.
+	github.com/argoproj/argo-cd/gitops-engine => github.com/argoproj/argo-cd/gitops-engine v0.0.0-20260618084203-443415b5527a
 
 	// This replace block is from Argo CD v3.2.3 go.mod
 	github.com/golang/protobuf => github.com/golang/protobuf v1.5.4

--- a/test/ginkgo/go.sum
+++ b/test/ginkgo/go.sum
@@ -33,10 +33,10 @@ github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFI
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/argoproj-labs/argocd-operator v0.18.0 h1:ukU1K4DnyAyPbD9UHCZQRziTy/ZjazAJ5pzfcQrA4/o=
 github.com/argoproj-labs/argocd-operator v0.18.0/go.mod h1:AlQPFgHsfi3ibtAuRvV2Gxn8rkFe9eunqzBb8AMS2nk=
-github.com/argoproj/argo-cd/gitops-engine v0.0.0-20260528113041-1801122b4391 h1:YyEJnb9DiPR+mdcojPTu81KBzapC9l/BCIc5ayNPh/g=
-github.com/argoproj/argo-cd/gitops-engine v0.0.0-20260528113041-1801122b4391/go.mod h1:6Q1KZzkeKlnCpzzZ1Fu72+WPMAt+ZeMD9KOO6aMjW68=
-github.com/argoproj/argo-cd/v3 v3.4.3 h1:JiVWV6WfA0SlLhN+9ppMMutKDBEnf283YLmZEQq1ivc=
-github.com/argoproj/argo-cd/v3 v3.4.3/go.mod h1:fWDp6ko+Pug6pCEmhZxd35V/Pd9QJgYhky3pJNnsuKE=
+github.com/argoproj/argo-cd/gitops-engine v0.0.0-20260618084203-443415b5527a h1:SJc7T9iblzEkvl9Ori/OZL6gZgDFxMnC5icqGg0rvWc=
+github.com/argoproj/argo-cd/gitops-engine v0.0.0-20260618084203-443415b5527a/go.mod h1:6Q1KZzkeKlnCpzzZ1Fu72+WPMAt+ZeMD9KOO6aMjW68=
+github.com/argoproj/argo-cd/v3 v3.4.4 h1:PmYfvrLRecuOXjoUjBVx0nRwtJv/Wc9a3jaWs37EyyI=
+github.com/argoproj/argo-cd/v3 v3.4.4/go.mod h1:fWDp6ko+Pug6pCEmhZxd35V/Pd9QJgYhky3pJNnsuKE=
 github.com/argoproj/pkg v0.13.7-0.20250305113207-cbc37dc61de5 h1:YBoLSjpoaJXaXAldVvBRKJuOPvIXz9UOv6S96gMJM/Q=
 github.com/argoproj/pkg v0.13.7-0.20250305113207-cbc37dc61de5/go.mod h1:ebVOzFJphdN1p6EG2mIMECv/3Rk/almSaxIYuFAmsSw=
 github.com/argoproj/pkg/v2 v2.0.1 h1:O/gCETzB/3+/hyFL/7d/VM/6pSOIRWIiBOTb2xqAHvc=


### PR DESCRIPTION
https://github.com/argoproj/argo-cd/releases/tag/v3.4.4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies to the latest patch versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->