### PR TITLE
chore(ci): add allow-unsafe-pr-checkout: true to actions/checkout@v7 to opt in to allow checkout of fork PRs

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -229,6 +229,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
+          allow-unsafe-pr-checkout: true
           persist-credentials: false
           # For pull_request_target, check out the contributor's commit rather
           # than the base branch (which is the default for that event).


### PR DESCRIPTION
See https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target