### PR TITLE
fix(write-back): resolve correct git source for implicit kustomize in multi-source apps

### DIFF
--- a/docs/basics/update-methods.md
+++ b/docs/basics/update-methods.md
@@ -384,6 +384,58 @@ spec:
 Note that using the helmvalues option needs the Helm values filename to be specified in the
 `writeBackConfig.gitConfig.writeBackTarget`.
 
+### <a name="method-git-multi-source"></a>Multi-Source Applications (mixed Kustomize and Helm)
+
+Argo CD supports [multi-source applications](https://argo-cd.readthedocs.io/en/stable/user-guide/multiple_sources/) where an `Application` or `ApplicationSet` lists several sources. A common pattern is combining a Git/Kustomize source (your own workload) with one or more Helm chart sources (third-party dependencies such as Redis or PostgreSQL).
+
+Image Updater handles this correctly: it identifies the correct write-back source by the `writeBackTarget` you configure. You only need to target the Kustomize or Helm source that contains your images; the other sources are left untouched.
+
+#### Kustomize + Helm example
+
+```yaml
+# ApplicationSet template
+spec:
+  writeBackConfig:
+    method: "git"
+    gitConfig:
+      writeBackTarget: "kustomization"  # targets the Kustomize git source only
+```
+
+```yaml
+sources:
+  # Source 0 — your workload (Kustomize, may have no explicit kustomize: field)
+  - repoURL: 'https://github.com/your-org/gitops.git'
+    path: ./deployments/myapp/overlays/staging
+    targetRevision: main
+
+  # Source 1 — third-party Helm chart; Image Updater ignores this one
+  - repoURL: 'registry-1.docker.io/bitnamicharts'
+    chart: redis
+    targetRevision: '20.11.*'
+    helm:
+      valueFiles:
+        - $values/deployments/myapp/base/redis/values.yaml
+
+  # Source 2 — values ref; also ignored
+  - repoURL: 'https://github.com/your-org/gitops.git'
+    ref: values
+    targetRevision: main
+```
+
+Image Updater locates the Kustomize write-back source in two steps:
+
+1. It first looks for a source with an explicit `kustomize:` spec block.
+2. If none is found, it falls back to `Status.SourceTypes` index alignment — Argo CD records the detected source type for every source in that field, so an implicit Kustomize source (where Argo CD auto-detects Kustomize via a `kustomization.yaml` file in the path) is still correctly identified.
+
+This means **you do not need to add an explicit `kustomize: {}` block** to your source spec — the `write-back-target: kustomization` annotation is sufficient.
+
+!!!note "Annotation-based configuration"
+    When using the annotation API (e.g. on an `ApplicationSet` template), the equivalent configuration is:
+    ```yaml
+    argocd-image-updater.argoproj.io/write-back-method: git
+    argocd-image-updater.argoproj.io/write-back-target: kustomization
+    ```
+
 ### <a name="method-git-pull-request"></a>Git Pull Request
 
 The Git Pull Request mode extends the `git` write-back method so that instead

--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -1098,6 +1098,19 @@ func getApplicationSource(ctx context.Context, app *argocdapi.Application, wbc *
 			}
 		}
 
+		// Second pass: use Status.SourceTypes index alignment to handle implicit source types.
+		// ArgoCD sets Status.SourceTypes[i] for Spec.Sources[i], so a kustomize app that has no
+		// explicit kustomize: spec field (ArgoCD auto-detects it via kustomization.yaml) will be
+		// found here even though s.Kustomize == nil in the first pass above.
+		if sourceType != argocdapi.ApplicationSourceTypeDirectory &&
+			len(app.Status.SourceTypes) == len(app.Spec.Sources) {
+			for i, st := range app.Status.SourceTypes {
+				if st == sourceType {
+					return &app.Spec.Sources[i]
+				}
+			}
+		}
+
 		// Fallback: look for any Helm or Kustomize source
 		for i := range app.Spec.Sources {
 			s := &app.Spec.Sources[i]

--- a/pkg/argocd/argocd_test.go
+++ b/pkg/argocd/argocd_test.go
@@ -567,6 +567,65 @@ func Test_GetApplicationSource(t *testing.T) {
 		assert.Equal(t, appSource.Path, "sources/source1")
 	})
 
