### PR TITLE
chore(e2e): install cosign to gh actions

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -258,6 +258,8 @@ jobs:
         run: |
           curl -fsSL https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
           sudo mkdir -p "$HOME/.kube" && sudo chown -R runner "$HOME/.kube"
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
       - name: Deploy operator and run e2e tests
         env:
           ARGOCD_CLUSTER_CONFIG_NAMESPACES: argocd-e2e-cluster-config, argocd-operator-system


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the automated end-to-end test setup to include a required signing tool before test execution, helping validation run more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->