### PR TITLE
feat: image verification to work with both modern registry signature lookup and legacy signature formats; test(e2e): image signature verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ test-results
 *.crt
 # htpasswd files (should be generated at runtime, not committed)
 **/htpasswd
+test/ginkgo/prereqs/assets/cosign

--- a/docs/configuration/images.md
+++ b/docs/configuration/images.md
@@ -521,10 +521,11 @@ spec:
 
 !!!note
     Only [cosign](https://github.com/sigstore/cosign) key-based verification
-    (`method: cosign-key`) is supported. The controller uses the OCI Referrers
-    API to locate the signature artifact pushed by `cosign sign`, so the registry
-    must support OCI Distribution Spec v1.1 referrers (Quay, GHCR,
-    and most modern registries do).
+    is supported. The controller first tries the OCI Referrers API (OCI Distribution
+    Spec v1.1) to locate signatures, and automatically falls back to the tag-based
+    storage used by cosign on older registries (the `sha256-<digest>` tag). Most
+    modern registries (Quay, GHCR) support the Referrers API; older or
+    self-hosted registries that do not will use the fallback automatically.
 
 !!!note
     When `imagesVerification` is present and `enabled` is `true` (the default),

--- a/pkg/argocd/argocd_test.go
+++ b/pkg/argocd/argocd_test.go
@@ -3652,6 +3652,7 @@ func Test_sortApplicationRefs(t *testing.T) {
 
 // Assisted-by: Gemini AI
 func Test_FilterApplicationsForUpdate(t *testing.T) {
+	const fakeCosignPEM = "-----BEGIN PUBLIC KEY-----\nfake\n-----END PUBLIC KEY-----"
 	// Define common applications to be used across test cases
 	appProd := &v1alpha1.Application{
 		ObjectMeta: v1.ObjectMeta{Name: "app-prod", Namespace: "testns", Labels: map[string]string{"env": "prod"}},
@@ -3702,6 +3703,7 @@ func Test_FilterApplicationsForUpdate(t *testing.T) {
 		name            string
 		initialApps     []client.Object
 		imageUpdaterCR  *api.ImageUpdater
+		secrets         []runtime.Object // K8s secrets available to the kube client, e.g. for cosign key lookups
 		expectedKeys    []string
 		expectedImages  map[string]int // map[appKey]expectedImageCount, for specificity check
 		expectNilResult bool
@@ -4306,6 +4308,101 @@ func Test_FilterApplicationsForUpdate(t *testing.T) {
 			},
 			expectedKeys: []string{"testns/verify-ann-app"},
 		},
+		{
+			// applicationRef.ImagesVerification (app level) must be honored when
+			// UseAnnotations is true: mergedImagesVerification = applicationRef.ImagesVerification
+			// directly, so a valid app-level cosign key should result in a verified image.
+			// See custom verification below for the actual EnableVerification/CosignKey assertions.
+			name: "UseAnnotations: app-level ImagesVerification is applied successfully",
+			initialApps: []client.Object{
+				&v1alpha1.Application{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "verify-app-level-app",
+						Namespace: "testns",
+						Annotations: map[string]string{
+							ImageUpdaterAnnotation: "web=ghcr.io/org/app:1.0",
+						},
+					},
+					Spec: v1alpha1.ApplicationSpec{
+						Source: &v1alpha1.ApplicationSource{
+							Kustomize: &v1alpha1.ApplicationSourceKustomize{},
+						},
+					},
+					Status: v1alpha1.ApplicationStatus{SourceType: v1alpha1.ApplicationSourceTypeKustomize},
+				},
+			},
+			imageUpdaterCR: &api.ImageUpdater{
+				ObjectMeta: v1.ObjectMeta{Name: "test-updater", Namespace: "testns"},
+				Spec: api.ImageUpdaterSpec{
+					ApplicationRefs: []api.ApplicationRef{
+						{
+							NamePattern:    "verify-app-level-app",
+							UseAnnotations: boolPtr(true),
+							ImagesVerification: &api.ImagesVerification{
+								CosignKey: &api.SecretRef{SecretName: "app-cosign-secret", Key: "cosign.pub"},
+							},
+						},
+					},
+				},
+			},
+			secrets: []runtime.Object{
+				&v1core.Secret{
+					ObjectMeta: v1.ObjectMeta{Namespace: "testns", Name: "app-cosign-secret"},
+					Data:       map[string][]byte{"cosign.pub": []byte(fakeCosignPEM)},
+				},
+			},
+			expectedKeys:   []string{"testns/verify-app-level-app"},
+			expectedImages: map[string]int{"testns/verify-app-level-app": 1},
+		},
+		{
+			// A global (CR-level) ImagesVerification block must be completely ignored
+			// when UseAnnotations is true and the applicationRef itself sets no
+			// ImagesVerification: mergedImagesVerification = applicationRef.ImagesVerification
+			// (nil here), it is never merged with cr.Spec.ImagesVerification. Even though
+			// the global cosign key is valid, the image must proceed unverified.
+			// See custom verification below for the actual EnableVerification/Verify assertions.
+			name: "UseAnnotations: global ImagesVerification is ignored at app level",
+			initialApps: []client.Object{
+				&v1alpha1.Application{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "verify-ignore-global-app",
+						Namespace: "testns",
+						Annotations: map[string]string{
+							ImageUpdaterAnnotation: "web=ghcr.io/org/app:1.0",
+						},
+					},
+					Spec: v1alpha1.ApplicationSpec{
+						Source: &v1alpha1.ApplicationSource{
+							Kustomize: &v1alpha1.ApplicationSourceKustomize{},
+						},
+					},
+					Status: v1alpha1.ApplicationStatus{SourceType: v1alpha1.ApplicationSourceTypeKustomize},
+				},
+			},
+			imageUpdaterCR: &api.ImageUpdater{
+				ObjectMeta: v1.ObjectMeta{Name: "test-updater", Namespace: "testns"},
+				Spec: api.ImageUpdaterSpec{
+					ImagesVerification: &api.ImagesVerification{
+						CosignKey: &api.SecretRef{SecretName: "global-cosign-secret", Key: "cosign.pub"},
+					},
+					ApplicationRefs: []api.ApplicationRef{
+						{
+							NamePattern:    "verify-ignore-global-app",
+							UseAnnotations: boolPtr(true),
+							// ImagesVerification intentionally unset at app level
+						},
+					},
+				},
+			},
+			secrets: []runtime.Object{
+				&v1core.Secret{
+					ObjectMeta: v1.ObjectMeta{Namespace: "testns", Name: "global-cosign-secret"},
+					Data:       map[string][]byte{"cosign.pub": []byte(fakeCosignPEM)},
+				},
+			},
+			expectedKeys:   []string{"testns/verify-ignore-global-app"},
+			expectedImages: map[string]int{"testns/verify-ignore-global-app": 1},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -4316,7 +4413,8 @@ func Test_FilterApplicationsForUpdate(t *testing.T) {
 			require.NoError(t, err)
 			kubeClient := kube.ImageUpdaterKubernetesClient{
 				KubeClient: &registryKube.KubernetesClient{
-					Clientset: fake.NewFakeKubeClient(),
+					Clientset: fake.NewFakeClientsetWithResources(tc.secrets...),
+					Context:   ctx,
 				},
 			}
 			// Execute
@@ -4393,6 +4491,30 @@ func Test_FilterApplicationsForUpdate(t *testing.T) {
 				}
 				require.NotNil(t, webImage, "web image should be found")
 				assert.Equal(t, image.StrategySemVer, webImage.UpdateStrategy, "web image should have semver strategy from per-image annotation, overriding application-wide latest")
+			}
+
+			// Custom verification that app-level ImagesVerification (set on the
+			// applicationRef) is actually applied when UseAnnotations is true.
+			if tc.name == "UseAnnotations: app-level ImagesVerification is applied successfully" {
+				appKey := "testns/verify-app-level-app"
+				require.Contains(t, appsForUpdate, appKey)
+				images := appsForUpdate[appKey].Images
+				require.Len(t, images, 1)
+				assert.True(t, images[0].EnableVerification, "app-level ImagesVerification should enable verification")
+				require.NotNil(t, images[0].Verify, "Verify should be populated from app-level cosign key")
+				assert.Equal(t, fakeCosignPEM, images[0].Verify.CosignKey, "cosign key should be fetched from the app-level secret")
+			}
+
+			// Custom verification that a global (CR-level) ImagesVerification block is
+			// ignored at the app level when UseAnnotations is true and the applicationRef
+			// itself does not set ImagesVerification.
+			if tc.name == "UseAnnotations: global ImagesVerification is ignored at app level" {
+				appKey := "testns/verify-ignore-global-app"
+				require.Contains(t, appsForUpdate, appKey)
+				images := appsForUpdate[appKey].Images
+				require.Len(t, images, 1)
+				assert.False(t, images[0].EnableVerification, "global ImagesVerification must not leak into an app-level rule that sets none")
+				assert.Nil(t, images[0].Verify, "Verify should remain unset since global config is ignored under UseAnnotations")
 			}
 		})
 	}

--- a/registry-scanner/pkg/image/verify.go
+++ b/registry-scanner/pkg/image/verify.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"strings"
 
 	"github.com/distribution/distribution/v3"
 	"github.com/distribution/distribution/v3/manifest/ocischema"
