### PR TITLE
chore(deps): bump ImageUpdater from 1.2.1 to 1.2.2

### DIFF
--- a/test/ginkgo/go.mod
+++ b/test/ginkgo/go.mod
@@ -3,7 +3,7 @@ module github.com/argoproj-labs/argocd-image-updater/test/ginkgo
 go 1.26.0
 
 require (
-	github.com/argoproj-labs/argocd-image-updater v1.2.1
+	github.com/argoproj-labs/argocd-image-updater v1.2.2
 	github.com/argoproj-labs/argocd-operator v0.18.0
 	github.com/argoproj/argo-cd/gitops-engine v0.7.1-0.20250908182407-97ad5b59a627
 	github.com/argoproj/argo-cd/v3 v3.4.4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency to a newer patch release, which may include stability and reliability improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->