### PR TITLE
fix(test): correct assert.Equal arg order and wrong webhook type in quay test (#1663) (#1687); fix(webhook-quay): Self-hosted Quay images redirect to quay.io, not self-hosted URL (#1683) (#1689)

### DIFF
--- a/pkg/webhook/quay.go
+++ b/pkg/webhook/quay.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/argoproj-labs/argocd-image-updater/pkg/argocd"
 )
@@ -75,9 +77,32 @@ func (q *QuayWebhook) Parse(r *http.Request) (*argocd.WebhookEvent, error) {
 	}
 	tag = payload.UpdatedTags[0]
 
+	registryURL := "quay.io"
+	if payload.DockerUrl != "" {
+		registryURL = extractRegistryFromDockerURL(payload.DockerUrl)
+	}
+
 	return &argocd.WebhookEvent{
-		RegistryURL: "quay.io",
+		RegistryURL: registryURL,
 		Repository:  payload.Repository,
 		Tag:         tag,
 	}, nil
+}
+
+// extractRegistryFromDockerURL extracts the registry hostname from a docker_url
+// field such as "quay.apps.example.com/namespace/repo"
+func extractRegistryFromDockerURL(dockerURL string) string {
+	raw := dockerURL
+	if !strings.HasPrefix(dockerURL, "http://") && !strings.HasPrefix(dockerURL, "https://") {
+		dockerURL = "https://" + dockerURL
+	}
+	if parsed, err := url.Parse(dockerURL); err == nil && parsed.Host != "" {
+		return parsed.Host
+	}
+	// Fallback: try to extract host manually by splitting on the first '/'
+	parts := strings.Split(raw, "/")
+	if len(parts) > 0 && strings.Contains(parts[0], ".") {
+		return parts[0]
+	}
+	return "quay.io"
 }