@@ -22,6 +23,24 @@ import (
 // sigstoreBundleType is the OCI artifactType used by cosign ≥ 2.x when
 // storing signatures via the OCI Referrers API (sigstore bundle / DSSE format).
 const sigstoreBundleType = "application/vnd.dev.sigstore.bundle.v0.3+json"
+
+// ociImageIndexMediaType is the media type of an OCI Image Index (manifest list).
+// cosign 2.x uses an Image Index as the container for tag-based fallback
+// signature storage: the index itself is stored at "sha256-<hex>.sig" and
+// each of its manifest entries is a sigstore bundle manifest.
+const ociImageIndexMediaType = "application/vnd.oci.image.index.v1+json"
+
+// simpleSigningMediaType is the layer media type of cosign's legacy
+// "Simple Signing" format (SIGNATURE_SPEC.md), used for local key-based
+// signing (cosign sign --key, no Fulcio/OIDC) when pushing to a registry
+// that does not support the OCI Referrers API. Unlike the sigstore bundle
+// format, the signature is a plain base64 annotation on the layer
+// descriptor and the payload is signed directly (no DSSE envelope/PAE).
+const simpleSigningMediaType = "application/vnd.dev.cosign.simplesigning.v1+json"
+
+// simpleSigningSigAnnotation is the annotation key holding the base64-encoded
+// ECDSA signature over sha256(payload) for the Simple Signing format.
+const simpleSigningSigAnnotation = "dev.cosignproject.cosign/signature"
 
 // Verify carries the signature verification policy for a single image.
 type Verify struct {
@@ -84,6 +103,19 @@ type simpleSigningPayload struct {
 	} `json:"critical"`
 }
 
+// inTotoStatement is the minimal representation of an in-toto v1 Statement
+// (https://in-toto.io/Statement/v1). Plain `cosign sign` (no --attest) using
+// the modern sigstore bundle format wraps this in the DSSE envelope instead
+// of the legacy simple-signing JSON — its predicateType is
+// "https://sigstore.dev/cosign/sign/v1" and the subject digest is what binds
+// the signature to a specific image manifest.
+type inTotoStatement struct {
+	Type    string `json:"_type"`
+	Subject []struct {
+		Digest map[string]string `json:"digest"`
+	} `json:"subject"`
+}
+
 // ---------------------------------------------------------------------------
 // VerifyWithPublicKey
 // ---------------------------------------------------------------------------
@@ -131,15 +163,27 @@ func VerifyWithPublicKey(ctx context.Context, img *ContainerImage, verifyConfig 
 // ---------------------------------------------------------------------------
 
 // fetchTagSignature resolves the image manifest digest, queries the OCI
-// Referrers API for all sigstore bundle artifacts, fetches every bundle
-// manifest, and collects all DSSE-wrapped ECDSA signatures across all bundles.
+// Referrers API for all sigstore bundle artifacts, and collects all
+// DSSE-wrapped ECDSA signatures.
+//
+// When the OCI Referrers API is unavailable or returns no results (e.g. the
+// registry does not implement OCI Distribution Spec v1.1), the function
+// automatically falls back to the tag-based storage cosign uses on such
+// registries. Which tag naming convention and payload format cosign chooses
+// depends on how the image was signed (keyless/bundle-based vs. local
+// key-based) rather than on cosign's version alone, so both are tried:
+//   - "sha256-<hex>" (no suffix): the OCI "Referrers Tag Schema" fallback for
+//     bundle-based signing, used by cosign ≥ 3.x by default and optionally by
+//     cosign 2.x.
+//   - "sha256-<hex>.sig": the legacy cosign Signature Spec tag. This is what
+//     `cosign sign --key` (no Fulcio/OIDC) still produces against a registry
+//     without OCI Referrers support, on any cosign version, and it may hold
+//     either a sigstore bundle/OCI Image Index or the pre-bundle legacy
+//     "Simple Signing" payload — see extractSigsFromManifest.
 //
 // The returned slice contains one entry per signer.  Errors on individual
 // referrers are logged as warnings and skipped so that a single bad artifact
 // cannot block a valid signature from being found.
-//
-// Only the sigstore bundle format (cosign ≥ 2.x) is supported. Legacy cosign
-// simple-signing (.sig tag) is not.
 func fetchTagSignatures(ctx context.Context, imgTag *tag.ImageTag, regClient RegistryFetcher) ([]*tag.TagSignature, error) {
 	logCtx := log.LoggerFromContext(ctx)
 
@@ -168,14 +212,16 @@ func fetchTagSignatures(ctx context.Context, imgTag *tag.ImageTag, regClient Reg
 		logCtx.Debugf("Computed manifest digest %s for tag %q", imgDigest, imgTag.TagName)
 	}
 
-	// --- Step 2: fetch OCI referrers ---
+	// --- Step 2: try OCI Referrers API (OCI Distribution Spec v1.1) ---
+	// A non-nil error here is non-fatal: the tag-based fallback is tried below.
 	logCtx.Debugf("Fetching OCI referrers for digest %s (tag %q)", imgDigest, imgTag.TagName)
-	referrers, err := regClient.Referrers(ctx, imgDigest)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch OCI referrers for digest %s: %w", imgDigest, err)
+	referrers, referrersErr := regClient.Referrers(ctx, imgDigest)
+	if referrersErr != nil {
+		logCtx.Debugf("OCI Referrers API unavailable for tag %q (digest %s): %v — will try tag-based fallback",
+			imgTag.TagName, imgDigest, referrersErr)
 	}
 
-	// --- Step 3 & 4: collect signatures from ALL sigstore bundle referrers ---
+	// --- Step 3: collect signatures from ALL sigstore bundle referrers ---
 	var allSigs []*tag.TagSignature
 	for _, ref := range referrers {
 		if ref.ArtifactType != sigstoreBundleType {
@@ -195,20 +241,96 @@ func fetchTagSignatures(ctx context.Context, imgTag *tag.ImageTag, regClient Reg
 		allSigs = append(allSigs, sigs...)
 	}
 
+	// --- Step 4: tag-based fallback for registries without OCI v1.1 Referrers ---
+	// The image digest is encoded into a tag by replacing ":" with "-", either
+	// with no suffix (OCI Referrers Tag Schema) or with the legacy ".sig"
+	// suffix (cosign Signature Spec). Both are tried so verification works
+	// regardless of how the signature was produced — see fetchTagSignatures'
+	// doc comment above for details.
 	if len(allSigs) == 0 {
-		return nil, fmt.Errorf("no cosign signature found in OCI referrers for image tag %q (digest %s)", imgTag.TagName, imgDigest)
+		digestTag := strings.ReplaceAll(imgDigest.String(), ":", "-")
+		for _, fallbackTag := range []string{digestTag, digestTag + ".sig"} {
+			logCtx.Debugf("No OCI referrers found for tag %q; trying tag-based fallback %q", imgTag.TagName, fallbackTag)
+			sigs, err := fetchSigsFromFallbackTag(ctx, fallbackTag, imgTag.TagName, imgDigest, regClient)
+			if err != nil {
+				logCtx.Debugf("Tag-based fallback %q not found for tag %q: %v", fallbackTag, imgTag.TagName, err)
+				continue
+			}
+			if len(sigs) > 0 {
+				logCtx.Debugf("Found %d cosign signature(s) via tag-based fallback %q for tag %q", len(sigs), fallbackTag, imgTag.TagName)
+				allSigs = append(allSigs, sigs...)
+				break
+			}
+		}
+	}
+
+	if len(allSigs) == 0 {
+		if referrersErr != nil {
+			// Surface the original Referrers error when both paths found nothing.
+			return nil, fmt.Errorf("failed to fetch OCI referrers for digest %s: %w", imgDigest, referrersErr)
+		}
+		return nil, fmt.Errorf("no cosign signature found in OCI referrers or tag-based fallback for image tag %q (digest %s)", imgTag.TagName, imgDigest)
 	}
 	return allSigs, nil
 }
 
-// ---------------------------------------------------------------------------
-// extractSigsFromManifest / extractDSSEBundle
-// ---------------------------------------------------------------------------
+// fetchSigsFromFallbackTag fetches the manifest at fallbackTag, if it exists,
+// and extracts sigstore bundle signatures from it. It transparently handles
+// both container formats cosign may use for the fallback artifact:
+//   - an OCI Image Index whose References() entries are the actual signature
+//     bundle manifests (cosign 2.x/3.x), or
+//   - a plain OCI Image Manifest holding the signature bundle directly
+//     (older cosign).
+//
+// A non-nil error means the tag does not exist or could not be read, which
+// the caller treats as "try the next fallback tag convention".
+func fetchSigsFromFallbackTag(ctx context.Context, fallbackTag, imgTagName string, imgDigest godigest.Digest, regClient RegistryFetcher) ([]*tag.TagSignature, error) {
+	logCtx := log.LoggerFromContext(ctx)
+
+	fallbackManifest, err := regClient.ManifestForTag(ctx, fallbackTag)
+	if err != nil {
+		return nil, err
+	}
+
+	fallbackMediaType, _, err := fallbackManifest.Payload()
+	if err != nil {
+		return nil, fmt.Errorf("error reading fallback manifest payload: %w", err)
+	}
+
+	if fallbackMediaType != ociImageIndexMediaType {
+		// Plain OCI Image Manifest at the fallback tag (older cosign).
+		return extractSigsFromManifest(ctx, fallbackManifest, fallbackTag, imgTagName, imgDigest, regClient)
+	}
+
+	// The fallback tag points to an OCI Image Index; each References() entry
+	// is a signature bundle manifest.
+	refs := fallbackManifest.References()
+	logCtx.Debugf("Tag-based fallback %q is an OCI Image Index with %d entr(ies) for tag %q",
+		fallbackTag, len(refs), imgTagName)
+
+	var sigs []*tag.TagSignature
+	for _, desc := range refs {
+		subManifest, err := regClient.ManifestForDigest(ctx, desc.Digest)
+		if err != nil {
+			logCtx.Warnf("Error fetching fallback index entry %s for tag %q: %v — skipping",
+				desc.Digest, imgTagName, err)
+			continue
+		}
+		s, err := extractSigsFromManifest(ctx, subManifest, desc.Digest.String(), imgTagName, imgDigest, regClient)
+		if err != nil {
+			logCtx.Warnf("Error extracting signatures from fallback index entry %s for tag %q: %v — skipping",
+				desc.Digest, imgTagName, err)
+			continue
+		}
+		sigs = append(sigs, s...)
+	}
+	return sigs, nil
+}
 
 // extractSigsFromManifest validates the OCI manifest and delegates to the
-// DSSE bundle extractor. Returns one TagSignature per signer in the envelope.
-// expectedDigest is the image manifest digest and is forwarded to extractDSSEBundle
-// for replay-attack prevention.
+// appropriate extractor based on the layer's media type. Returns one
+// TagSignature per signer found. expectedDigest is the image manifest digest,
+// forwarded for replay-attack prevention.
 func extractSigsFromManifest(ctx context.Context, m distribution.Manifest, manifestRef, imgTagName string, expectedDigest godigest.Digest, regClient RegistryFetcher) ([]*tag.TagSignature, error) {
 	ociSig, ok := m.(*ocischema.DeserializedManifest)
 	if !ok {
@@ -219,18 +341,22 @@ func extractSigsFromManifest(ctx context.Context, m distribution.Manifest, manif
 	}
 
 	layer := ociSig.Layers[0]
-	if layer.MediaType != sigstoreBundleType {
+	switch layer.MediaType {
+	case sigstoreBundleType:
+		return extractDSSEBundle(ctx, layer, imgTagName, expectedDigest, regClient)
+	case simpleSigningMediaType:
+		return extractSimpleSigning(ctx, layer, imgTagName, expectedDigest, regClient)
+	default:
 		return nil, fmt.Errorf("unsupported cosign layer media type %q in manifest %q (image tag %q)",
 			layer.MediaType, manifestRef, imgTagName)
 	}
-
-	return extractDSSEBundle(ctx, layer, imgTagName, expectedDigest, regClient)
 }
 
 // extractDSSEBundle fetches the sigstore bundle blob, parses the DSSE envelope,
-// validates that the embedded image digest matches expectedDigest, and returns
-// one TagSignature per signer. PayloadDigest is hex(sha256(PAE)) — the exact
-// bytes each private key signed.
+// validates that the embedded image digest matches expectedDigest (see
+// extractEmbeddedDigest for the two payload formats this supports), and
+// returns one TagSignature per signer. PayloadDigest is hex(sha256(PAE)) —
+// the exact bytes each private key signed.
 //
 // The digest binding check prevents a valid bundle signed for image A from being
 // replayed as a referrer of image B and still passing ECDSA verification.
@@ -263,29 +389,8 @@ func extractDSSEBundle(ctx context.Context, layer distribution.Descriptor, imgTa
 		return nil, fmt.Errorf("failed to decode dsseEnvelope payload for image tag %q: %w", imgTagName, err)
 	}
 
-	// Bind the signature to the exact image manifest digest embedded in the
-	// simple-signing payload when the field is present.  Without this check a
-	// valid bundle signed for image A could be replayed as a referrer of image B
-	// and still pass ECDSA verification.
-	//
-	// Some cosign / sigstore-go versions or non-standard bundle formats omit the
-	// field.  In that case we skip the check and rely on the OCI Referrers API's
-	// own subject-digest binding (a referrer's OCI manifest must declare the
-	// subject it attests to, enforced by the registry at write time).
-	var ssPayload simpleSigningPayload
-	if err := json.Unmarshal(decodedPayload, &ssPayload); err != nil {
-		return nil, fmt.Errorf("failed to parse simple-signing payload for image tag %q: %w", imgTagName, err)
-	}
-	if embeddedDigest := ssPayload.Critical.Image.DockerManifestDigest; embeddedDigest != "" {
-		if embeddedDigest != expectedDigest.String() {
-			return nil, fmt.Errorf("payload manifest digest %q does not match image manifest digest %q for image tag %q",
-				embeddedDigest, expectedDigest, imgTagName)
-		}
-	} else {
-		log.LoggerFromContext(ctx).Debugf(
-			"bundle payload for image tag %q does not contain docker-manifest-digest; relying on OCI subject binding",
-			imgTagName,
-		)
+	if err := checkDigestBinding(ctx, decodedPayload, imgTagName, expectedDigest, "bundle"); err != nil {
+		return nil, err
 	}
 
 	// PAE digest is the same for all signers in this envelope.
@@ -301,6 +406,90 @@ func extractDSSEBundle(ctx context.Context, layer distribution.Descriptor, imgTa
 		})
 	}
 	return sigs, nil
+}
+
+// checkDigestBinding binds a signature to the exact image manifest digest
+// embedded in its payload. Without this check a valid signature made for
+// image A could be replayed against image B and still pass ECDSA
+// verification.
+//
+// An embedded digest is required, not optional: this helper is also used for
+// the tag-based fallback path, which has no registry-enforced subject
+// binding (the fallback tag name is just a string; nothing stops a signature
+// blob signed for one digest from being pushed under another digest's tag).
+// A payload with no embedded digest in either supported format is therefore
+// treated as a verification failure rather than silently allowed.
+func checkDigestBinding(_ context.Context, payload []byte, imgTagName string, expectedDigest godigest.Digest, payloadKind string) error {
+	embeddedDigest, err := extractEmbeddedDigest(payload, expectedDigest)
+	if err != nil {
+		return fmt.Errorf("failed to parse %s payload for image tag %q: %w", payloadKind, imgTagName, err)
+	}
+	if embeddedDigest == "" {
+		return fmt.Errorf("%s payload for image tag %q has no embedded manifest digest (docker-manifest-digest or in-toto subject digest)",
+			payloadKind, imgTagName)
+	}
+	if embeddedDigest != expectedDigest.String() {
+		return fmt.Errorf("payload manifest digest %q does not match image manifest digest %q for image tag %q",
+			embeddedDigest, expectedDigest, imgTagName)
+	}
+	return nil
+}
+
+// extractEmbeddedDigest returns the "<algo>:<hex>" image manifest digest
+// embedded in a cosign signature payload, in whichever of the two formats
+// cosign uses:
+//   - legacy Simple Signing: critical.image.docker-manifest-digest
+//   - in-toto Statement (used inside DSSE bundles for plain `cosign sign`):
+//     subject[].digest[<algo>]
+//
+// Returns "" with a nil error if neither field is present, so the caller can
+// decide how to treat a genuinely unbound payload.
+func extractEmbeddedDigest(payload []byte, expectedDigest godigest.Digest) (string, error) {
+	var stmt inTotoStatement
+	if err := json.Unmarshal(payload, &stmt); err != nil {
+		return "", err
+	}
+	if strings.HasPrefix(stmt.Type, "https://in-toto.io/Statement") {
+		algo := expectedDigest.Algorithm().String()
+		for _, subj := range stmt.Subject {
+			if hex, ok := subj.Digest[algo]; ok && hex != "" {
+				return algo + ":" + hex, nil
+			}
+		}
+		return "", nil
+	}
+
+	var ssPayload simpleSigningPayload
+	if err := json.Unmarshal(payload, &ssPayload); err != nil {
+		return "", err
+	}
+	return ssPayload.Critical.Image.DockerManifestDigest, nil
+}
+
+// extractSimpleSigning extracts a signature stored using cosign's legacy
+// "Simple Signing" format: the base64 ECDSA signature is a layer annotation,
+// and it signs sha256(payload) directly — no DSSE envelope or PAE encoding
+// is involved, unlike the sigstore bundle format.
+func extractSimpleSigning(ctx context.Context, layer distribution.Descriptor, imgTagName string, expectedDigest godigest.Digest, regClient RegistryFetcher) ([]*tag.TagSignature, error) {
+	sig, ok := layer.Annotations[simpleSigningSigAnnotation]
+	if !ok || sig == "" {
+		return nil, fmt.Errorf("simple-signing layer for image tag %q has no %q annotation", imgTagName, simpleSigningSigAnnotation)
+	}
+
+	payloadBytes, err := regClient.BlobContent(ctx, layer.Digest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch simple-signing payload blob for image tag %q: %w", imgTagName, err)
+	}
+
+	if err := checkDigestBinding(ctx, payloadBytes, imgTagName, expectedDigest, "simple-signing"); err != nil {
+		return nil, err
+	}
+
+	payloadHash := sha256.Sum256(payloadBytes)
+	return []*tag.TagSignature{{
+		Sig:           sig,
+		PayloadDigest: hex.EncodeToString(payloadHash[:]),
+	}}, nil
 }
 
 // computePAE returns the DSSE Pre-Authentication Encoding bytes:

--- a/registry-scanner/pkg/image/verify_test.go
+++ b/registry-scanner/pkg/image/verify_test.go
@@ -134,6 +134,35 @@ func makeDSSEBundleWithSigners(t *testing.T, privKeys []*ecdsa.PrivateKey, imgDi
 	return manifest, blobDigest, blobBytes
 }
 
+// makeSimpleSigning creates a legacy cosign "Simple Signing" manifest (a
+// single layer with mediaType simpleSigningMediaType, whose signature is a
+// layer annotation rather than a DSSE envelope). Returns the manifest, the
+// payload blob digest (for mockFetcher.blobs keying), and the raw blob bytes.
+func makeSimpleSigning(t *testing.T, priv *ecdsa.PrivateKey, imgDigest string) (manifest *ocischema.DeserializedManifest, blobDigest string, blobBytes []byte) {
+	t.Helper()
+
+	payload := []byte(fmt.Sprintf(`{"critical":{"image":{"docker-manifest-digest":"%s"},"type":"cosign container image signature"}}`, imgDigest))
+	payloadHash := sha256.Sum256(payload)
+	sig, err := ecdsa.SignASN1(rand.Reader, priv, payloadHash[:])
+	require.NoError(t, err)
+
+	dgst := godigest.FromBytes(payload)
+	blobDigest = dgst.String()
+	manifest = &ocischema.DeserializedManifest{
+		Manifest: ocischema.Manifest{
+			Layers: []distribution.Descriptor{{
+				MediaType: simpleSigningMediaType,
+				Digest:    dgst,
+				Size:      int64(len(payload)),
+				Annotations: map[string]string{
+					simpleSigningSigAnnotation: base64.StdEncoding.EncodeToString(sig),
+				},
+			}},
+		},
+	}
+	return manifest, blobDigest, payload
+}
+
 // bundleReferrer builds a referrer descriptor for a sigstore bundle artifact.
 func bundleReferrer(sigArtifactDigest string) distribution.Descriptor {
 	return distribution.Descriptor{
@@ -184,6 +213,17 @@ func (m *mockManifest) Payload() (string, []byte, error) {
 	return "application/vnd.oci.image.manifest.v1+json", m.payload, nil
 }
 func (m *mockManifest) References() []distribution.Descriptor { return nil }
+
+// mockIndex simulates an OCI Image Index returned by a registry for the
+// tag-based cosign 2.x fallback ("sha256-<hex>" tag → image index → bundle).
+type mockIndex struct {
+	refs []distribution.Descriptor
+}
+
+func (m *mockIndex) Payload() (string, []byte, error) {
+	return "application/vnd.oci.image.index.v1+json", []byte(`{}`), nil
+}
+func (m *mockIndex) References() []distribution.Descriptor { return m.refs }
 
 func (m *mockFetcher) ManifestForTag(_ context.Context, tagStr string) (distribution.Manifest, error) {
 	if err, ok := m.errors[tagStr]; ok {
@@ -349,12 +389,13 @@ func Test_fetchTagSignatures(t *testing.T) {
 		assert.ErrorContains(t, err, "invalid manifest digest")
 	})
 
-	t.Run("Referrers error returns error", func(t *testing.T) {
+	t.Run("Referrers error with no tag-based fallback returns OCI referrers error", func(t *testing.T) {
 		imgTag := &tag.ImageTag{TagName: "1.0.21", ManifestDigest: imgManifestDigest}
 		fetcher := &mockFetcher{
 			referrerErrors: map[string]error{
 				imgManifestDigest: fmt.Errorf("registry unavailable"),
 			},
+			// No fallback tag manifest — both paths fail.
 		}
 		_, err := fetchTagSignatures(ctx, imgTag, fetcher)
 		assert.ErrorContains(t, err, "failed to fetch OCI referrers")
@@ -370,13 +411,13 @@ func Test_fetchTagSignatures(t *testing.T) {
 			},
 		}
 		_, err := fetchTagSignatures(ctx, imgTag, fetcher)
-		assert.ErrorContains(t, err, "no cosign signature found in OCI referrers")
+		assert.ErrorContains(t, err, "no cosign signature found in OCI referrers or tag-based fallback")
 	})
 
 	t.Run("empty referrers returns error", func(t *testing.T) {
 		imgTag := &tag.ImageTag{TagName: "1.0.21", ManifestDigest: imgManifestDigest}
 		_, err := fetchTagSignatures(ctx, imgTag, &mockFetcher{})
-		assert.ErrorContains(t, err, "no cosign signature found in OCI referrers")
+		assert.ErrorContains(t, err, "no cosign signature found in OCI referrers or tag-based fallback")
 	})
 
 	t.Run("ManifestForDigest error skips referrer and returns no-signature error", func(t *testing.T) {
@@ -390,7 +431,7 @@ func Test_fetchTagSignatures(t *testing.T) {
 			},
 		}
 		_, err := fetchTagSignatures(ctx, imgTag, fetcher)
-		assert.ErrorContains(t, err, "no cosign signature found in OCI referrers")
+		assert.ErrorContains(t, err, "no cosign signature found in OCI referrers or tag-based fallback")
 	})
 
 	t.Run("sig manifest is not an OCI manifest skips referrer and returns no-signature error", func(t *testing.T) {
@@ -405,7 +446,7 @@ func Test_fetchTagSignatures(t *testing.T) {
 			},
 		}
 		_, err := fetchTagSignatures(ctx, imgTag, fetcher)
-		assert.ErrorContains(t, err, "no cosign signature found in OCI referrers")
+		assert.ErrorContains(t, err, "no cosign signature found in OCI referrers or tag-based fallback")
 	})
 
 	t.Run("sig manifest has no layers skips referrer and returns no-signature error", func(t *testing.T) {
@@ -419,7 +460,7 @@ func Test_fetchTagSignatures(t *testing.T) {
 			},
 		}
 		_, err := fetchTagSignatures(ctx, imgTag, fetcher)
-		assert.ErrorContains(t, err, "no cosign signature found in OCI referrers")
+		assert.ErrorContains(t, err, "no cosign signature found in OCI referrers or tag-based fallback")
 	})
 
 	t.Run("layer has wrong media type skips referrer and returns no-signature error", func(t *testing.T) {
@@ -441,7 +482,7 @@ func Test_fetchTagSignatures(t *testing.T) {
 			},
 		}
 		_, err := fetchTagSignatures(ctx, imgTag, fetcher)
-		assert.ErrorContains(t, err, "no cosign signature found in OCI referrers")
+		assert.ErrorContains(t, err, "no cosign signature found in OCI referrers or tag-based fallback")
 	})
 
 	t.Run("blob fetch error skips referrer and returns no-signature error", func(t *testing.T) {
@@ -459,7 +500,7 @@ func Test_fetchTagSignatures(t *testing.T) {
 			},
 		}
 		_, err := fetchTagSignatures(ctx, imgTag, fetcher)
-		assert.ErrorContains(t, err, "no cosign signature found in OCI referrers")
+		assert.ErrorContains(t, err, "no cosign signature found in OCI referrers or tag-based fallback")
 	})
 
 	t.Run("second referrer matches when first referrer manifest fails", func(t *testing.T) {
@@ -485,6 +526,169 @@ func Test_fetchTagSignatures(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, got)
 		assert.NoError(t, verifySignature("quay.io/org/app:1.0.21", got[0], kp.pemPub))
+	})
+
+	// -----------------------------------------------------------------------
+	// tag-based fallback (sha256-<hex> tag)
+	// -----------------------------------------------------------------------
+
+	// fallbackTag is the legacy cosign ≤2.5.x tag for imgManifestDigest
+	// ("sha256:<hex>" → "sha256-<hex>.sig").
+	const fallbackTag = "sha256-aabb1234aabb1234aabb1234aabb1234aabb1234aabb1234aabb1234aabb1234.sig"
+	// noSuffixFallbackTag is the cosign ≥3.x OCI Referrers Tag Schema fallback
+	// tag for imgManifestDigest ("sha256:<hex>" → "sha256-<hex>", no suffix).
+	const noSuffixFallbackTag = "sha256-aabb1234aabb1234aabb1234aabb1234aabb1234aabb1234aabb1234aabb1234"
+
+	t.Run("tag-based fallback succeeds via no-suffix tag (cosign 3.x)", func(t *testing.T) {
+		// cosign >= 3.x stores the fallback artifact under the digest tag
+		// without a ".sig" suffix (OCI Referrers Tag Schema).
+		bundleManifest, blobDigest, blobBytes := makeDSSEBundle(t, kp.priv, imgManifestDigest)
+		imgTag := &tag.ImageTag{TagName: "1.0.21", ManifestDigest: imgManifestDigest}
+
+		fetcher := &mockFetcher{
+			manifests: map[string]distribution.Manifest{
+				noSuffixFallbackTag: bundleManifest,
+			},
+			blobs: map[string][]byte{blobDigest: blobBytes},
+		}
+
+		got, err := fetchTagSignatures(ctx, imgTag, fetcher)
+		require.NoError(t, err)
+		require.NotEmpty(t, got)
+		assert.NoError(t, verifySignature("quay.io/org/app:1.0.21", got[0], kp.pemPub))
+	})
+
+	t.Run("tag-based fallback succeeds via legacy Simple Signing format", func(t *testing.T) {
+		// cosign key-based signing (no Fulcio/OIDC) to a registry without OCI
+		// Referrers falls back to the legacy Simple Signing manifest format
+		// (annotation-based signature, no DSSE envelope).
+		simpleManifest, blobDigest, blobBytes := makeSimpleSigning(t, kp.priv, imgManifestDigest)
+		imgTag := &tag.ImageTag{TagName: "1.0.21", ManifestDigest: imgManifestDigest}
+
+		fetcher := &mockFetcher{
+			manifests: map[string]distribution.Manifest{
+				fallbackTag: simpleManifest,
+			},
+			blobs: map[string][]byte{blobDigest: blobBytes},
+		}
+
+		got, err := fetchTagSignatures(ctx, imgTag, fetcher)
+		require.NoError(t, err)
+		require.NotEmpty(t, got)
+		assert.NoError(t, verifySignature("quay.io/org/app:1.0.21", got[0], kp.pemPub))
+	})
+
+	t.Run("tag-based fallback succeeds when OCI referrers is empty", func(t *testing.T) {
+		// Registry returns no referrers (e.g. Docker Distribution v2 without OCI v1.1).
+		// cosign stored the signature as a tag instead.
+		bundleManifest, blobDigest, blobBytes := makeDSSEBundle(t, kp.priv, imgManifestDigest)
+		imgTag := &tag.ImageTag{TagName: "1.0.21", ManifestDigest: imgManifestDigest}
+
+		fetcher := &mockFetcher{
+			// Referrers returns empty (nil, nil) — default for mockFetcher.
+			manifests: map[string]distribution.Manifest{
+				fallbackTag: bundleManifest,
+			},
+			blobs: map[string][]byte{blobDigest: blobBytes},
+		}
+
+		got, err := fetchTagSignatures(ctx, imgTag, fetcher)
+		require.NoError(t, err)
+		require.NotEmpty(t, got)
+		assert.NoError(t, verifySignature("quay.io/org/app:1.0.21", got[0], kp.pemPub))
+	})
+
+	t.Run("tag-based fallback succeeds when OCI referrers API returns error", func(t *testing.T) {
+		// Registry returns a 404 / unsupported error for the Referrers endpoint.
+		// The error is non-fatal; verification succeeds via the fallback tag.
+		bundleManifest, blobDigest, blobBytes := makeDSSEBundle(t, kp.priv, imgManifestDigest)
+		imgTag := &tag.ImageTag{TagName: "1.0.21", ManifestDigest: imgManifestDigest}
+
+		fetcher := &mockFetcher{
+			referrerErrors: map[string]error{
+				imgManifestDigest: fmt.Errorf("404 page not found"),
+			},
+			manifests: map[string]distribution.Manifest{
+				fallbackTag: bundleManifest,
+			},
+			blobs: map[string][]byte{blobDigest: blobBytes},
+		}
+
+		got, err := fetchTagSignatures(ctx, imgTag, fetcher)
+		require.NoError(t, err)
+		require.NotEmpty(t, got)
+		assert.NoError(t, verifySignature("quay.io/org/app:1.0.21", got[0], kp.pemPub))
+	})
+
+	t.Run("tag-based fallback with OCI Image Index (cosign 2.x) succeeds", func(t *testing.T) {
+		// cosign 2.x stores the fallback tag as an OCI Image Index whose single
+		// entry is the actual signature bundle manifest.
+		bundleManifest, blobDigest, blobBytes := makeDSSEBundle(t, kp.priv, imgManifestDigest)
+		imgTag := &tag.ImageTag{TagName: "1.0.21", ManifestDigest: imgManifestDigest}
+
+		fetcher := &mockFetcher{
+			manifests: map[string]distribution.Manifest{
+				fallbackTag: &mockIndex{
+					refs: []distribution.Descriptor{
+						{Digest: godigest.Digest(sigArtifactDigest)},
+					},
+				},
+				sigArtifactDigest: bundleManifest,
+			},
+			blobs: map[string][]byte{blobDigest: blobBytes},
+		}
+
+		got, err := fetchTagSignatures(ctx, imgTag, fetcher)
+		require.NoError(t, err)
+		require.NotEmpty(t, got)
+		assert.NoError(t, verifySignature("quay.io/org/app:1.0.21", got[0], kp.pemPub))
+	})
+
+	t.Run("tag-based fallback OCI Image Index entry fetch error is skipped", func(t *testing.T) {
+		// The index exists but fetching its only sub-manifest fails.
+		imgTag := &tag.ImageTag{TagName: "1.0.21", ManifestDigest: imgManifestDigest}
+
+		fetcher := &mockFetcher{
+			manifests: map[string]distribution.Manifest{
+				fallbackTag: &mockIndex{
+					refs: []distribution.Descriptor{
+						{Digest: godigest.Digest(sigArtifactDigest)},
+					},
+				},
+			},
+			errors: map[string]error{
+				sigArtifactDigest: fmt.Errorf("network timeout"),
+			},
+		}
+		_, err := fetchTagSignatures(ctx, imgTag, fetcher)
+		assert.ErrorContains(t, err, "no cosign signature found in OCI referrers or tag-based fallback")
+	})
+
+	t.Run("OCI referrers empty and fallback tag not found returns no-signature error", func(t *testing.T) {
+		imgTag := &tag.ImageTag{TagName: "1.0.21", ManifestDigest: imgManifestDigest}
+		// Empty mock: no referrers, no fallback tag.
+		_, err := fetchTagSignatures(ctx, imgTag, &mockFetcher{})
+		assert.ErrorContains(t, err, "no cosign signature found in OCI referrers or tag-based fallback")
+	})
+
+	t.Run("fallback tag manifest extraction error returns no-signature error", func(t *testing.T) {
+		// The fallback manifest exists but has an unsupported layer media type.
+		imgTag := &tag.ImageTag{TagName: "1.0.21", ManifestDigest: imgManifestDigest}
+		badManifest := &ocischema.DeserializedManifest{
+			Manifest: ocischema.Manifest{
+				Layers: []distribution.Descriptor{{
+					MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+					Digest:    godigest.Digest(sigArtifactDigest),
+				}},
+			},
+		}
+		fetcher := &mockFetcher{
+			manifests: map[string]distribution.Manifest{
+				fallbackTag: badManifest,
+			},
+		}
+		_, err := fetchTagSignatures(ctx, imgTag, fetcher)
+		assert.ErrorContains(t, err, "no cosign signature found in OCI referrers or tag-based fallback")
 	})
 }
 
@@ -536,6 +740,77 @@ func Test_extractSigFromManifest(t *testing.T) {
 		got, err := extractSigsFromManifest(ctx, bundleManifest, manifestRef, "1.0.21", expectedDigest, fetcher)
 		require.NoError(t, err)
 		require.NotEmpty(t, got)
+		assert.NoError(t, verifySignature("quay.io/org/app:1.0.21", got[0], kp.pemPub))
+	})
+
+	t.Run("valid simple-signing layer delegates to extractSimpleSigning and succeeds", func(t *testing.T) {
+		simpleManifest, blobDigest, blobBytes := makeSimpleSigning(t, kp.priv, testImageDigest)
+		fetcher := &mockFetcher{
+			blobs: map[string][]byte{blobDigest: blobBytes},
+		}
+
+		got, err := extractSigsFromManifest(ctx, simpleManifest, manifestRef, "1.0.21", expectedDigest, fetcher)
+		require.NoError(t, err)
+		require.NotEmpty(t, got)
+		assert.NoError(t, verifySignature("quay.io/org/app:1.0.21", got[0], kp.pemPub))
+	})
+}
+
+// ---------------------------------------------------------------------------
+// extractSimpleSigning
+// ---------------------------------------------------------------------------
+
+func Test_extractSimpleSigning(t *testing.T) {
+	ctx := context.Background()
+	kp := newTestKeyPair(t)
+	const testImageDigest = "sha256:29d4b64da00e01ca2ce893a1d2bfe5ca6e6421c107f52fdffe6537bf760ddc03"
+	expectedDigest := godigest.Digest(testImageDigest)
+
+	t.Run("missing signature annotation returns error", func(t *testing.T) {
+		layer := distribution.Descriptor{
+			MediaType:   simpleSigningMediaType,
+			Digest:      godigest.FromBytes([]byte(`{}`)),
+			Annotations: nil,
+		}
+		_, err := extractSimpleSigning(ctx, layer, "1.0.21", expectedDigest, &mockFetcher{})
+		assert.ErrorContains(t, err, "no")
+		assert.ErrorContains(t, err, simpleSigningSigAnnotation)
+	})
+
+	t.Run("blob fetch error returns error", func(t *testing.T) {
+		dgst := godigest.FromBytes([]byte(`{}`))
+		layer := distribution.Descriptor{
+			MediaType:   simpleSigningMediaType,
+			Digest:      dgst,
+			Annotations: map[string]string{simpleSigningSigAnnotation: "fakesig"},
+		}
+		fetcher := &mockFetcher{
+			blobErrors: map[string]error{dgst.String(): fmt.Errorf("I/O error")},
+		}
+		_, err := extractSimpleSigning(ctx, layer, "1.0.21", expectedDigest, fetcher)
+		assert.ErrorContains(t, err, "failed to fetch simple-signing payload blob")
+	})
+
+	t.Run("payload digest mismatch returns error", func(t *testing.T) {
+		simpleManifest, blobDigest, blobBytes := makeSimpleSigning(t, kp.priv, "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+		layer := simpleManifest.Layers[0]
+		fetcher := &mockFetcher{
+			blobs: map[string][]byte{blobDigest: blobBytes},
+		}
+		_, err := extractSimpleSigning(ctx, layer, "1.0.21", expectedDigest, fetcher)
+		assert.ErrorContains(t, err, "does not match image manifest digest")
+	})
+
+	t.Run("valid simple-signing payload returns correct TagSignature", func(t *testing.T) {
+		simpleManifest, blobDigest, blobBytes := makeSimpleSigning(t, kp.priv, testImageDigest)
+		layer := simpleManifest.Layers[0]
+		fetcher := &mockFetcher{
+			blobs: map[string][]byte{blobDigest: blobBytes},
+		}
+
+		got, err := extractSimpleSigning(ctx, layer, "1.0.21", expectedDigest, fetcher)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
 		assert.NoError(t, verifySignature("quay.io/org/app:1.0.21", got[0], kp.pemPub))
 	})
 }
@@ -649,8 +924,11 @@ func Test_extractDSSEBundle(t *testing.T) {
 		assert.ErrorContains(t, err, "does not match image manifest digest")
 	})
 
