### PR TITLE
feat(argocd): support Plugin source type with git write-back

### DIFF
--- a/docs/configuration/applications.md
+++ b/docs/configuration/applications.md
@@ -351,6 +351,46 @@ Where `<method>` must be one of `argocd` (imperative) or `git` (declarative).
 
 The default used by Argo CD Image Updater is `argocd`.
 
+### Plugin source type
+
+Applications using a custom plugin source type are supported with the **git**
+write-back method, provided the plugin consumes Helm-style or Kustomize-style
+values files from git (e.g. helmfile). The `argocd` write-back method is
+**not** supported for Plugin apps because ArgoCD has no mechanism to override
+plugin environment variables from the Application spec.
+
+Configure the write-back target explicitly to control the file format:
+
+| Target | Format written to Git |
+|--------|-----------------------|
+| `kustomization` or `kustomization:<path>` | `kustomization.yaml` (Kustomize image override) |
+| `helmvalues:<path>` | Helm values YAML |
+| *(none / default)* | `.argocd-source-<app>.yaml` (ArgoCD Helm parameter overrides — Plugin apps are classified as Helm) |
+
+**Helmfile example** using `kustomization` write-back:
+
+```yaml
+spec:
+  writeBackConfig:
+    method: "git"
+    gitConfig:
+      repository: "https://github.com/myorg/infra.git"
+      branch: "main"
+  applicationRefs:
+    - namePattern: "my-helmfile-app.*"
+      writeBackConfig:
+        gitConfig:
+          writeBackTarget: "kustomization"
+      images:
+        - alias: img
+          imageName: "myregistry/myapp"
+          commonUpdateSettings:
+            updateStrategy: semver
+```
+
+The helmfile then reads the image tag from the generated `kustomization.yaml`
+via `readFile "kustomization.yaml" | fromYaml`.
+
 ## <a name="complete-example"></a>Complete example
 
 Here's a complete example that demonstrates various configuration options:

--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -1103,6 +1103,11 @@ func getApplicationType(app *argocdapi.Application, wbc *WriteBackConfig) Applic
 		return ApplicationTypeKustomize
 	} else if sourceType == argocdapi.ApplicationSourceTypeHelm {
 		return ApplicationTypeHelm
+	} else if sourceType == argocdapi.ApplicationSourceTypePlugin &&
+		wbc != nil && wbc.Method == WriteBackGit {
+		// Plugin apps: the write-back target format determines serialization, not the source type.
+		// KustomizeBase being non-empty is already caught above via getApplicationSourceType.
+		return ApplicationTypeHelm
 	} else {
 		return ApplicationTypeUnsupported
 	}

--- a/pkg/argocd/argocd_test.go
+++ b/pkg/argocd/argocd_test.go
@@ -359,6 +359,7 @@ func Test_GetApplicationType(t *testing.T) {
 	})
 
 	t.Run("Plugin app with argocd write-back remains unsupported", func(t *testing.T) {
+		// Spec.Source is intentionally omitted: source type is driven by Status.SourceType, not Spec.
 		application := &v1alpha1.Application{
 			ObjectMeta: v1.ObjectMeta{
 				Name:      "test-app",

--- a/pkg/argocd/argocd_test.go
+++ b/pkg/argocd/argocd_test.go
@@ -336,6 +336,46 @@ func Test_GetApplicationType(t *testing.T) {
 		assert.Equal(t, ApplicationTypeKustomize, appType)
 	})
 
+	t.Run("Plugin app with git write-back returns Helm type", func(t *testing.T) {
+		application := &v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "test-app",
+				Namespace: "argocd",
+			},
+			Spec: v1alpha1.ApplicationSpec{
+				Source: &v1alpha1.ApplicationSource{
+					Plugin: &v1alpha1.ApplicationSourcePlugin{},
+				},
+			},
+			Status: v1alpha1.ApplicationStatus{
+				SourceType: v1alpha1.ApplicationSourceTypePlugin,
+			},
+		}
+		wbc := &WriteBackConfig{
+			Method: WriteBackGit,
+		}
+		appType := GetApplicationType(application, wbc)
+		assert.Equal(t, ApplicationTypeHelm, appType)
+	})
+
+	t.Run("Plugin app with argocd write-back remains unsupported", func(t *testing.T) {
+		application := &v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "test-app",
+				Namespace: "argocd",
+			},
+			Spec: v1alpha1.ApplicationSpec{},
+			Status: v1alpha1.ApplicationStatus{
+				SourceType: v1alpha1.ApplicationSourceTypePlugin,
+			},
+		}
+		// nil wbc → unsupported
+		assert.Equal(t, ApplicationTypeUnsupported, GetApplicationType(application, nil))
+		// explicit argocd method → unsupported
+		wbc := &WriteBackConfig{Method: WriteBackApplication}
+		assert.Equal(t, ApplicationTypeUnsupported, GetApplicationType(application, wbc))
+	})
+
 }
 
 func Test_GetApplicationSourceType(t *testing.T) {

--- a/pkg/argocd/argocd_test.go
+++ b/pkg/argocd/argocd_test.go
@@ -358,6 +358,32 @@ func Test_GetApplicationType(t *testing.T) {
 		assert.Equal(t, ApplicationTypeHelm, appType)
 	})
 
