### PR TITLE
Add blank lines preservation on git writeback

### DIFF
--- a/pkg/argocd/git.go
+++ b/pkg/argocd/git.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"text/template"
 
 	"sigs.k8s.io/kustomize/api/konfig"
@@ -418,8 +419,8 @@ func writeKustomization(ctx context.Context, applicationImages *ApplicationImage
 }
 
 // updateKustomizeFile reads the kustomization file at path, applies the filter to it, and writes the result back
-// to the file. This is the same behavior as kyaml.UpdateFile, but it preserves the original order of YAML fields
-// and indentation of YAML sequences to minimize git diffs.
+// to the file. This is the same behavior as kyaml.UpdateFile, but it preserves the original order of YAML fields,
+// indentation of YAML sequences, and blank lines to minimize git diffs.
 func updateKustomizeFile(ctx context.Context, filter kyaml.Filter, path string) (error, bool) {
 	log := log.LoggerFromContext(ctx)
 
@@ -429,8 +430,13 @@ func updateKustomizeFile(ctx context.Context, filter kyaml.Filter, path string) 
 		return err, false
 	}
 
-	// Read the yaml document from bytes
-	originalYSlice, err := kio.FromBytes(yRaw)
+	// Encode blank lines as marker comments so they survive the kyaml round-trip.
+	// kyaml (go.yaml.in/yaml/v3) discards blank lines during parsing but preserves
+	// head comments, so we convert blank lines to comments and restore them afterward.
+	yEncoded := encodeBlankLines(yRaw)
+
+	// Read the yaml document from bytes (use encoded to keep comparison consistent)
+	originalYSlice, err := kio.FromBytes(yEncoded)
 	if err != nil {
 		return err, false
 	}
@@ -450,7 +456,7 @@ func updateKustomizeFile(ctx context.Context, filter kyaml.Filter, path string) 
 	// Create a reader, preserving indentation of sequences
 	var out bytes.Buffer
 	rw := &kio.ByteReadWriter{
-		Reader:            bytes.NewBuffer(yRaw),
+		Reader:            bytes.NewBuffer(yEncoded),
 		Writer:            &out,
 		PreserveSeqIndent: true,
 	}
@@ -495,8 +501,8 @@ func updateKustomizeFile(ctx context.Context, filter kyaml.Filter, path string) 
 		return nil, true
 	}
 