-	t.Run("payload without docker-manifest-digest field is allowed", func(t *testing.T) {
-		// Some bundle variants omit the field; we fall back to OCI subject binding.
+	t.Run("payload without docker-manifest-digest field fails closed", func(t *testing.T) {
+		// The tag-based fallback path has no registry-enforced subject binding,
+		// so a missing digest field must be rejected rather than silently
+		// allowed — otherwise a signature for image A could be replayed under
+		// image B's fallback tag.
 		noDigestPayload := []byte(`{"critical":{"image":{}}}`)
 		paeHash := sha256.Sum256(computePAE(payloadType, noDigestPayload))
 		sig, err := ecdsa.SignASN1(rand.Reader, kp.priv, paeHash[:])
@@ -668,10 +946,68 @@ func Test_extractDSSEBundle(t *testing.T) {
 		fetcher := &mockFetcher{
 			blobs: map[string][]byte{layer.Digest.String(): blobBytes},
 		}
-		got, err := extractDSSEBundle(ctx, layer, "1.0.21", expectedDigest, fetcher)
+		_, err = extractDSSEBundle(ctx, layer, "1.0.21", expectedDigest, fetcher)
+		assert.ErrorContains(t, err, "has no embedded manifest digest")
+	})
+
+	t.Run("in-toto statement payload with matching subject digest succeeds", func(t *testing.T) {
+		// Real cosign >= 2.x, when doing plain `cosign sign` (no --attest)
+		// against a registry without OCI Referrers support, wraps an in-toto
+		// v1 Statement in the DSSE envelope instead of the legacy
+		// simple-signing JSON. Verified empirically against cosign v3.1.1.
+		inTotoPayloadType := "application/vnd.in-toto+json"
+		inTotoPayload := []byte(fmt.Sprintf(
+			`{"_type":"https://in-toto.io/Statement/v1","subject":[{"digest":{"sha256":"%s"},"annotations":{}}],"predicateType":"https://sigstore.dev/cosign/sign/v1","predicate":{}}`,
+			expectedDigest.Encoded(),
+		))
+		paeHash := sha256.Sum256(computePAE(inTotoPayloadType, inTotoPayload))
+		sig, err := ecdsa.SignASN1(rand.Reader, kp.priv, paeHash[:])
 		require.NoError(t, err)
-		require.Len(t, got, 1)
-		assert.NoError(t, verifySignature("quay.io/org/app:1.0.21", got[0], kp.pemPub))
+
+		blobBytes, err := json.Marshal(sigstoreBundle{
+			DSSEEnvelope: &dsseEnvelope{
+				Payload:     base64.StdEncoding.EncodeToString(inTotoPayload),
+				PayloadType: inTotoPayloadType,
+				Signatures:  []dsseSignature{{Sig: base64.StdEncoding.EncodeToString(sig)}},
+			},
+		})
+		require.NoError(t, err)
+		layer := makeLayer(blobBytes)
+		fetcher := &mockFetcher{
+			blobs: map[string][]byte{layer.Digest.String(): blobBytes},
+		}
+		sigs, err := extractDSSEBundle(ctx, layer, "1.0.21", expectedDigest, fetcher)
+		require.NoError(t, err)
+		require.Len(t, sigs, 1)
+		wantDigestHex := hex.EncodeToString(paeHash[:])
+		assert.Equal(t, wantDigestHex, sigs[0].PayloadDigest)
+		assert.NoError(t, verifySignature("test-image", sigs[0], kp.pemPub))
+	})
+
+	t.Run("in-toto statement payload with mismatched subject digest fails", func(t *testing.T) {
+		inTotoPayloadType := "application/vnd.in-toto+json"
+		inTotoPayload := []byte(fmt.Sprintf(
+			`{"_type":"https://in-toto.io/Statement/v1","subject":[{"digest":{"sha256":"%s"},"annotations":{}}],"predicateType":"https://sigstore.dev/cosign/sign/v1","predicate":{}}`,
+			godigest.Digest(otherDigest).Encoded(),
+		))
+		paeHash := sha256.Sum256(computePAE(inTotoPayloadType, inTotoPayload))
+		sig, err := ecdsa.SignASN1(rand.Reader, kp.priv, paeHash[:])
+		require.NoError(t, err)
+
+		blobBytes, err := json.Marshal(sigstoreBundle{
+			DSSEEnvelope: &dsseEnvelope{
+				Payload:     base64.StdEncoding.EncodeToString(inTotoPayload),
+				PayloadType: inTotoPayloadType,
+				Signatures:  []dsseSignature{{Sig: base64.StdEncoding.EncodeToString(sig)}},
+			},
+		})
+		require.NoError(t, err)
+		layer := makeLayer(blobBytes)
+		fetcher := &mockFetcher{
+			blobs: map[string][]byte{layer.Digest.String(): blobBytes},
+		}
+		_, err = extractDSSEBundle(ctx, layer, "1.0.21", expectedDigest, fetcher)
+		assert.ErrorContains(t, err, "does not match image manifest digest")
 	})
 
 	t.Run("valid bundle returns correct TagSignature", func(t *testing.T) {
@@ -839,5 +1175,54 @@ func Test_VerifyWithPublicKey(t *testing.T) {
 
 		err := VerifyWithPublicKey(ctx, img, verifyConfig, fetcher)
 		assert.NoError(t, err)
+	})
+
+	t.Run("tag-based fallback verified end-to-end when OCI referrers API is unavailable", func(t *testing.T) {
+		// Models a real-world local registry (e.g. Docker Distribution v2) that
+		// returns 404 for the Referrers endpoint; cosign stored the signature as
+		// the tag "sha256-<hex>.sig".
+		const fallbackTag = "sha256-ccdd1234ccdd1234ccdd1234ccdd1234ccdd1234ccdd1234ccdd1234ccdd1234.sig"
+		img := newTestImageTag("1.0.21", imgManifestDigest)
+		bundleManifest, blobDigest, blobBytes := makeDSSEBundle(t, kp.priv, imgManifestDigest)
+
+		fetcher := &mockFetcher{
+			referrerErrors: map[string]error{
+				imgManifestDigest: fmt.Errorf("404 page not found"),
+			},
+			manifests: map[string]distribution.Manifest{
+				fallbackTag: bundleManifest,
+			},
+			blobs: map[string][]byte{blobDigest: blobBytes},
+		}
+
+		err := VerifyWithPublicKey(ctx, img, verifyConfig, fetcher)
+		assert.NoError(t, err)
+		require.NotEmpty(t, img.ImageTag.TagSignatures)
+	})
+
+	t.Run("tag-based OCI Image Index fallback verified end-to-end (cosign 2.x registry)", func(t *testing.T) {
+		// cosign 2.x stores signatures as an OCI Image Index at "sha256-<hex>.sig".
+		const fallbackTag = "sha256-ccdd1234ccdd1234ccdd1234ccdd1234ccdd1234ccdd1234ccdd1234ccdd1234.sig"
+		img := newTestImageTag("1.0.21", imgManifestDigest)
+		bundleManifest, blobDigest, blobBytes := makeDSSEBundle(t, kp.priv, imgManifestDigest)
+
+		fetcher := &mockFetcher{
+			referrerErrors: map[string]error{
+				imgManifestDigest: fmt.Errorf("404 page not found"),
+			},
+			manifests: map[string]distribution.Manifest{
+				fallbackTag: &mockIndex{
+					refs: []distribution.Descriptor{
+						{Digest: godigest.Digest(sigArtifactDigest)},
+					},
+				},
+				sigArtifactDigest: bundleManifest,
+			},
+			blobs: map[string][]byte{blobDigest: blobBytes},
+		}
+
+		err := VerifyWithPublicKey(ctx, img, verifyConfig, fetcher)
+		assert.NoError(t, err)
+		require.NotEmpty(t, img.ImageTag.TagSignatures)
 	})
 }

--- a/test/ginkgo/Makefile
+++ b/test/ginkgo/Makefile
@@ -74,7 +74,8 @@ endif
 .PHONY: deploy-argocd-operator undeploy-argocd-operator kustomize test-e2e \
    k3d-cluster-create k3d-cluster-delete k3d-image-import configure-docker-daemon \
    git-container-build git-container-push create-local-container-registry \
-   apply-imageupdater-crd
+   apply-imageupdater-crd push-signature-test-images generate-cosign-keypair \
+   sign-signature-test-image
 
 kustomize:
 	$(MAKE) -C ../../ kustomize
@@ -144,6 +145,12 @@ test-e2e: ## Build local image updater, deploy operator, and run parallel e2e te
 	$(MAKE) apply-imageupdater-crd
 	@echo "--- Deploying local container registry ---"
 	$(MAKE) create-local-container-registry
+	@echo "--- Building and pushing test images for signature verification tests ---"
+	$(MAKE) push-signature-test-images
+	@echo "--- Generating cosign key pair; store public key in prereqs/assets/cosign/ ---"
+	$(MAKE) generate-cosign-keypair
+	@echo "--- Signing test-image:signed with the generated cosign key ---"
+	$(MAKE) sign-signature-test-image
 	@echo "--- Running Parallel E2E tests ---"
 	$(MAKE) -C ../../ e2e-tests-parallel-ginkgo
 	@echo "--- Running Sequential E2E tests ---"
@@ -166,6 +173,12 @@ GIT_IMAGE_TAG		?= latest
 
 GIT_IMAGE_SLUG		:= $(GIT_IMAGE_REPO)/$(GIT_IMAGE_NAME):$(GIT_IMAGE_TAG)
 
+COSIGN                   ?= cosign
+SIG_TEST_IMAGE_NAME      ?= test-image
+SIG_TEST_DOCKERFILE      ?= $(CURRENT_DIR)/prereqs/containers/signature-test/Dockerfile
+SIG_TEST_CONTEXT         ?= $(CURRENT_DIR)/prereqs/containers/signature-test
+COSIGN_KEYPAIR_DIR       ?= $(CURRENT_DIR)/prereqs/assets/cosign
+
 git-container-build: ## Build git container image
 	$(CONTAINER_TOOL) build -t $(GIT_IMAGE_SLUG) -f ./prereqs/containers/git/Dockerfile ./prereqs/containers/git
 
@@ -184,3 +197,39 @@ create-local-container-registry: ## Create local container registry
 	@echo "--- Verifying operator deployment ---"
 	@$(KUBECTL) get deployment -n argocd-operator-system || true
 	@$(KUBECTL) get pods -n argocd-operator-system || true
+
+push-signature-test-images: ## Build and push 1.0.0/1.0.1/1.0.2 test images for signature verification tests
+	@echo "--- Building and pushing signature test images ---"
+	@for tag in 1.0.0 1.0.1 1.0.2; do \
+		echo "Building $(GIT_IMAGE_REPO)/$(SIG_TEST_IMAGE_NAME):$$tag ..."; \
+		$(CONTAINER_TOOL) build --no-cache --build-arg IMAGETAG=$$tag \
+			-t $(GIT_IMAGE_REPO)/$(SIG_TEST_IMAGE_NAME):$$tag \
+			-f $(SIG_TEST_DOCKERFILE) $(SIG_TEST_CONTEXT); \
+		$(CONTAINER_TOOL) push $(GIT_IMAGE_REPO)/$(SIG_TEST_IMAGE_NAME):$$tag; \
+	done
+	@echo "--- Signature test images pushed ---"
+
+generate-cosign-keypair: ## Generate cosign key pair; store public key in prereqs/assets/cosign/
+	@echo "--- Generating cosign key pair ---"
+	@mkdir -p $(COSIGN_KEYPAIR_DIR)
+	@if [ -f "$(COSIGN_KEYPAIR_DIR)/cosign.key" ]; then \
+		echo "Key pair already exists at $(COSIGN_KEYPAIR_DIR), skipping generation."; \
+	else \
+		cd $(COSIGN_KEYPAIR_DIR) && COSIGN_PASSWORD="" $(COSIGN) generate-key-pair; \
+		echo "Key pair generated at $(COSIGN_KEYPAIR_DIR)"; \
+	fi
+
+sign-signature-test-image: ## Sign 127.0.0.1:30000/test-image:1.0.2 by digest with the generated cosign key
+	@echo "--- Signing $(GIT_IMAGE_REPO)/$(SIG_TEST_IMAGE_NAME):1.0.2 by digest ---"
+	@if [ ! -f "$(COSIGN_KEYPAIR_DIR)/cosign.key" ]; then \
+		echo "Error: cosign key not found at $(COSIGN_KEYPAIR_DIR)/cosign.key. Run 'make generate-cosign-keypair' first."; \
+		exit 1; \
+	fi
+	@DIGEST=$$($(CONTAINER_TOOL) inspect --format='{{index .RepoDigests 0}}' \
+		$(GIT_IMAGE_REPO)/$(SIG_TEST_IMAGE_NAME):1.0.2); \
+	echo "Resolved digest reference: $$DIGEST"; \
+	COSIGN_PASSWORD="" \
+		$(COSIGN) sign --yes --key $(COSIGN_KEYPAIR_DIR)/cosign.key \
+		--allow-insecure-registry \
+		$$DIGEST
+	@echo "--- Image $(GIT_IMAGE_REPO)/$(SIG_TEST_IMAGE_NAME):1.0.2 signed successfully ---"

--- a/test/ginkgo/README.md
+++ b/test/ginkgo/README.md
@@ -18,6 +18,7 @@ This workflow is designed for developers to test their local changes in a realis
 You must have the following tools installed locally:
 - [Docker](https://docs.docker.com/get-docker/)
 - [k3d](https://k3d.io/#installation)
+- [cosign](https://docs.sigstore.dev/cosign/system_config/installation/) — required by the image signature verification test, which generates a key pair, signs a test image, and verifies the signature end-to-end.
 
 **Note on Docker Configuration on Mac**: The E2E tests use a local container registry at `127.0.0.1:30000` which requires Docker to be configured to allow insecure registries. The `test-e2e` target automatically configures Docker daemon.json for you, but if you run tests manually on Mac, you may need to run `make -C test/ginkgo configure-docker-daemon` first.
 

--- a/test/ginkgo/parallel/1-010-verify-image_test.go
+++ b/test/ginkgo/parallel/1-010-verify-image_test.go
@@ -1,0 +1,357 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package parallel
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/argoproj/argo-cd/gitops-engine/pkg/health"
+	appv1alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	applicationFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/application"
+
+	imageUpdaterApi "github.com/argoproj-labs/argocd-image-updater/api/v1alpha1"
+
+	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
+
+	"github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture"
+	argocdFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/argocd"
+	deplFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/deployment"
+	iuFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/imageupdater"
+	k8sFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/k8s"
+	ssFixture "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/statefulset"
+	fixtureUtils "github.com/argoproj-labs/argocd-image-updater/test/ginkgo/fixture/utils"
+)
+
+var _ = Describe("ArgoCD Image Updater Parallel E2E Tests", func() {
+
+	Context("1-010-verify-image_test", func() {
+
+		var (
+			k8sClient    client.Client
+			ctx          context.Context
+			ns           *corev1.Namespace
+			cleanupFunc  func()
+			imageUpdater *imageUpdaterApi.ImageUpdater
+			argoCD       *argov1beta1api.ArgoCD
+		)
+
+		BeforeEach(func() {
+			fixture.EnsureParallelCleanSlate()
+
+			k8sClient, _ = fixtureUtils.GetE2ETestKubeClient()
+			ctx = context.Background()
+		})
+
+		AfterEach(func() {
+			// Collect debug info BEFORE cleanup so pod logs are still available.
+			fixture.OutputDebugOnFail(ns)
+
+			if imageUpdater != nil {
+				By("deleting ImageUpdater CR")
+				_ = k8sClient.Delete(ctx, imageUpdater)
+				Eventually(imageUpdater, "2m", "3s").Should(k8sFixture.NotExistByName())
+			}
+
+			if argoCD != nil {
+				By("deleting ArgoCD CR")
+				_ = k8sClient.Delete(ctx, argoCD)
+			}
+
+			if cleanupFunc != nil {
+				cleanupFunc()
+			}
+		})
+
+		It("verifies that image update is skipped for unsigned images and succeeds for signed images", func() {
+
+			By("creating simple namespace-scoped Argo CD instance with image updater enabled")
+			ns, cleanupFunc = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
+
+			By("creating argocd-image-updater-config ConfigMap with local registry config")
+			// The image-updater controller reads this ConfigMap at startup. Creating it before
+			// the ArgoCD CR ensures the controller picks it up on first boot without a restart.
+			// prefix: 127.0.0.1:30000 maps image names in CRs to the in-cluster registry API URL.
+			// api_url uses the cluster-internal service DNS so the image-updater pod (running
+			// inside k3d) can reach the registry on both Linux CI and macOS without relying on
+			// host.docker.internal, which is not available in Linux k3d containers.
+			// insecure: true skips TLS verification for the self-signed registry certificate.
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "argocd-image-updater-config",
+					Namespace: ns.Name,
+				},
+				Data: map[string]string{
+					"registries.conf": `registries:
+- name: Local Registry
+  api_url: https://e2e-registry-public.argocd-operator-system.svc.cluster.local
+  prefix: 127.0.0.1:30000
+  insecure: true
+`,
+				},
+			}
+			Expect(k8sClient.Create(ctx, configMap)).To(Succeed())
+
+			By("reading cosign public key and creating Secret in test namespace")
+			cosignPubKey, err := os.ReadFile("../prereqs/assets/cosign/cosign.pub")
+			Expect(err).ToNot(HaveOccurred(), "cosign.pub not found — run 'make generate-cosign-keypair' first")
+			cosignSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cosign-pubkey",
+					Namespace: ns.Name,
+				},
+				Data: map[string][]byte{
+					"cosign.pub": cosignPubKey,
+				},
+			}
+			Expect(k8sClient.Create(ctx, cosignSecret)).To(Succeed())
+
+			By("Creating local git repo")
+			iuFixture.CreateLocalGitRepo(ctx, k8sClient, ns.Name)
+
+			By("waiting for local git repo to be ready")
+			gitDepl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: iuFixture.Name, Namespace: ns.Name}}
+			Eventually(gitDepl).Should(k8sFixture.ExistByName())
+			Eventually(gitDepl, "2m", "3s").Should(deplFixture.HaveReadyReplicas(1), "git repo server was not ready")
+
+			argoCD = &argov1beta1api.ArgoCD{
+				ObjectMeta: metav1.ObjectMeta{Name: "argocd", Namespace: ns.Name},
+				Spec: argov1beta1api.ArgoCDSpec{
+					ImageUpdater: argov1beta1api.ArgoCDImageUpdaterSpec{
+						Env: []corev1.EnvVar{
+							{
+								Name:  "IMAGE_UPDATER_LOGLEVEL",
+								Value: "trace",
+							},
+							{
+								Name:  "IMAGE_UPDATER_INTERVAL",
+								Value: "15s",
+							},
+						},
+						Enabled: true,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
+
+			By("waiting for ArgoCD CR to be reconciled and the instance to be ready")
+			Eventually(argoCD, "5m", "3s").Should(argocdFixture.BeAvailable())
+
+			By("verifying all workloads are started")
+			deploymentsShouldExist := []string{"argocd-redis", "argocd-server", "argocd-repo-server", "argocd-argocd-image-updater-controller"}
+			for _, depl := range deploymentsShouldExist {
+				depl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: depl, Namespace: ns.Name}}
+				Eventually(depl).Should(k8sFixture.ExistByName())
+				Eventually(depl).Should(deplFixture.HaveReplicas(1))
+				Eventually(depl, "3m", "3s").Should(deplFixture.HaveReadyReplicas(1), depl.Name+" was not ready")
+			}
+
+			statefulSet := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "argocd-application-controller", Namespace: ns.Name}}
+			Eventually(statefulSet).Should(k8sFixture.ExistByName())
+			Eventually(statefulSet).Should(ssFixture.HaveReplicas(1))
+			Eventually(statefulSet, "3m", "3s").Should(ssFixture.HaveReadyReplicas(1))
+
+			By("creating Application with initial basic image")
+			app := &appv1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "app-01",
+					Namespace: ns.Name,
+				},
+				Spec: appv1alpha1.ApplicationSpec{
+					Project: "default",
+					Source: &appv1alpha1.ApplicationSource{
+						RepoURL:        fmt.Sprintf("https://%s.%s.svc.cluster.local:8081/testdata.git", iuFixture.Name, ns.Name),
+						Path:           "1-010-verify-image-test",
+						TargetRevision: "HEAD",
+					},
+					Destination: appv1alpha1.ApplicationDestination{
+						Server:    "https://kubernetes.default.svc",
+						Namespace: ns.Name,
+					},
+					SyncPolicy: &appv1alpha1.SyncPolicy{
+						Automated: &appv1alpha1.SyncPolicyAutomated{
+							Prune: ptr.To(true),
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+
+			By("verifying the Application synced and is healthy with the basic image")
+			Eventually(app, "4m", "3s").Should(applicationFixture.HaveHealthStatusCode(health.HealthStatusHealthy))
+			Eventually(app, "4m", "3s").Should(applicationFixture.HaveSyncStatusCode(appv1alpha1.SyncStatusCodeSynced))
+
+			// ---------------------------------------------------------------------------
+			// Phase 1: unsigned image — signature verification must block the update
+			// ---------------------------------------------------------------------------
+
+			By("creating ImageUpdater CR targeting 1.0.1 (unsigned — verification must fail → no update)")
+			// Semver constraint "1.0.1" matches exactly tag 1.0.1 (unsigned).
+			// The sha256-<hex> cosign signature tag is not valid semver and is silently ignored.
+			// Verification fails because 1.0.1 has no cosign signature → image stays at 1.0.0.
+			updateStrategy := "semver"
+			forceUpdate := false
+			verificationEnabled := true
+			method := fmt.Sprintf("git:secret:%s/%s", ns.Name, iuFixture.Name)
+			branch := "master"
+			repository := fmt.Sprintf("https://%s.%s.svc.cluster.local:8081/testdata.git", iuFixture.Name, ns.Name)
+
+			imageUpdater = &imageUpdaterApi.ImageUpdater{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "image-updater",
+					Namespace: ns.Name,
+				},
+				Spec: imageUpdaterApi.ImageUpdaterSpec{
+					ImagesVerification: &imageUpdaterApi.ImagesVerification{
+						Enabled: &verificationEnabled,
+						CosignKey: &imageUpdaterApi.SecretRef{
+							SecretName: "cosign-pubkey",
+							Key:        "cosign.pub",
+						},
+					},
+					CommonUpdateSettings: &imageUpdaterApi.CommonUpdateSettings{
+						UpdateStrategy: &updateStrategy,
+						ForceUpdate:    &forceUpdate,
+					},
+					WriteBackConfig: &imageUpdaterApi.WriteBackConfig{
+						Method: &method,
+						GitConfig: &imageUpdaterApi.GitConfig{
+							Branch:     &branch,
+							Repository: &repository,
+						},
+					},
+					ApplicationRefs: []imageUpdaterApi.ApplicationRef{
+						{
+							NamePattern: "app*",
+							Images: []imageUpdaterApi.ImageConfig{
+								{
+									Alias:     "test",
+									ImageName: "127.0.0.1:30000/test-image:1.0.1",
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, imageUpdater)).To(Succeed())
+
+			By("waiting for ImageUpdater controller to process the CR at least once")
+			Eventually(func() int32 {
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(imageUpdater), imageUpdater); err != nil {
+					return 0
+				}
+				return imageUpdater.Status.ApplicationsMatched
+			}, "2m", "3s").Should(BeNumerically(">", 0))
+
+			By("ensuring image stays at '1.0.0' — unsigned 1.0.1 must not pass verification")
+			triggerRefresh := iuFixture.TriggerArgoCDRefresh(ctx, k8sClient, app)
+			Consistently(func() string {
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(app), app); err != nil {
+					return ""
+				}
+				triggerRefresh()
+				if len(app.Status.Summary.Images) > 0 {
+					return app.Status.Summary.Images[0]
+				}
+				return ""
+			}, "30s", "5s").Should(Equal("127.0.0.1:30000/test-image:1.0.0"))
+
+			By("deleting phase-1 ImageUpdater CR")
+			Expect(k8sClient.Delete(ctx, imageUpdater)).To(Succeed())
+			Eventually(imageUpdater, "2m", "3s").Should(k8sFixture.NotExistByName())
+			imageUpdater = nil
+
+			// ---------------------------------------------------------------------------
+			// Phase 2: signed image — signature verification must allow the update
+			// ---------------------------------------------------------------------------
+
+			By("creating ImageUpdater CR targeting ~1.0 range (1.0.2 is signed — verification must succeed)")
+			// Semver constraint "~1.0" allows patch updates: >=1.0.0, <1.1.0.
+			// Available semver tags: 1.0.0, 1.0.1, 1.0.2  (sha256-<hex> is not valid semver, ignored).
+			// Semver picks 1.0.2 as the highest. 1.0.2 is signed → verification passes → update to 1.0.2.
+
+			imageUpdater = &imageUpdaterApi.ImageUpdater{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "image-updater",
+					Namespace: ns.Name,
+				},
+				Spec: imageUpdaterApi.ImageUpdaterSpec{
+					ImagesVerification: &imageUpdaterApi.ImagesVerification{
+						Enabled: &verificationEnabled,
+						CosignKey: &imageUpdaterApi.SecretRef{
+							SecretName: "cosign-pubkey",
+							Key:        "cosign.pub",
+						},
+					},
+					CommonUpdateSettings: &imageUpdaterApi.CommonUpdateSettings{
+						UpdateStrategy: &updateStrategy,
+						ForceUpdate:    &forceUpdate,
+					},
+					WriteBackConfig: &imageUpdaterApi.WriteBackConfig{
+						Method: &method,
+						GitConfig: &imageUpdaterApi.GitConfig{
+							Branch:     &branch,
+							Repository: &repository,
+						},
+					},
+					ApplicationRefs: []imageUpdaterApi.ApplicationRef{
+						{
+							NamePattern: "app*",
+							Images: []imageUpdaterApi.ImageConfig{
+								{
+									Alias:     "test",
+									ImageName: "127.0.0.1:30000/test-image:~1.0",
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, imageUpdater)).To(Succeed())
+
+			By("waiting for ImageUpdater controller to process Phase-2 CR at least once")
+			Eventually(func() int32 {
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(imageUpdater), imageUpdater); err != nil {
+					return 0
+				}
+				return imageUpdater.Status.ApplicationsMatched
+			}, "2m", "3s").Should(BeNumerically(">", 0))
+
+			By("ensuring that the Application image is updated to '1.0.2' after verification succeeds")
+			triggerRefresh2 := iuFixture.TriggerArgoCDRefresh(ctx, k8sClient, app)
+			Eventually(func() string {
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(app), app); err != nil {
+					return ""
+				}
+				triggerRefresh2()
+				if len(app.Status.Summary.Images) > 0 {
+					return app.Status.Summary.Images[0]
+				}
+				return ""
+			}, "5m", "3s").Should(Equal("127.0.0.1:30000/test-image:1.0.2"))
+		})
+	})
+})

--- a/test/ginkgo/prereqs/assets/registry.yaml
+++ b/test/ginkgo/prereqs/assets/registry.yaml
@@ -43,7 +43,7 @@ spec:
         - registry
         - serve
         - /tmp/config/registry.conf
-        image: registry
+        image: registry:3
         ports:
           - containerPort: 5000
         volumeMounts:
@@ -123,7 +123,7 @@ spec:
         - registry
         - serve
         - /tmp/config/registry.conf
-        image: registry
+        image: registry:3
         ports:
           - containerPort: 5000
         volumeMounts:

--- a/test/ginkgo/prereqs/containers/git/testdata/1-010-verify-image-test/deployment.yaml
+++ b/test/ginkgo/prereqs/containers/git/testdata/1-010-verify-image-test/deployment.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: 1-010-verify-image-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: 1-010-verify-image-test
+  template:
+    metadata:
+      labels:
+        app: 1-010-verify-image-test
+    spec:
+      containers:
+      - name: test
+        image: 127.0.0.1:30000/test-image:1.0.0

--- a/test/ginkgo/prereqs/containers/git/testdata/1-010-verify-image-test/kustomization.yaml
+++ b/test/ginkgo/prereqs/containers/git/testdata/1-010-verify-image-test/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - deployment.yaml

--- a/test/ginkgo/prereqs/containers/signature-test/Dockerfile
+++ b/test/ginkgo/prereqs/containers/signature-test/Dockerfile
@@ -1,0 +1,4 @@
+FROM busybox
+ARG IMAGETAG=unset
+RUN echo "$IMAGETAG" > /tmp/tag
+CMD ["sleep", "infinity"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end support for verifying signed images during local test runs.
  * Expanded image verification to work with both modern registry signature lookup and legacy signature formats.

* **Bug Fixes**
  * Improved verification fallback when registry referrers are unavailable.
  * Tightened digest checks so unsigned or mismatched signatures fail closed.

* **Tests**
  * Added broader coverage for signature verification, fallback behavior, and signed image update flows.

* **Documentation**
  * Updated local E2E setup instructions and clarified supported verification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->