+	t.Run("Plugin app with kustomization write-back target returns Kustomize type", func(t *testing.T) {
+		// writeBackTarget: "kustomization" sets wbc.KustomizeBase via parseKustomizeBase().
+		// getApplicationSourceType() checks KustomizeBase first, so the Plugin source type
+		// is never reached — this is why Plugin + kustomization already works without the
+		// new Plugin branch added in this patch.
+		application := &v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "test-app",
+				Namespace: "argocd",
+			},
+			Spec: v1alpha1.ApplicationSpec{
+				Source: &v1alpha1.ApplicationSource{
+					Plugin: &v1alpha1.ApplicationSourcePlugin{},
+				},
+			},
+			Status: v1alpha1.ApplicationStatus{
+				SourceType: v1alpha1.ApplicationSourceTypePlugin,
+			},
+		}
+		wbc := &WriteBackConfig{
+			Method:        WriteBackGit,
+			KustomizeBase: "k8s/apps/my-app", // set by parseKustomizeBase when writeBackTarget: "kustomization"
+		}
+		assert.Equal(t, ApplicationTypeKustomize, GetApplicationType(application, wbc))
+	})
+
 	t.Run("Plugin app with argocd write-back remains unsupported", func(t *testing.T) {
 		// Spec.Source is intentionally omitted: source type is driven by Status.SourceType, not Spec.
 		application := &v1alpha1.Application{

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -4176,6 +4176,59 @@ helm:
 		assert.NotEmpty(t, yamlOutput)
 		assert.Equal(t, strings.TrimSpace(strings.ReplaceAll(expected, "\t", "  ")), strings.TrimSpace(string(yamlOutput)))
 	})
+
+	t.Run("Plugin app with git write-back produces Helm values output", func(t *testing.T) {
+		// A Plugin (e.g. helmfile) app should be treated as Helm when wbc.Method == WriteBackGit,
+		// so marshalParamsOverride should produce Helm parameter override YAML.
+		app := v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "helmfile-app",
+				Namespace: "argocd",
+			},
+			Spec: v1alpha1.ApplicationSpec{
+				Source: &v1alpha1.ApplicationSource{
+					RepoURL: "https://github.com/example/helmfile-repo",
+					Path:    "k8s/apps/my-app",
+					Plugin:  &v1alpha1.ApplicationSourcePlugin{},
+				},
+			},
+			Status: v1alpha1.ApplicationStatus{
+				SourceType: v1alpha1.ApplicationSourceTypePlugin,
+				Summary: v1alpha1.ApplicationSummary{
+					Images: []string{"myregistry/myapp:v0.9.0"},
+				},
+			},
+		}
+
+		im := NewImage(image.NewFromIdentifier("myapp=myregistry/myapp"))
+		im.HelmImageName = "image.name"
+		im.HelmImageTag = "image.tag"
+
+		applicationImages := &ApplicationImages{
+			Application: app,
+			Images:      ImageList{im},
+			WriteBackConfig: &WriteBackConfig{
+				Method: WriteBackGit,
+				Target: "k8s/apps/my-app/.argocd-source-helmfile-app.yaml",
+			},
+		}
+
+		// SetHelmImage must be called before marshalParamsOverride so the in-memory
+		// app.Spec.Source.Helm is populated — this mirrors UpdateApplication's flow.
+		newImg := image.NewFromIdentifier("myregistry/myapp:v1.0.0")
+		err := SetHelmImage(context.Background(), &applicationImages.Application, newImg, applicationImages.WriteBackConfig, im)
+		require.NoError(t, err)
+
+		yamlOutput, err := marshalParamsOverride(context.Background(), applicationImages, nil)
+		require.NoError(t, err)
+		assert.NotEmpty(t, yamlOutput)
+
+		// Verify it's Helm format (has "helm:" key, not "kustomize:")
+		outputStr := string(yamlOutput)
+		assert.Contains(t, outputStr, "image.tag")
+		assert.Contains(t, outputStr, "v1.0.0")
+		assert.NotContains(t, outputStr, "kustomize:")
+	})
 }
 
 func Test_GetHelmValue(t *testing.T) {

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -4228,6 +4228,7 @@ helm:
 		assert.Contains(t, outputStr, "image.tag")
 		assert.Contains(t, outputStr, "v1.0.0")
 		assert.NotContains(t, outputStr, "kustomize:")
+		assert.Contains(t, outputStr, "helm:")
 	})
 }
 