+	// Reproduces the bug from GitHub issue #1096: a multi-source app where the kustomize source
+	// has no explicit kustomize: spec field (ArgoCD auto-detects it via kustomization.yaml).
+	// Without the Status.SourceTypes alignment second pass, getApplicationSource falls through to
+	// the Helm fallback and returns the Redis chart source, causing git credential lookup to fail
+	// against a Helm OCI registry URL.
+	t.Run("Return kustomize Source from multisource application when kustomize source has no explicit kustomize field", func(t *testing.T) {
+		application := &v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "test-app",
+				Namespace: "testns",
+			},
+			Spec: v1alpha1.ApplicationSpec{
+				Sources: v1alpha1.ApplicationSources{
+					// Source 0: implicit kustomize (no kustomize: spec field)
+					v1alpha1.ApplicationSource{
+						RepoURL:        "git@github.com:organisation/gitops.git",
+						Path:           "./deployments/myapp/overlays/staging",
+						TargetRevision: "main",
+					},
+					// Source 1: Helm chart
+					v1alpha1.ApplicationSource{
+						RepoURL:        "registry-1.docker.io/bitnamicharts",
+						Chart:          "redis",
+						TargetRevision: "20.11.*",
+						Helm: &v1alpha1.ApplicationSourceHelm{
+							ValueFiles: []string{"$values/deployments/myapp/base/redis/values.yaml"},
+						},
+					},
+					// Source 2: git values ref (no path, no helm)
+					v1alpha1.ApplicationSource{
+						RepoURL:        "https://github.com/organisation/gitops.git",
+						Ref:            "values",
+						TargetRevision: "main",
+					},
+				},
+			},
+			Status: v1alpha1.ApplicationStatus{
+				// ArgoCD reports Kustomize for the path-based source even without an explicit kustomize: field
+				SourceTypes: []v1alpha1.ApplicationSourceType{
+					v1alpha1.ApplicationSourceTypeKustomize,
+					v1alpha1.ApplicationSourceTypeHelm,
+					v1alpha1.ApplicationSourceTypeDirectory,
+				},
+			},
+		}
+
+		wbc := &WriteBackConfig{
+			Method:        WriteBackGit,
+			KustomizeBase: "./deployments/myapp/overlays/staging",
+		}
+
+		appSource := GetApplicationSource(context.Background(), application, wbc)
+		require.NotNil(t, appSource)
+		assert.Equal(t, "git@github.com:organisation/gitops.git", appSource.RepoURL,
+			"Expected the git kustomize source, not the Helm chart source")
+		assert.Equal(t, "./deployments/myapp/overlays/staging", appSource.Path)
+		assert.Nil(t, appSource.Helm, "Should not have returned the Helm source")
+	})
+
 }
 
 func Test_GetApplicationSource_SourceHydrator(t *testing.T) {


### PR DESCRIPTION
## What

Fixes a bug where git write-back in a multi-source `Application` / `ApplicationSet` that mixes a Kustomize source with one or more Helm chart sources would fail with:

```
Could not update application spec: could not get creds for repo 'registry-1.docker.io/bitnamicharts':
credentials for 'registry-1.docker.io/bitnamicharts' are not configured in Argo CD settings
```

Fixes #1096 (original report, upstream: argoproj-labs/argocd-image-updater#1096).

## Why the existing fix (v1.1.1 / PR #1443) was incomplete

PR #1443 added `WriteBackConfig` awareness to `getApplicationSourceType` so that a `.yaml`-suffixed write-back target is correctly interpreted as Helm even when Kustomize appears first in `Status.SourceTypes`. That covers the **Helm** write-back direction.

The **Kustomize** write-back direction was still broken for _implicit_ kustomize sources — sources that have a `path:` pointing at a directory with a `kustomization.yaml`, but no explicit `kustomize:` spec block. ArgoCD auto-detects and reports these as `Kustomize` in `Status.SourceTypes`, but `Spec.Sources[i].Kustomize` is `nil`.

`getApplicationSource` checked `s.Kustomize != nil` in its first pass. Finding nothing, it fell through to a second loop that returns the first source with _any_ `helm:` or `kustomize:` field — which picked the Redis Helm chart. `wbc.GitRepo` then became `registry-1.docker.io/bitnamicharts`, a Helm OCI registry rather than a git endpoint, and git credential lookup failed.

## Fix

Added a second pass in `getApplicationSource` that uses `Status.SourceTypes` index alignment:

```go
// Second pass: use Status.SourceTypes index alignment to handle implicit source types.
if sourceType != argocdapi.ApplicationSourceTypeDirectory &&
    len(app.Status.SourceTypes) == len(app.Spec.Sources) {
    for i, st := range app.Status.SourceTypes {
        if st == sourceType {
            return &app.Spec.Sources[i]
        }
    }
}
```

ArgoCD sets `Status.SourceTypes[i]` for `Spec.Sources[i]`, so the implicit kustomize source is correctly identified even without an explicit `kustomize:` spec block.

## Changes

| File | Change |
|------|--------|
| `pkg/argocd/argocd.go` | Second-pass `Status.SourceTypes` alignment in `getApplicationSource` |
| `pkg/argocd/argocd_test.go` | Regression test reproducing the exact 3-source ApplicationSet shape from #1096 |
| `docs/basics/update-methods.md` | New **Multi-Source Applications** section documenting the Kustomize + Helm pattern |

## Testing

```bash
go test ./pkg/argocd/... -run "Test_GetApplicationSource|Test_MultiSource" -v
go test ./pkg/argocd/...
```

All existing tests pass; the new test (`Return kustomize Source from multisource application when kustomize source has no explicit kustomize field`) reproduces the failure before the fix and passes after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for Git write-back in multi-source applications combining Kustomize and Helm.
  * Included an ApplicationSet example showing how to target only the intended source for image updates.
  * Documented both explicit write-back targeting and annotation-based equivalents.
* **Bug Fixes**
  * Improved multi-source source selection for implicit Kustomize/Helm detection by aligning with reported source types.
  * Added regression coverage to ensure write-back targets the correct Kustomize source and avoids incorrectly selecting Helm.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->