--- a/pkg/webhook/quay_test.go
+++ b/pkg/webhook/quay_test.go
@@ -92,14 +92,15 @@ func TestQuayWebhook_Parse(t *testing.T) {
 	webhook := NewQuayWebhook("")
 
 	tests := []struct {
-		name         string
-		payload      string
-		expectedRepo string
-		expectedTag  string
-		expectError  bool
+		name             string
+		payload          string
+		expectedRegistry string
+		expectedRepo     string
+		expectedTag      string
+		expectError      bool
 	}{
 		{
-			name: "valid payload",
+			name: "valid payload with quay.io docker_url",
 			payload: `{
 				"name": "repository",
 				"repository": "mynamespace/repository",
@@ -110,9 +111,75 @@ func TestQuayWebhook_Parse(t *testing.T) {
 					"latest"
 				]
 			}`,
-			expectedRepo: "mynamespace/repository",
-			expectedTag:  "latest",
-			expectError:  false,
+			expectedRegistry: "quay.io",
+			expectedRepo:     "mynamespace/repository",
+			expectedTag:      "latest",
+			expectError:      false,
+		},
+		{
+			name: "private quay registry in docker_url",
+			payload: `{
+				"name": "repository",
+				"repository": "mynamespace/repository",
+				"namespace": "mynamespace",
+				"docker_url": "quay.apps.example.com/mynamespace/repository",
+				"homepage": "https://quay.apps.example.com/repository/mynamespace/repository",
+				"updated_tags": [
+					"dev"
+				]
+			}`,
+			expectedRegistry: "quay.apps.example.com",
+			expectedRepo:     "mynamespace/repository",
+			expectedTag:      "dev",
+			expectError:      false,
+		},
+		{
+			name: "private quay registry with https scheme in docker_url",
+			payload: `{
+				"name": "repository",
+				"repository": "ariss/alrl",
+				"namespace": "ariss",
+				"docker_url": "https://quay.internal.corp/ariss/alrl",
+				"homepage": "https://quay.internal.corp/repository/ariss/alrl",
+				"updated_tags": [
+					"v1.0"
+				]
+			}`,
+			expectedRegistry: "quay.internal.corp",
+			expectedRepo:     "ariss/alrl",
+			expectedTag:      "v1.0",
+			expectError:      false,
+		},
+		{
+			name: "empty docker_url falls back to quay.io",
+			payload: `{
+				"name": "repository",
+				"repository": "mynamespace/repository",
+				"namespace": "mynamespace",
+				"docker_url": "",
+				"updated_tags": [
+					"latest"
+				]
+			}`,
+			expectedRegistry: "quay.io",
+			expectedRepo:     "mynamespace/repository",
+			expectedTag:      "latest",
+			expectError:      false,
+		},
+		{
+			name: "missing docker_url falls back to quay.io",
+			payload: `{
+				"name": "repository",
+				"repository": "mynamespace/repository",
+				"namespace": "mynamespace",
+				"updated_tags": [
+					"latest"
+				]
+			}`,
+			expectedRegistry: "quay.io",
+			expectedRepo:     "mynamespace/repository",
+			expectedTag:      "latest",
+			expectError:      false,
 		},
 		{
 			name: "valid payload with multiple tags",
@@ -127,9 +194,10 @@ func TestQuayWebhook_Parse(t *testing.T) {
 					"v1.0"
 				]
 			}`,
-			expectedRepo: "mynamespace/repository",
-			expectedTag:  "latest",
-			expectError:  false,
+			expectedRegistry: "quay.io",
+			expectedRepo:     "mynamespace/repository",
+			expectedTag:      "latest",
+			expectError:      false,
 		},
 		{
 			name: "valid payload with no tags",
@@ -186,9 +254,33 @@ func TestQuayWebhook_Parse(t *testing.T) {
 			}
 
 			assert.NotNil(t, event, "Event was nil")
-			assert.Equal(t, "quay.io", event.RegistryURL, "Expected repository url to be %s, but got %s", "quay.io", event.RegistryURL)
-			assert.Equal(t, tt.expectedRepo, event.Repository, "Expect repository to be %s, but got %s", tt.expectedRepo, event.Repository)
-			assert.Equal(t, tt.expectedTag, event.Tag, "Expected tag to be %s, but got %s", tt.expectedTag, event.Tag)
+			assert.Equal(t, tt.expectedRegistry, event.RegistryURL)
+			assert.Equal(t, tt.expectedRepo, event.Repository)
+			assert.Equal(t, tt.expectedTag, event.Tag)
+		})
+	}
+}
+
+func TestExtractRegistryFromDockerURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"public quay.io", "quay.io/ns/repo", "quay.io"},
+		{"private hostname", "quay.apps.example.com/ns/repo", "quay.apps.example.com"},
+		{"with https scheme", "https://quay.internal.corp/ns/repo", "quay.internal.corp"},
+		{"with http scheme", "http://quay.internal.corp/ns/repo", "quay.internal.corp"},
+		{"hostname with port", "quay.internal.corp:8443/ns/repo", "quay.internal.corp:8443"},
+		{"bare hostname no path", "quay.apps.example.com", "quay.apps.example.com"},
+		{"manual split fallback", "quay.custom.io:bad:port/ns/repo", "quay.custom.io:bad:port"},
+		{"unparseable url falls back to quay.io", "/ns/repo", "quay.io"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractRegistryFromDockerURL(tt.input)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/pkg/webhook/quay_test.go
+++ b/pkg/webhook/quay_test.go
@@ -10,10 +10,10 @@ import (
 
 func TestNewQuayWebhook(t *testing.T) {
 	secret := "test"
-	webhook := NewDockerHubWebhook(secret)
+	webhook := NewQuayWebhook(secret)
 
 	assert.NotNil(t, webhook, "webhook was nil")
-	assert.Equal(t, webhook.secret, secret, "Secret is not the same expected %s but got %s", secret, webhook.secret)
+	assert.Equal(t, secret, webhook.secret, "Secret is not the same expected %s but got %s", secret, webhook.secret)
 }
 
 func TestQuayWebhook_GetRegistryType(t *testing.T) {
@@ -21,7 +21,7 @@ func TestQuayWebhook_GetRegistryType(t *testing.T) {
 	registryType := webhook.GetRegistryType()
 
 	assert.NotNil(t, webhook, "Webhook was nil")
-	assert.Equal(t, registryType, "quay.io", "Registry type is not quay.io got: %s", registryType)
+	assert.Equal(t, "quay.io", registryType, "Registry type is not quay.io got: %s", registryType)
 }
 
 func TestQuayWebhook_Validate(t *testing.T) {
@@ -186,9 +186,9 @@ func TestQuayWebhook_Parse(t *testing.T) {
 			}
 
 			assert.NotNil(t, event, "Event was nil")
-			assert.Equal(t, event.RegistryURL, "quay.io", "Expected repository url to be %s, but got %s", "quay.io", event.RegistryURL)
-			assert.Equal(t, event.Repository, tt.expectedRepo, "Expect repository to be %s, but got %s", tt.expectedRepo, event.Repository)
-			assert.Equal(t, event.Tag, tt.expectedTag, "Expected tag to be %s, but got %s", tt.expectedTag, event.Tag)
+			assert.Equal(t, "quay.io", event.RegistryURL, "Expected repository url to be %s, but got %s", "quay.io", event.RegistryURL)
+			assert.Equal(t, tt.expectedRepo, event.Repository, "Expect repository to be %s, but got %s", tt.expectedRepo, event.Repository)
+			assert.Equal(t, tt.expectedTag, event.Tag, "Expected tag to be %s, but got %s", tt.expectedTag, event.Tag)
 		})
 	}
 }

--- a/pkg/webhook/server_test.go
+++ b/pkg/webhook/server_test.go
@@ -78,7 +78,7 @@ func testEndpointConnectivity(t *testing.T, url string, expectedStatus int) {
 
 	res, err := client.Get(url)
 	if res != nil {
-		assert.Equal(t, res.StatusCode, expectedStatus, "Did not receive the expected status of %d got: %d", expectedStatus, res.StatusCode)
+		assert.Equal(t, expectedStatus, res.StatusCode, "Did not receive the expected status of %d got: %d", expectedStatus, res.StatusCode)
 		defer res.Body.Close()
 	}
 	assert.NotNil(t, res, "No body received so server is not alive")
@@ -92,8 +92,8 @@ func TestNewWebhookServer(t *testing.T) {
 	server := NewWebhookServer(8080, handler, reconciler)
 
 	assert.NotNil(t, server, "Server was nil")
-	assert.Equal(t, server.Port, 8080, "Port is not 8080 got %d", server.Port)
-	assert.Equal(t, server.Handler, handler, "Handler is not equal")
+	assert.Equal(t, 8080, server.Port, "Port is not 8080 got %d", server.Port)
+	assert.Equal(t, handler, server.Handler, "Handler is not equal")
 	assert.NotNil(t, server.Reconciler, "Reconciler was nil")
 
 }
@@ -166,8 +166,8 @@ func TestWebhookServerHandleHealth(t *testing.T) {
 	body, err := io.ReadAll(res.Body)
 	assert.NoError(t, err, "Error while parsing body")
 
-	assert.Equal(t, res.StatusCode, http.StatusOK, "Did not receive the correct status code got: %d", res.StatusCode)
-	assert.Equal(t, string(body), "OK", "Did not receive the correct health message")
+	assert.Equal(t, http.StatusOK, res.StatusCode, "Did not receive the correct status code got: %d", res.StatusCode)
+	assert.Equal(t, "OK", string(body), "Did not receive the correct health message")
 }
 
 // TestWebhookServerHealthEndpoint ensures that the health endpoint of the server is working properly
@@ -195,8 +195,8 @@ func TestWebhookServerHealthEndpoint(t *testing.T) {
 
 		body, err := io.ReadAll(res.Body)
 		assert.NoError(t, err)
-		assert.Equal(t, string(body), "OK", "Did not receive 'OK' got: %s", string(body))
-		assert.Equal(t, res.StatusCode, http.StatusOK, "Did not receive status 200 got: %d", res.StatusCode)
+		assert.Equal(t, "OK", string(body), "Did not receive 'OK' got: %s", string(body))
+		assert.Equal(t, http.StatusOK, res.StatusCode, "Did not receive status 200 got: %d", res.StatusCode)
 	}
 }
 
@@ -248,7 +248,7 @@ func TestWebhookServerHandleWebhook(t *testing.T) {
 			res := rec.Result()
 			defer res.Body.Close()
 
-			assert.Equal(t, res.StatusCode, tt.expectedStatus, "Did not receive ok status")
+			assert.Equal(t, tt.expectedStatus, res.StatusCode, "Did not receive ok status")
 		})
 	}
 
@@ -317,7 +317,7 @@ func TestWebhookServerWebhookEndpoint(t *testing.T) {
 		defer res.Body.Close()
 
 		assert.NoError(t, err)
-		assert.Equal(t, res.StatusCode, http.StatusOK, "Did not receive status 200 got: %d", res.StatusCode)
+		assert.Equal(t, http.StatusOK, res.StatusCode, "Did not receive status 200 got: %d", res.StatusCode)
 	}
 
 	body2 := `{}`
@@ -329,7 +329,7 @@ func TestWebhookServerWebhookEndpoint(t *testing.T) {
 		defer res2.Body.Close()
 
 		assert.NoError(t, err)
-		assert.Equal(t, res2.StatusCode, http.StatusBadRequest, "Did not receive status 400 got: %d", res.StatusCode)
+		assert.Equal(t, http.StatusBadRequest, res2.StatusCode, "Did not receive status 400 got: %d", res2.StatusCode)
 	}
 }
 


### PR DESCRIPTION
this PR backports 2 fixes from release-1.2 to release-1.1 branch:
* fix(test): correct assert.Equal arg order and wrong webhook type in quay test (#1663) (#1687)
* fix(webhook-quay): Self-hosted Quay images redirect to quay.io, not self-hosted URL (#1683) (#1689)

In order to maintain a consistant order, this PR should be merged after #1692 and #1691