### PR DESCRIPTION
Closes #168

## Summary

ArgoCD Image Updater currently skips any Application whose source type is `Plugin` with:

```
skipping app '...' of type 'Plugin' because it's not of supported source type
```

This makes it incompatible with helmfile, cdk8s, argocd-vault-plugin, and any other custom plugin source — regardless of write-back method.

## Root cause

`getApplicationType()` in `pkg/argocd/argocd.go` only recognises `Helm` and `Kustomize`. Plugin falls through to `ApplicationTypeUnsupported`, which causes `IsValidApplicationType()` to return false and skip the app entirely.

## Fix

When source type is `Plugin` **and** the write-back method is `git`, return `ApplicationTypeHelm`. For git write-back, the write-back target format (helmvalues file, kustomization file, or default Helm parameter overrides) determines how the image tag is serialised — the source type is irrelevant to that operation.

The `argocd` write-back method for Plugin apps remains unsupported: ArgoCD has no mechanism to override plugin parameters directly from the Application spec.

**Note:** The `kustomization` write-back target is already handled transparently. When `writeBackTarget: "kustomization"` is set, `parseKustomizeBase()` populates `wbc.KustomizeBase`, which causes `getApplicationSourceType()` to return `ApplicationSourceTypeKustomize` before `getApplicationType()` ever reaches the Plugin branch. So Plugin + kustomization write-back target was already working; this patch covers Plugin + helmvalues and Plugin + default Helm overrides.

## Changes

| File | Change |
|------|--------|
| `pkg/argocd/argocd.go` | Add Plugin branch in `getApplicationType()` (5 lines) |
| `pkg/argocd/argocd_test.go` | Three new sub-tests in `Test_GetApplicationType` (Plugin + git → Helm, Plugin + kustomization target → Kustomize, Plugin + argocd → Unsupported) |
| `pkg/argocd/update_test.go` | New sub-test in `Test_MarshalParamsOverride` — Plugin app + git write-back → Helm YAML output |
| `docs/configuration/applications.md` | New "Plugin source type" section under write-back documentation |

## Testing

Tests follow TDD: failing tests committed before the fix, fix committed after.

```
go test ./pkg/argocd/... -count=1
ok   github.com/argoproj-labs/argocd-image-updater/pkg/argocd
```

## Motivation

The driving use case is a helmfile-based ArgoCD application: helmfile is configured as a Config Management Plugin, and the image tag is passed through a `values.yaml` file tracked in git. When a new image is pushed to the registry, Image Updater should write the new tag back to that values file so the next ArgoCD sync picks it up automatically.

This pattern — helmfile CMP + git write-back to a chart values file — is currently blocked entirely because Image Updater rejects any Plugin source app before even attempting a write-back. This patch removes that restriction for git write-back, where the target file format (not the source type) is what determines how the tag is serialised.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for plugin-based apps, including the required Git write-back behavior, supported `writeBackTarget` outputs, and updated examples.
* **Bug Fixes**
  * Corrected plugin app handling so Git write-back classifies plugin sources appropriately and generates the expected Helm-formatted output.
* **Tests**
  * Expanded coverage for plugin scenarios to verify application type selection and the generated parameter override YAML format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->