### PR TITLE
feat(pr): Avoid creating duplicate PRs for apps sharing the same write-back-target and updates

### DIFF
--- a/docs/basics/update-methods.md
+++ b/docs/basics/update-methods.md
@@ -478,7 +478,8 @@ The head branch (PR source) is derived automatically by the controller using
 the template `image-updater-<targetKey>-<sha256>`, where `<targetKey>` is
 an 8-character hash of the write-back target (git repo, branch, and target
 path). This ensures that multiple applications sharing the same write-back
-target produce the same PR branch, avoiding duplicate pull requests.
+target and the same update set produce the same PR branch, avoiding duplicate
+pull requests.
 
 !!!warning "Breaking change in pull request branch naming (v1.3.0)"
     Prior to v1.3.0 the default PR head branch was

--- a/docs/basics/update-methods.md
+++ b/docs/basics/update-methods.md
@@ -481,8 +481,8 @@ path). This ensures that multiple applications sharing the same write-back
 target and the same update set produce the same PR branch, avoiding duplicate
 pull requests.
 
-!!!warning "Breaking change in pull request branch naming (v1.3.0)"
-    Prior to v1.3.0 the default PR head branch was
+!!!warning "Breaking change in pull request branch naming"
+    The default PR head branch was previously
     `image-updater-<appNamespace>-<appName>-<sha256>`. It is now
     `image-updater-<targetKey>-<sha256>`. After upgrading, the first
     reconciliation will create a new branch with the new naming scheme.

--- a/docs/basics/update-methods.md
+++ b/docs/basics/update-methods.md
@@ -303,7 +303,10 @@ The following variables are provided for this template:
   * `.Alias` holds the alias of the image that was updated
   * `.OldTag` holds the tag name or SHA digest previous to the update
   * `.NewTag` holds the tag name or SHA digest that was updated to
-* `.SHA256` is a unique SHA256 has representing these changes
+* `.SHA256` is a unique SHA256 hash representing these changes
+* `.TargetKey` is a short hash (8 hex characters) identifying the write-back target (derived from git repo, branch, and target path)
+* `.AppNamespace` is the namespace of the application being updated
+* `.AppName` is the name of the application being updated
 
 Please note that if the output of the template exceeds 255 characters (git branch name limit) it will be truncated.
 
@@ -442,7 +445,7 @@ The Git Pull Request mode extends the `git` write-back method so that instead
 of pushing directly to the tracking branch, Argo CD Image Updater:
 
 1. Pushes the image update commit to an automatically generated **head branch**
-   (`image-updater-<namespace>-<appName>-<sha256>`).
+   (`image-updater-<targetKey>-<sha256>`).
 2. Opens a **pull request** or **merge request** from that head
    branch into the configured base branch.
 
@@ -472,8 +475,19 @@ before it is merged and applied by Argo CD.
     from being reconciled.
 
 The head branch (PR source) is derived automatically by the controller using