-	// Write to file the changes
-	if err := os.WriteFile(path, out.Bytes(), 0600); err != nil {
+	// Write to file the changes, restoring blank lines from the marker comments
+	if err := os.WriteFile(path, decodeBlankLines(out.Bytes()), 0600); err != nil {
 		return err, false
 	}
 
@@ -538,6 +544,29 @@ func imageFilter(imgSet types.Image) (kyaml.Filter, error) {
 	return kyaml.FilterFunc(func(object *kyaml.RNode) (*kyaml.RNode, error) {
 		return object, object.PipeE(setter)
 	}), nil
+}
+
+const blankLineMarker = "# __preserve_blank_line__"
+
+// encodeBlankLines replaces blank lines with a marker comment so they survive
+// the kyaml round-trip. kyaml discards blank lines but preserves head comments.
+func encodeBlankLines(data []byte) []byte {
+	lines := strings.Split(string(data), "\n")
+	end := len(lines)
+	if end > 0 && lines[end-1] == "" {
+		end-- // don't encode the trailing empty string from the final \n
+	}
+	for i := 0; i < end; i++ {
+		if strings.TrimSpace(lines[i]) == "" {
+			lines[i] = blankLineMarker
+		}
+	}
+	return []byte(strings.Join(lines, "\n"))
+}
+
+// decodeBlankLines converts blank line markers back to actual blank lines.
+func decodeBlankLines(data []byte) []byte {
+	return bytes.ReplaceAll(data, []byte(blankLineMarker+"\n"), []byte("\n"))
 }
 
 func findKustomization(base string) string {

--- a/pkg/argocd/git_test.go
+++ b/pkg/argocd/git_test.go
@@ -354,6 +354,7 @@ func Test_updateKustomizeFile(t *testing.T) {
 		wantContent string
 		filter      kyaml.Filter
 		wantErr     bool
+		wantSkip    bool
 	}{
 		{
 			name: "sorted",
@@ -397,8 +398,12 @@ func Test_updateKustomizeFile(t *testing.T) {
 - name: foo
   digest: sha23456
 `,
-			wantContent: "",
-			filter:      filter,
+			wantContent: `images:
+- name: foo
+  digest: sha23456
+`,
+			filter:   filter,
+			wantSkip: true,
 		},
 		{
 			name: "invalid-path",
@@ -444,6 +449,31 @@ images:
 `,
 			filter: filter,
 		},
+		{
+			// Verifies that when nothing needs to change, blank lines in the file
+			// are neither removed nor corrupted by the encode/decode step.
+			name: "no-change-blank-lines",
+			content: `apiVersion: kustomize.config.k8s.io/v1beta1
+
+images:
+- name: foo
+  digest: sha23456
+
+resources:
+- some-resource.yaml
+`,
+			wantContent: `apiVersion: kustomize.config.k8s.io/v1beta1
+
+images:
+- name: foo
+  digest: sha23456
+
+resources:
+- some-resource.yaml
+`,
+			filter:   filter,
+			wantSkip: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -458,16 +488,14 @@ images:
 			if tt.wantErr {
 				assert.Error(t, err)
 				assert.False(t, skip)
-			} else if tt.name == "no-change" {
-				assert.Nil(t, err)
-				assert.True(t, skip)
 			} else {
-				got, err := os.ReadFile(path)
-				if err != nil {
-					t.Fatal(err)
+				assert.Nil(t, err)
+				assert.Equal(t, tt.wantSkip, skip)
+				got, readErr := os.ReadFile(path)
+				if readErr != nil {
+					t.Fatal(readErr)
 				}
 				assert.Equal(t, tt.wantContent, string(got))
-				assert.False(t, skip)
 			}
 		})
 	}

--- a/pkg/argocd/git_test.go
+++ b/pkg/argocd/git_test.go
@@ -410,6 +410,40 @@ func Test_updateKustomizeFile(t *testing.T) {
 			filter:      filter,
 			wantErr:     true,
 		},
+		{
+			name: "blank-lines-between-sections",
+			content: `images:
+- name: foo
+  digest: sha12345
+
+resources:
+- some-resource.yaml
+`,
+			wantContent: `images:
+- name: foo
+  digest: sha23456
+
+resources:
+- some-resource.yaml
+`,
+			filter: filter,
+		},
+		{
+			name: "blank-lines-before-images",
+			content: `apiVersion: kustomize.config.k8s.io/v1beta1
+
+images:
+- name: foo
+  digest: sha12345
+`,
+			wantContent: `apiVersion: kustomize.config.k8s.io/v1beta1
+
+images:
+- name: foo
+  digest: sha23456
+`,
+			filter: filter,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/argocd/git_test.go
+++ b/pkg/argocd/git_test.go
@@ -354,7 +354,6 @@ func Test_updateKustomizeFile(t *testing.T) {
 		wantContent string
 		filter      kyaml.Filter
 		wantErr     bool
-		wantSkip    bool
 	}{
 		{
 			name: "sorted",
@@ -398,12 +397,8 @@ func Test_updateKustomizeFile(t *testing.T) {
 - name: foo
   digest: sha23456
 `,
-			wantContent: `images:
-- name: foo
-  digest: sha23456
-`,
-			filter:   filter,
-			wantSkip: true,
+			wantContent: "",
+			filter:      filter,
 		},
 		{
 			name: "invalid-path",
@@ -449,31 +444,6 @@ images:
 `,
 			filter: filter,
 		},
-		{
-			// Verifies that when nothing needs to change, blank lines in the file
-			// are neither removed nor corrupted by the encode/decode step.
-			name: "no-change-blank-lines",
-			content: `apiVersion: kustomize.config.k8s.io/v1beta1
-
-images:
-- name: foo
-  digest: sha23456
-
-resources:
-- some-resource.yaml
-`,
-			wantContent: `apiVersion: kustomize.config.k8s.io/v1beta1
-
-images:
-- name: foo
-  digest: sha23456
-
-resources:
-- some-resource.yaml
-`,
-			filter:   filter,
-			wantSkip: true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -488,14 +458,16 @@ resources:
 			if tt.wantErr {
 				assert.Error(t, err)
 				assert.False(t, skip)
-			} else {
+			} else if tt.name == "no-change" {
 				assert.Nil(t, err)
-				assert.Equal(t, tt.wantSkip, skip)
-				got, readErr := os.ReadFile(path)
-				if readErr != nil {
-					t.Fatal(readErr)
+				assert.True(t, skip)
+			} else {
+				got, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatal(err)
 				}
 				assert.Equal(t, tt.wantContent, string(got))
+				assert.False(t, skip)
 			}
 		})
 	}


### PR DESCRIPTION
## What

Blank lines in `kustomization.yaml` were stripped on every git writeback update (issue [#501](https://github.com/argoproj-labs/argocd-image-updater/issues/501)). Sequence indentation was fixed earlier in PR #1002 via `PreserveSeqIndent: true`, but blank lines remained broken.

## Why

`go.yaml.in/yaml/v3` (kyaml's underlying library) does **not** preserve blank lines during round-trip parsing. The `HeadComment` field on `yaml.Node` stores only comments *not separated by an empty line* — blank lines are the delimiter, not a stored value. When kyaml serializes the node tree back to text, blank lines are gone.

## How

Before piping through kyaml, encode each blank line as a special marker head-comment (`# __preserve_blank_line__`). kyaml *does* preserve `HeadComment` fields through the round-trip (the `ByteWriter` calls `encoder.Encode(nodes[i].Document())` which serializes the full `yaml.Node` including all comment fields). After kyaml writes the output, decode the markers back to blank lines.

Both the change-detection comparison and the `ByteReadWriter` now use the same encoded bytes (`yEncoded`), so the skip-detection logic remains consistent.

## Limitation

Blank lines **immediately before** an image list entry that gets replaced will still be lost — `ElementSetter` discards the old node's `HeadComment` when replacing. This edge case (blank lines within an `images:` list) is uncommon and can be addressed separately.

## Testing

Two new test cases added to `Test_updateKustomizeFile`:
- `blank-lines-between-sections`: blank line between `images:` and `resources:` sections
- `blank-lines-before-images`: blank line between `apiVersion:` and `images:`

```
go test ./pkg/argocd/... -run Test_updateKustomizeFile -v
```

All existing tests continue to pass.

Closes #501

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved blank lines when updating Kubernetes kustomization YAML files, ensuring formatting remains unchanged around image updates.
  * Improved YAML round-trip behavior so spacing is retained after modifying image digests.
* **Tests**
  * Added coverage for kustomization updates when blank lines appear before `images` or between `images` and `resources`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->