-the template `image-updater-<appNamespace>-<appName>-<sha256>`, ensuring a
-stable, unique branch name per application and set of image changes.
+the template `image-updater-<targetKey>-<sha256>`, where `<targetKey>` is
+an 8-character hash of the write-back target (git repo, branch, and target
+path). This ensures that multiple applications sharing the same write-back
+target produce the same PR branch, avoiding duplicate pull requests.
+
+!!!warning "Breaking change in pull request branch naming (v1.3.0)"
+    Prior to v1.3.0 the default PR head branch was
+    `image-updater-<appNamespace>-<appName>-<sha256>`. It is now
+    `image-updater-<targetKey>-<sha256>`. After upgrading, the first
+    reconciliation will create a new branch with the new naming scheme.
+    Any open PRs that used the old branch name will **not** be closed
+    automatically — you must close them and delete their head branches
+    manually.
 
 #### Credentials
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -187,9 +187,11 @@ spec:
 ```
 
 The controller automatically pushes the update to a branch named
-`image-updater-<namespace>-<appName>-<sha256>` and opens a pull request from
-that branch into `main`. If an open PR for the same pair already exists it is
-left untouched.
+`image-updater-<targetKey>-<sha256>` (where `<targetKey>` is a short hash
+of the write-back target) and opens a pull request from that branch into
+`main`. If an open PR for the same pair already exists it is left untouched.
+Multiple applications sharing the same write-back target will reuse the same
+PR branch, avoiding duplicate pull requests.
 
 ## Using `semver` update strategy with version constraints
 

--- a/pkg/argocd/git.go
+++ b/pkg/argocd/git.go
@@ -74,7 +74,7 @@ func TemplateCommitMessage(ctx context.Context, tpl *template.Template, appName 
 // TemplateBranchName parses a string to a template, and returns a
 // branch name from that new template. If a branch name can not be
 // rendered, it returns an empty value.
-func TemplateBranchName(ctx context.Context, branchName, appNamespace, appName string, changeList []ChangeEntry) string {
+func TemplateBranchName(ctx context.Context, branchName, appNamespace, appName, targetKey string, changeList []ChangeEntry) string {
 	log := log.LoggerFromContext(ctx)
 	var cmBuf bytes.Buffer
 
@@ -95,6 +95,7 @@ func TemplateBranchName(ctx context.Context, branchName, appNamespace, appName s
 	type branchNameTemplate struct {
 		AppNamespace string
 		AppName      string
+		TargetKey    string
 		Images       []imageChange
 		SHA256       string
 	}
@@ -119,6 +120,7 @@ func TemplateBranchName(ctx context.Context, branchName, appNamespace, appName s
 	tplData := branchNameTemplate{
 		AppNamespace: appNamespace,
 		AppName:      appName,
+		TargetKey:    targetKey,
 		Images:       changes,
 		SHA256:       hex.EncodeToString(hasher.Sum(nil)),
 	}
@@ -230,10 +232,9 @@ func commitChangesGit(ctx context.Context, applicationImages *ApplicationImages,
 
 	// Set custom pushBranch name for PR/MR mode
 	if wbc.PRProvider > 0 {
-		// The default template produces a stable branch name per app and new image tag.
-		customTemplate := "image-updater-{{.AppNamespace}}-{{.AppName}}-{{.SHA256}}"
+		customTemplate := "image-updater-{{.TargetKey}}-{{.SHA256}}"
 		logCtx.Tracef("setting git push branch for PR/MR mode using custom template '%s'", customTemplate)
-		pushBranch = TemplateBranchName(ctx, customTemplate, app.Namespace, app.Name, changeList)
+		pushBranch = TemplateBranchName(ctx, customTemplate, app.Namespace, app.Name, wbc.WriteBackTargetKey(), changeList)
 		if pushBranch == "" {
 			return fmt.Errorf("git branch name could not be created from the template: %s", customTemplate)
 		}
@@ -244,7 +245,7 @@ func commitChangesGit(ctx context.Context, applicationImages *ApplicationImages,
 	} else if wbc.GitWriteBranch != "" {
 		// use GitWriteBranch for git mode without PR
 		logCtx.Debugf("Using branch template: %s", wbc.GitWriteBranch)
-		pushBranch = TemplateBranchName(ctx, wbc.GitWriteBranch, "", "", changeList)
+		pushBranch = TemplateBranchName(ctx, wbc.GitWriteBranch, "", "", "", changeList)
 		if pushBranch == "" {
 			return fmt.Errorf("git branch name could not be created from the template: %s", wbc.GitWriteBranch)
 		}

--- a/pkg/argocd/git_test.go
+++ b/pkg/argocd/git_test.go
@@ -118,7 +118,7 @@ func Test_TemplateBranchName(t *testing.T) {
 				NewTag: tag.NewImageTag("2.1", time.Now(), ""),
 			},
 		}
-		r := TemplateBranchName(context.Background(), tpl, "", "", cl)
+		r := TemplateBranchName(context.Background(), tpl, "", "", "", cl)
 		assert.NotEmpty(t, r)
 		assert.Equal(t, exp, r)
 	})
@@ -132,7 +132,7 @@ func Test_TemplateBranchName(t *testing.T) {
 				NewTag: tag.NewImageTag("1.1", time.Now(), ""),
 			},
 		}
-		r := TemplateBranchName(context.Background(), tpl, "", "", cl)
+		r := TemplateBranchName(context.Background(), tpl, "", "", "", cl)
 		assert.NotEmpty(t, r)
 		assert.Equal(t, exp, r)
 	})
@@ -147,7 +147,7 @@ func Test_TemplateBranchName(t *testing.T) {
 				NewTag: tag.NewImageTag("1.1", time.Now(), ""),
 			},
 		}
-		r := TemplateBranchName(context.Background(), tpl, "", "", cl)
+		r := TemplateBranchName(context.Background(), tpl, "", "", "", cl)
 		assert.NotEmpty(t, r)
 		assert.Equal(t, exp, r)
 	})
@@ -159,7 +159,7 @@ func Test_TemplateBranchName(t *testing.T) {
 			"in-blandit-vel-pharetra-vel-urna-aliquam-euismod-elit-vel-mi"
 		exp := tpl[:255]
 		cl := []ChangeEntry{}
-		r := TemplateBranchName(context.Background(), tpl, "", "", cl)
+		r := TemplateBranchName(context.Background(), tpl, "", "", "", cl)
 		assert.NotEmpty(t, r)
 		assert.Equal(t, exp, r)
 		assert.Len(t, r, 255)
@@ -173,7 +173,7 @@ func Test_TemplateBranchName(t *testing.T) {
 				NewTag: tag.NewImageTag("1.1", time.Now(), ""),
 			},
 		}
-		r := TemplateBranchName(context.Background(), tpl, "my-namespace", "my-app", cl)
+		r := TemplateBranchName(context.Background(), tpl, "my-namespace", "my-app", "", cl)
 		assert.Equal(t, "image-updater-my-namespace-my-app", r)
 	})
 	t.Run("AppNamespace and AppName are stable regardless of image changes", func(t *testing.T) {
@@ -192,14 +192,14 @@ func Test_TemplateBranchName(t *testing.T) {
 				NewTag: tag.NewImageTag("1.2", time.Now(), ""),
 			},
 		}
-		r1 := TemplateBranchName(context.Background(), tpl, "my-namespace", "my-app", clV1)
-		r2 := TemplateBranchName(context.Background(), tpl, "my-namespace", "my-app", clV2)
+		r1 := TemplateBranchName(context.Background(), tpl, "my-namespace", "my-app", "", clV1)
+		r2 := TemplateBranchName(context.Background(), tpl, "my-namespace", "my-app", "", clV2)
 		assert.Equal(t, "image-updater-my-namespace-my-app", r1)
 		assert.Equal(t, r1, r2, "branch name should be stable across different image updates")
 	})
 	t.Run("AppNamespace and AppName empty when not provided", func(t *testing.T) {
 		tpl := "image-updater-{{.AppNamespace}}-{{.AppName}}"
-		r := TemplateBranchName(context.Background(), tpl, "", "", []ChangeEntry{})
+		r := TemplateBranchName(context.Background(), tpl, "", "", "", []ChangeEntry{})
 		assert.Equal(t, "image-updater--", r)
 	})
 	t.Run("AppName usable alongside image variables", func(t *testing.T) {
@@ -211,8 +211,34 @@ func Test_TemplateBranchName(t *testing.T) {
 				NewTag: tag.NewImageTag("1.5", time.Now(), ""),
 			},
 		}
-		r := TemplateBranchName(context.Background(), tpl, "prod", "my-app", cl)
+		r := TemplateBranchName(context.Background(), tpl, "prod", "my-app", "", cl)
 		assert.Equal(t, "my-app-nginx-1.5", r)
+	})
+	t.Run("TargetKey in template for PR dedup", func(t *testing.T) {
+		tpl := "image-updater-{{.TargetKey}}-{{.SHA256}}"
+		cl := []ChangeEntry{
+			{
+				Image:  image.NewFromIdentifier("nginx"),
+				OldTag: tag.NewImageTag("1.0", time.Now(), ""),
+				NewTag: tag.NewImageTag("1.1", time.Now(), ""),
+			},
+		}
+		r := TemplateBranchName(context.Background(), tpl, "ns", "app-a", "abc12345", cl)
+		assert.Contains(t, r, "abc12345", "branch should contain the target key hash")
+		assert.NotContains(t, r, "app-a", "branch should not contain app name")
+	})
+	t.Run("Same target key and changes produce same branch for different apps", func(t *testing.T) {
+		tpl := "image-updater-{{.TargetKey}}-{{.SHA256}}"
+		cl := []ChangeEntry{
+			{
+				Image:  image.NewFromIdentifier("nginx"),
+				OldTag: tag.NewImageTag("1.0", time.Now(), ""),
+				NewTag: tag.NewImageTag("1.1", time.Now(), ""),
+			},
+		}
+		r1 := TemplateBranchName(context.Background(), tpl, "ns", "app-a", "abc12345", cl)
+		r2 := TemplateBranchName(context.Background(), tpl, "ns", "app-b", "abc12345", cl)
+		assert.Equal(t, r1, r2, "different apps with same target key and changes should produce the same branch")
 	})
 }
 

--- a/pkg/argocd/types.go
+++ b/pkg/argocd/types.go
@@ -1,6 +1,8 @@
 package argocd
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"sync"
 	"text/template"
 
@@ -92,6 +94,18 @@ type WriteBackConfig struct {
 	PullRequest            *PullRequest
 }
 
+// WriteBackTargetKey returns a short hash that uniquely identifies the
+// write-back target for PR deduplication. Two applications sharing the same
+// git repo, base branch, and target path produce the same key.
+func (wbc *WriteBackConfig) WriteBackTargetKey() string {
+	target := wbc.Target
+	if target == "" {
+		target = wbc.KustomizeBase
+	}
+	h := sha256.Sum256([]byte(wbc.GitRepo + "|" + wbc.GitBranch + "|" + target))
+	return hex.EncodeToString(h[:])[:8]
+}
+
 // RequiresLocking returns true if write-back method requires repository locking
 func (wbc *WriteBackConfig) RequiresLocking() bool {
 	switch wbc.Method {
@@ -130,13 +144,28 @@ type ChangeEntry struct {
 type SyncIterationState struct {
 	lock            sync.Mutex
 	repositoryLocks map[string]*sync.Mutex
+	prCreated       map[string]bool
 }
 
 // NewSyncIterationState returns a new instance of SyncIterationState
 func NewSyncIterationState() *SyncIterationState {
 	return &SyncIterationState{
 		repositoryLocks: make(map[string]*sync.Mutex),
+		prCreated:       make(map[string]bool),
 	}
+}
+
+// MarkPRCreated records that a PR has been created for the given write-back
+// target key. Returns true on the first call for a key (caller should proceed
+// with PR creation) and false on subsequent calls (caller should skip).
+func (state *SyncIterationState) MarkPRCreated(targetKey string) bool {
+	state.lock.Lock()
+	defer state.lock.Unlock()
+	if state.prCreated[targetKey] {
+		return false
+	}
+	state.prCreated[targetKey] = true
+	return true
 }
 
 // GetRepositoryLock returns the lock for a specified repository

--- a/pkg/argocd/types_test.go
+++ b/pkg/argocd/types_test.go
@@ -1,0 +1,82 @@
+package argocd
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_WriteBackTargetKey(t *testing.T) {
+	t.Run("Same repo, branch, and target produce the same key", func(t *testing.T) {
+		wbc1 := &WriteBackConfig{GitRepo: "https://github.com/org/repo.git", GitBranch: "main", Target: "overlays/dev/values.yaml"}
+		wbc2 := &WriteBackConfig{GitRepo: "https://github.com/org/repo.git", GitBranch: "main", Target: "overlays/dev/values.yaml"}
+		assert.Equal(t, wbc1.WriteBackTargetKey(), wbc2.WriteBackTargetKey())
+	})
+
+	t.Run("Different repo produces a different key", func(t *testing.T) {
+		wbc1 := &WriteBackConfig{GitRepo: "https://github.com/org/repo-a.git", GitBranch: "main", Target: "values.yaml"}
+		wbc2 := &WriteBackConfig{GitRepo: "https://github.com/org/repo-b.git", GitBranch: "main", Target: "values.yaml"}
+		assert.NotEqual(t, wbc1.WriteBackTargetKey(), wbc2.WriteBackTargetKey())
+	})
+
+	t.Run("Different branch produces a different key", func(t *testing.T) {
+		wbc1 := &WriteBackConfig{GitRepo: "https://github.com/org/repo.git", GitBranch: "main", Target: "values.yaml"}
+		wbc2 := &WriteBackConfig{GitRepo: "https://github.com/org/repo.git", GitBranch: "staging", Target: "values.yaml"}
+		assert.NotEqual(t, wbc1.WriteBackTargetKey(), wbc2.WriteBackTargetKey())
+	})
+
+	t.Run("Different target produces a different key", func(t *testing.T) {
+		wbc1 := &WriteBackConfig{GitRepo: "https://github.com/org/repo.git", GitBranch: "main", Target: "overlays/dev/values.yaml"}
+		wbc2 := &WriteBackConfig{GitRepo: "https://github.com/org/repo.git", GitBranch: "main", Target: "overlays/prod/values.yaml"}
+		assert.NotEqual(t, wbc1.WriteBackTargetKey(), wbc2.WriteBackTargetKey())
+	})
+
+	t.Run("KustomizeBase used when Target is empty", func(t *testing.T) {
+		wbc1 := &WriteBackConfig{GitRepo: "https://github.com/org/repo.git", GitBranch: "main", KustomizeBase: "overlays/dev"}
+		wbc2 := &WriteBackConfig{GitRepo: "https://github.com/org/repo.git", GitBranch: "main", KustomizeBase: "overlays/dev"}
+		assert.Equal(t, wbc1.WriteBackTargetKey(), wbc2.WriteBackTargetKey())
+	})
+
+	t.Run("Key is 8 hex characters", func(t *testing.T) {
+		wbc := &WriteBackConfig{GitRepo: "https://github.com/org/repo.git", GitBranch: "main", Target: "values.yaml"}
+		key := wbc.WriteBackTargetKey()
+		assert.Len(t, key, 8)
+	})
+}
+
+func Test_MarkPRCreated(t *testing.T) {
+	t.Run("First call returns true, second returns false", func(t *testing.T) {
+		state := NewSyncIterationState()
+		assert.True(t, state.MarkPRCreated("target-a"))
+		assert.False(t, state.MarkPRCreated("target-a"))
+	})
+
+	t.Run("Different keys both return true", func(t *testing.T) {
+		state := NewSyncIterationState()
+		assert.True(t, state.MarkPRCreated("target-a"))
+		assert.True(t, state.MarkPRCreated("target-b"))
+	})
+
+	t.Run("Thread safety", func(t *testing.T) {
+		state := NewSyncIterationState()
+		var wg sync.WaitGroup
+		results := make([]bool, 10)
+		for i := 0; i < 10; i++ {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				results[idx] = state.MarkPRCreated("same-key")
+			}(i)
+		}
+		wg.Wait()
+
+		trueCount := 0
+		for _, r := range results {
+			if r {
+				trueCount++
+			}
+		}
+		assert.Equal(t, 1, trueCount, "exactly one goroutine should get true")
+	})
+}

--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -899,11 +899,20 @@ func parseGitConfig(ctx context.Context, app *v1alpha1.Application, kubeClient *
 }
 
 func commitChangesLocked(ctx context.Context, applicationImages *ApplicationImages, state *SyncIterationState, changeList []ChangeEntry) error {
+	logCtx := log.LoggerFromContext(ctx)
 	wbc := applicationImages.WriteBackConfig
 	if wbc.RequiresLocking() {
 		lock := state.GetRepositoryLock(wbc.GitRepo)
 		lock.Lock()
 		defer lock.Unlock()
+	}
+
+	if wbc.PRProvider > 0 {
+		targetKey := wbc.WriteBackTargetKey()
+		if !state.MarkPRCreated(targetKey) {
+			logCtx.Infof("Skipping PR creation: another application already created a PR for the same write-back target in this cycle")
+			return nil
+		}
 	}
 
 	return commitChanges(ctx, applicationImages, changeList)

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -6500,60 +6500,6 @@ replacements: []
 	})
 }
 
-func Test_CommitChangesLockedPRDedup(t *testing.T) {
-	t.Run("First app proceeds, second app with same target is skipped", func(t *testing.T) {
-		state := NewSyncIterationState()
-		wbc := &WriteBackConfig{
-			Method:     WriteBackGit,
-			GitRepo:    "https://github.com/org/repo.git",
-			GitBranch:  "main",
-			Target:     "overlays/dev/values.yaml",
-			PRProvider: PRProviderGitHub,
-		}
-
-		// First app should proceed (MarkPRCreated returns true)
-		targetKey := wbc.WriteBackTargetKey()
-		assert.True(t, state.MarkPRCreated(targetKey))
-
-		// Second app with same target should be skipped
-		assert.False(t, state.MarkPRCreated(targetKey))
-	})
-
-	t.Run("Apps with different targets both proceed", func(t *testing.T) {
-		state := NewSyncIterationState()
-		wbc1 := &WriteBackConfig{
-			Method:     WriteBackGit,
-			GitRepo:    "https://github.com/org/repo.git",
-			GitBranch:  "main",
-			Target:     "overlays/dev/values.yaml",
-			PRProvider: PRProviderGitHub,
-		}
-		wbc2 := &WriteBackConfig{
-			Method:     WriteBackGit,
-			GitRepo:    "https://github.com/org/repo.git",
-			GitBranch:  "main",
-			Target:     "overlays/prod/values.yaml",
-			PRProvider: PRProviderGitHub,
-		}
-
-		assert.True(t, state.MarkPRCreated(wbc1.WriteBackTargetKey()))
-		assert.True(t, state.MarkPRCreated(wbc2.WriteBackTargetKey()))
-	})
-
-	t.Run("Non-PR mode skips dedup", func(t *testing.T) {
-		wbc := &WriteBackConfig{
-			Method:     WriteBackGit,
-			GitRepo:    "https://github.com/org/repo.git",
-			GitBranch:  "main",
-			Target:     "overlays/dev/values.yaml",
-			PRProvider: PRProviderUnsupported,
-		}
-		// PRProvider == 0 means the dedup guard in commitChangesLocked is not entered
-		assert.Equal(t, PRProviderUnsupported, wbc.PRProvider)
-		assert.False(t, wbc.PRProvider > 0)
-	})
-}
-
 func Test_parseKustomizeBase(t *testing.T) {
 	cases := []struct {
 		name     string

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -5970,7 +5970,7 @@ func Test_CommitUpdates(t *testing.T) {
 				NewTag: tag.NewImageTag("1.1", time.Now(), ""),
 			},
 		}
-		gitMock.On("Checkout", TemplateBranchName(ctx, wbc.GitWriteBranch, "", "", cl), mock.Anything).Return(nil)
+		gitMock.On("Checkout", TemplateBranchName(ctx, wbc.GitWriteBranch, "", "", "", cl), mock.Anything).Return(nil)
 
 		applicationImages := &ApplicationImages{
 			Application:     app,
@@ -6497,6 +6497,60 @@ replacements: []
 		}
 		err = commitChanges(ctx, applicationImages, nil)
 		assert.Errorf(t, err, "failed to resolve ref")
+	})
+}
+
+func Test_CommitChangesLockedPRDedup(t *testing.T) {
+	t.Run("First app proceeds, second app with same target is skipped", func(t *testing.T) {
+		state := NewSyncIterationState()
+		wbc := &WriteBackConfig{
+			Method:     WriteBackGit,
+			GitRepo:    "https://github.com/org/repo.git",
+			GitBranch:  "main",
+			Target:     "overlays/dev/values.yaml",
+			PRProvider: PRProviderGitHub,
+		}
+
+		// First app should proceed (MarkPRCreated returns true)
+		targetKey := wbc.WriteBackTargetKey()
+		assert.True(t, state.MarkPRCreated(targetKey))
+
+		// Second app with same target should be skipped
+		assert.False(t, state.MarkPRCreated(targetKey))
+	})
+
+	t.Run("Apps with different targets both proceed", func(t *testing.T) {
+		state := NewSyncIterationState()
+		wbc1 := &WriteBackConfig{
+			Method:     WriteBackGit,
+			GitRepo:    "https://github.com/org/repo.git",
+			GitBranch:  "main",
+			Target:     "overlays/dev/values.yaml",
+			PRProvider: PRProviderGitHub,
+		}
+		wbc2 := &WriteBackConfig{
+			Method:     WriteBackGit,
+			GitRepo:    "https://github.com/org/repo.git",
+			GitBranch:  "main",
+			Target:     "overlays/prod/values.yaml",
+			PRProvider: PRProviderGitHub,
+		}
+
+		assert.True(t, state.MarkPRCreated(wbc1.WriteBackTargetKey()))
+		assert.True(t, state.MarkPRCreated(wbc2.WriteBackTargetKey()))
+	})
+
+	t.Run("Non-PR mode skips dedup", func(t *testing.T) {
+		wbc := &WriteBackConfig{
+			Method:     WriteBackGit,
+			GitRepo:    "https://github.com/org/repo.git",
+			GitBranch:  "main",
+			Target:     "overlays/dev/values.yaml",
+			PRProvider: PRProviderUnsupported,
+		}
+		// PRProvider == 0 means the dedup guard in commitChangesLocked is not entered
+		assert.Equal(t, PRProviderUnsupported, wbc.PRProvider)
+		assert.False(t, wbc.PRProvider > 0)
 	})
 }
 

--- a/test/ginkgo/parallel/1-009-github-pull-request_test.go
+++ b/test/ginkgo/parallel/1-009-github-pull-request_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -326,7 +327,7 @@ var _ = Describe("ArgoCD Image Updater Parallel E2E Tests", func() {
 			// ---------------------------------------------------------------
 			By("waiting for the GitHub PR to be created")
 			expectedTitle := "build: automatic update of app-01"
-			expectedHeadPrefix := "image-updater-"
+			expectedHeadPattern := regexp.MustCompile(`^image-updater-[a-f0-9]{8}-[a-f0-9]{64}$`)
 			expectedBody := "updates image dkarpele/my-guestbook tag '1.0.0' to '29437546.0'"
 
 			triggerRefresh := iuFixture.TriggerArgoCDRefresh(ctx, k8sClient, app)
@@ -349,7 +350,7 @@ var _ = Describe("ArgoCD Image Updater Parallel E2E Tests", func() {
 
 				for _, pr := range prs {
 					if pr.GetTitle() == expectedTitle &&
-						strings.HasPrefix(pr.GetHead().GetRef(), expectedHeadPrefix) {
+						expectedHeadPattern.MatchString(pr.GetHead().GetRef()) {
 						foundPR = pr
 						prNumber = pr.GetNumber()
 						prHeadBranch = pr.GetHead().GetRef()

--- a/test/ginkgo/parallel/1-009-github-pull-request_test.go
+++ b/test/ginkgo/parallel/1-009-github-pull-request_test.go
@@ -326,7 +326,7 @@ var _ = Describe("ArgoCD Image Updater Parallel E2E Tests", func() {
 			// ---------------------------------------------------------------
 			By("waiting for the GitHub PR to be created")
 			expectedTitle := "build: automatic update of app-01"
-			expectedHeadPrefix := fmt.Sprintf("image-updater-%s-app-01-", ns.Name)
+			expectedHeadPrefix := "image-updater-"
 			expectedBody := "updates image dkarpele/my-guestbook tag '1.0.0' to '29437546.0'"
 
 			triggerRefresh := iuFixture.TriggerArgoCDRefresh(ctx, k8sClient, app)
@@ -374,8 +374,8 @@ var _ = Describe("ArgoCD Image Updater Parallel E2E Tests", func() {
 				"PR should target the configured base branch")
 
 			By("verifying PR head branch naming convention")
-			Expect(strings.HasPrefix(foundPR.GetHead().GetRef(), expectedHeadPrefix)).To(BeTrue(),
-				"head branch %q should start with %q", foundPR.GetHead().GetRef(), expectedHeadPrefix)
+			Expect(foundPR.GetHead().GetRef()).To(MatchRegexp(`^image-updater-[a-f0-9]{8}-[a-f0-9]{64}$`),
+				"head branch %q should follow the image-updater-<targetKey>-<sha256> pattern", foundPR.GetHead().GetRef())
 
 			By("verifying PR head branch belongs to the configured repository owner")
 			Expect(foundPR.GetHead().GetRepo().GetFullName()).To(Equal(ghOwner + "/" + ghRepo))


### PR DESCRIPTION
Fixes #1686 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PR/MR Git write-back head branches now use a stable, target-specific `targetKey` (`image-updater-<targetKey>-<sha256>`) and provide `{{.TargetKey}}` for branch templates.
  * PR/MR creation is deduplicated within a sync cycle per write-back target to prevent duplicate PRs.
* **Bug Fixes**
  * Improved branch rendering so names are consistent across apps using the same write-back path.
* **Documentation**
  * Updated Git write-back docs and examples for the new PR branch naming; added a breaking-change note for already-open PRs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->