### PR TITLE
fix: reject cross-namespace secret references in git write-back

### DIFF
--- a/config/samples/argocd-image-updater_v1alpha1_imageupdater-pull-request.yaml
+++ b/config/samples/argocd-image-updater_v1alpha1_imageupdater-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: argocd
 spec:
   writeBackConfig:
-    method: "git:secret:argocd/git-creds"
+    method: "git:secret:git-creds"
     gitConfig:
       pullRequest:
         github: {}
@@ -19,7 +19,7 @@ spec:
         - alias: "nginx"
           imageName: "nginx:1.17.10"
       writeBackConfig:
-        method: "git:secret:argocd/git-creds"
+        method: "git:secret:git-creds"
         gitConfig:
           branch: "main"
           writeBackTarget: "helmvalues:/helm/config/test-values.yaml"

--- a/config/samples/argocd-image-updater_v1alpha1_imageupdater.yaml
+++ b/config/samples/argocd-image-updater_v1alpha1_imageupdater.yaml
@@ -15,7 +15,7 @@ spec:
     pullSecret: "secret:<namespace>/<secret_name>#<field>"
     platforms: [ "linux/arm64", "linux/amd64" ]
   writeBackConfig:
-    method: "git:secret:argocd-image-updater/git-creds"
+    method: "git:secret:git-creds"
     gitConfig: # Group git-related settings. Should be ignored when writeBackMethod: "argocd"
       repository: "git@github.com:example/example.git"
       branch: "main"
@@ -39,7 +39,7 @@ spec:
         pullSecret: "secret:<namespace>/<secret_name>#<field>"
         platforms: [ "linux/arm64", "linux/amd64" ]
       writeBackConfig:
-        method: "git:secret:argocd-image-updater/git-creds"
+        method: "git:secret:git-creds"
         gitConfig: # Group git-related settings. Should be ignored when writeBackMethod: "argocd"
           repository: "git@github.com:example/example.git"
           branch: "main"
@@ -90,7 +90,7 @@ spec:
         ignoreTags: [ "latest", "master" ]
         pullSecret: "secret:<namespace>/<secret_name>#<field>"
       writeBackConfig:
-        method: "git:secret:argocd-image-updater/git-creds"
+        method: "git:secret:git-creds"
         gitConfig: # Group git-related settings. Should be ignored when writeBackMethod: "argocd"
           repository: "git@github.com:example/example.git"
           branch: "main"

--- a/docs/basics/update-methods.md
+++ b/docs/basics/update-methods.md
@@ -128,15 +128,34 @@ the `writeBackConfig.method` field using `git:<credref>` format. Where `<credref
 take one of following values:
 
 * `repocreds` (default) - Git repository credentials configured in Argo CD settings
-* `secret:<namespace>/<secret>` - namespace and secret name.
+* `secret:<secret>` - secret name only; the secret must exist in the same namespace as the `ImageUpdater` CR.
+* `secret:<namespace>/<secret>` - fully-qualified secret reference; the namespace **must** match the namespace of the `ImageUpdater` CR.
 
 Example:
 
 ```yaml
 spec:
   writeBackConfig:
-    method: "git:secret:argocd-image-updater/git-creds"
+    method: "git:secret:git-creds"
 ```
+
+Or with an explicit namespace (must equal the CR's namespace):
+
+```yaml
+spec:
+  writeBackConfig:
+    method: "git:secret:argocd/git-creds"
+```
+
+!!!warning "Cross-namespace secret references are rejected"
+    The `namespace/secret` format is preserved for backwards compatibility.
+    However, the namespace in the reference
+    **must** equal the namespace of the `ImageUpdater` CR. Referencing a secret
+    from a different namespace (e.g. specifying `team-b/git-creds` while the CR
+    runs in `team-a`) is rejected with an error. This prevents tenants from
+    reading secrets they do not own.
+    If no namespace is specified (plain `secret:<secret>` form), the CR's own
+    namespace is used automatically.
 
 If the repository is accessed using HTTPS, the secret must contain either user credentials or GitHub app credentials.
 
@@ -497,7 +516,7 @@ access token (PAT)** or a **GitHub App**. SSH keys cannot be used because they
 do not provide the HTTP token needed to call the SCM API.
 
 Configure credentials via the `writeBackConfig.method` field using the
-`git:secret:<namespace>/<secret>` format (see
+`git:secret:<secret>` format (see
 [Specifying Git credentials](#method-git-credentials) for how to create the
 secret). The author identity of the commits and the PR is derived from those
 credentials.
@@ -526,7 +545,7 @@ repository URL.
 ```yaml
 spec:
   writeBackConfig:
-    method: "git:secret:argocd-image-updater/git-creds"
+    method: "git:secret:git-creds"
     gitConfig:
       repository: "https://github.com/example/example.git"
       branch: "main"        # base branch; colon format not supported here
@@ -544,7 +563,7 @@ metadata:
   namespace: argocd
 spec:
   writeBackConfig:
-    method: "git:secret:argocd/git-creds"
+    method: "git:secret:git-creds"
     gitConfig:
       repository: "https://github.com/example/example.git"
       branch: "main"
@@ -556,7 +575,7 @@ spec:
         - alias: "nginx"
           imageName: "nginx:1.17.10"
       writeBackConfig:
-        method: "git:secret:argocd/git-creds"
+        method: "git:secret:git-creds"
         gitConfig:
           branch: "main"
           writeBackTarget: "helmvalues:/helm/config/values.yaml"
@@ -569,7 +588,7 @@ add `pullRequest.gitlab` to your `gitConfig`:
 
 ```yaml
 writeBackConfig:
-  method: "git:secret:argocd/gitlab-creds"
+  method: "git:secret:gitlab-creds"
   gitConfig:
     repository: "https://gitlab.com/org/repo.git"
     branch: "main"

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -165,7 +165,7 @@ metadata:
 spec:
   writeBackConfig:
     # HTTPS PAT or GitHub App credentials are required; SSH is not supported for PR mode.
-    method: "git:secret:argocd/git-creds"
+    method: "git:secret:git-creds"
     gitConfig:
       repository: "https://github.com/myorg/myrepo.git"
       # Specify only the base branch. The colon "base:target" format is not
@@ -181,7 +181,7 @@ spec:
           commonUpdateSettings:
             updateStrategy: "semver"
       writeBackConfig:
-        method: "git:secret:argocd/git-creds"
+        method: "git:secret:git-creds"
         gitConfig:
           writeBackTarget: "helmvalues:/helm/values.yaml"
 ```

--- a/pkg/argocd/gitcreds.go
+++ b/pkg/argocd/gitcreds.go
@@ -27,7 +27,7 @@ func getGitCredsSource(ctx context.Context, creds string, kubeClient *kube.Image
 			return getCredsFromSecret(wbc, creds[len("secret:"):], kubeClient, namespace)
 		}, nil
 	}
-	return nil, fmt.Errorf("unexpected credentials format. Expected 'repocreds' or 'secret:<namespace>/<secret>' but got '%s'", creds)
+	return nil, fmt.Errorf("unexpected credentials format. Expected 'repocreds', 'secret:<secret>' or 'secret:<namespace>/<secret>' but got '%s'", creds)
 }
 
 // getCredsFromArgoCD loads repository credentials from Argo CD settings

--- a/pkg/argocd/gitcreds.go
+++ b/pkg/argocd/gitcreds.go
@@ -16,7 +16,7 @@ import (
 )
 
 // getGitCredsSource returns git credentials source that loads credentials from the secret or from Argo CD settings
-func getGitCredsSource(ctx context.Context, creds string, kubeClient *kube.ImageUpdaterKubernetesClient, wbc *WriteBackConfig) (GitCredsSource, error) {
+func getGitCredsSource(ctx context.Context, creds string, kubeClient *kube.ImageUpdaterKubernetesClient, wbc *WriteBackConfig, namespace string) (GitCredsSource, error) {
 	switch {
 	case creds == "repocreds":
 		return func(app *v1alpha1.Application) (git.Creds, error) {
@@ -24,7 +24,7 @@ func getGitCredsSource(ctx context.Context, creds string, kubeClient *kube.Image
 		}, nil
 	case strings.HasPrefix(creds, "secret:"):
 		return func(app *v1alpha1.Application) (git.Creds, error) {
-			return getCredsFromSecret(wbc, creds[len("secret:"):], kubeClient)
+			return getCredsFromSecret(wbc, creds[len("secret:"):], kubeClient, namespace)
 		}, nil
 	}
 	return nil, fmt.Errorf("unexpected credentials format. Expected 'repocreds' or 'secret:<namespace>/<secret>' but got '%s'", creds)
@@ -111,17 +111,25 @@ func getCAPath(ctx context.Context, repoURL string) string {
 }
 
 // getCredsFromSecret loads repository credentials from secret
-func getCredsFromSecret(wbc *WriteBackConfig, credentialsSecret string, kubeClient *kube.ImageUpdaterKubernetesClient) (git.Creds, error) {
+func getCredsFromSecret(wbc *WriteBackConfig, credentialsSecret string, kubeClient *kube.ImageUpdaterKubernetesClient, namespace string) (git.Creds, error) {
 	var credentials map[string][]byte
 	var err error
 	s := strings.SplitN(credentialsSecret, "/", 2)
 	if len(s) == 2 {
+		if s[0] != namespace {
+			return nil, fmt.Errorf("secret namespace '%s' differs from app namespace '%s'", s[0], namespace)
+		}
 		credentials, err = kubeClient.KubeClient.GetSecretData(s[0], s[1])
 		if err != nil {
 			return nil, err
 		}
+	} else if len(s) == 1 {
+		credentials, err = kubeClient.KubeClient.GetSecretData(namespace, s[0])
+		if err != nil {
+			return nil, err
+		}
 	} else {
-		return nil, fmt.Errorf("secret ref must be in format 'namespace/name', but is '%s'", credentialsSecret)
+		return nil, fmt.Errorf("wrong writeBackConfig.method format specified git:secret: '%s'", credentialsSecret)
 	}
 
 	if ok, _ := git.IsSSHURL(wbc.GitRepo); ok {

--- a/pkg/argocd/gitcreds_test.go
+++ b/pkg/argocd/gitcreds_test.go
@@ -65,37 +65,50 @@ func TestGetCredsFromSecret(t *testing.T) {
 		name          string
 		gitRepo       string
 		secretRef     string
+		namespace     string
 		expectedCreds git.Creds
 		expectedErr   string
 	}{
 		{
-			name:          "HTTPS credentials",
+			name:          "HTTPS credentials with matching namespace",
 			gitRepo:       "https://github.com/example/repo.git",
 			secretRef:     "foo/bar",
+			namespace:     "foo",
 			expectedCreds: git.NewHTTPSCreds("myuser", "mypass", "", "", true, "", store, false),
 		},
 		{
-			name:        "invalid secret reference format",
+			name:          "no namespace defaults to app namespace",
+			gitRepo:       "https://github.com/example/repo.git",
+			secretRef:     "bar",
+			namespace:     "foo",
+			expectedCreds: git.NewHTTPSCreds("myuser", "mypass", "", "", true, "", store, false),
+		},
+		{
+			name:        "cross-namespace reference is rejected",
 			gitRepo:     "https://github.com/example/repo.git",
-			secretRef:   "invalid",
-			expectedErr: "secret ref must be in format 'namespace/name', but is 'invalid'",
+			secretRef:   "team-b/bar",
+			namespace:   "team-a",
+			expectedErr: "secret namespace 'team-b' differs from app namespace 'team-a'",
 		},
 		{
 			name:        "missing password field",
 			gitRepo:     "https://github.com/example/repo.git",
 			secretRef:   "foo1/bar1",
+			namespace:   "foo1",
 			expectedErr: "invalid secret foo1/bar1: does not contain field password",
 		},
 		{
 			name:        "unknown repository type",
 			gitRepo:     "unknown://example.com/repo.git",
 			secretRef:   "foo/bar",
+			namespace:   "foo",
 			expectedErr: "unknown repository type",
 		},
 		{
 			name:      "GitHub App with enterprise base URL",
 			gitRepo:   "https://ghe.example.com/org/repo.git",
 			secretRef: "ns/ghapp",
+			namespace: "ns",
 			expectedCreds: git.NewGitHubAppCreds(
 				123, 456, "appprivatekey",
 				"https://ghe.example.com/api/v3", "https://ghe.example.com/org/repo.git",
@@ -106,6 +119,7 @@ func TestGetCredsFromSecret(t *testing.T) {
 			name:      "GitHub App with absent optional fields defaults safely",
 			gitRepo:   "https://github.com/org/repo.git",
 			secretRef: "ns/ghapp-minimal",
+			namespace: "ns",
 			expectedCreds: git.NewGitHubAppCreds(
 				789, 101, "minimalkey",
 				"", "https://github.com/org/repo.git",
@@ -116,12 +130,14 @@ func TestGetCredsFromSecret(t *testing.T) {
 			name:        "non-numeric githubAppID",
 			gitRepo:     "https://github.com/org/repo.git",
 			secretRef:   "ns/ghapp-bad-id",
+			namespace:   "ns",
 			expectedErr: "invalid value in field githubAppID",
 		},
 		{
 			name:      "malformed insecure value defaults to false",
 			gitRepo:   "https://github.com/org/repo.git",
 			secretRef: "ns/ghapp-bad-insecure",
+			namespace: "ns",
 			expectedCreds: git.NewGitHubAppCreds(
 				123, 456, "key",
 				"", "https://github.com/org/repo.git",
@@ -136,7 +152,7 @@ func TestGetCredsFromSecret(t *testing.T) {
 				GitRepo:  tt.gitRepo,
 				GitCreds: store,
 			}
-			creds, err := getCredsFromSecret(wbc, tt.secretRef, &kubeClient)
+			creds, err := getCredsFromSecret(wbc, tt.secretRef, &kubeClient, tt.namespace)
 			if tt.expectedErr != "" {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.expectedErr)
@@ -157,17 +173,17 @@ func TestGetGitCredsSource(t *testing.T) {
 	}
 
 	// Test case 1: 'repocreds' credentials
-	creds1, err := getGitCredsSource(ctx, "repocreds", kubeClient, wbc)
+	creds1, err := getGitCredsSource(ctx, "repocreds", kubeClient, wbc, "")
 	assert.NoError(t, err)
 	assert.NotNil(t, creds1)
 
 	// Test case 2: 'secret:<namespace>/<secret>' credentials
-	creds2, err := getGitCredsSource(ctx, "secret:foo/bar", kubeClient, wbc)
+	creds2, err := getGitCredsSource(ctx, "secret:foo/bar", kubeClient, wbc, "")
 	assert.NoError(t, err)
 	assert.NotNil(t, creds2)
 
 	// Test case 3: Unexpected credentials format
-	_, err = getGitCredsSource(ctx, "invalid", kubeClient, wbc)
+	_, err = getGitCredsSource(ctx, "invalid", kubeClient, wbc, "")
 	assert.Error(t, err)
 	assert.EqualError(t, err, "unexpected credentials format. Expected 'repocreds' or 'secret:<namespace>/<secret>' but got 'invalid'")
 }

--- a/pkg/argocd/gitcreds_test.go
+++ b/pkg/argocd/gitcreds_test.go
@@ -185,7 +185,7 @@ func TestGetGitCredsSource(t *testing.T) {
 	// Test case 3: Unexpected credentials format
 	_, err = getGitCredsSource(ctx, "invalid", kubeClient, wbc, "")
 	assert.Error(t, err)
-	assert.EqualError(t, err, "unexpected credentials format. Expected 'repocreds' or 'secret:<namespace>/<secret>' but got 'invalid'")
+	assert.EqualError(t, err, "unexpected credentials format. Expected 'repocreds', 'secret:<secret>' or 'secret:<namespace>/<secret>' but got 'invalid'")
 }
 
 func TestGetCAPath(t *testing.T) {

--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -890,7 +890,7 @@ func parseGitConfig(ctx context.Context, app *v1alpha1.Application, kubeClient *
 		repo := *settings.GitConfig.Repository
 		wbc.GitRepo = repo
 	}
-	credsSource, err := getGitCredsSource(ctx, creds, kubeClient, wbc)
+	credsSource, err := getGitCredsSource(ctx, creds, kubeClient, wbc, app.GetNamespace())
 	if err != nil {
 		return fmt.Errorf("invalid git credentials source: %v", err)
 	}

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -178,7 +178,7 @@ func Test_UpdateApplication(t *testing.T) {
 				Method:  WriteBackGit,
 				GitRepo: "https://example.com/example",
 				GetCreds: func(app *v1alpha1.Application) (git.Creds, error) {
-					return getCredsFromSecret(&WriteBackConfig{}, "argocd-image-updater/git-creds", &kubeClient, "")
+					return getCredsFromSecret(&WriteBackConfig{}, "argocd-image-updater/git-creds", &kubeClient, "argocd-image-updater")
 				},
 			},
 		}

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -178,7 +178,7 @@ func Test_UpdateApplication(t *testing.T) {
 				Method:  WriteBackGit,
 				GitRepo: "https://example.com/example",
 				GetCreds: func(app *v1alpha1.Application) (git.Creds, error) {
-					return getCredsFromSecret(&WriteBackConfig{}, "argocd-image-updater/git-creds", &kubeClient)
+					return getCredsFromSecret(&WriteBackConfig{}, "argocd-image-updater/git-creds", &kubeClient, "")
 				},
 			},
 		}
@@ -5423,7 +5423,8 @@ func Test_GetGitCreds(t *testing.T) {
 		}
 		app := v1alpha1.Application{
 			ObjectMeta: v1.ObjectMeta{
-				Name: "testapp",
+				Name:      "testapp",
+				Namespace: "argocd-image-updater",
 			},
 			Spec: v1alpha1.ApplicationSpec{
 				Source: &v1alpha1.ApplicationSource{
@@ -5469,7 +5470,8 @@ func Test_GetGitCreds(t *testing.T) {
 		}
 		app := v1alpha1.Application{
 			ObjectMeta: v1.ObjectMeta{
-				Name: "testapp",
+				Name:      "testapp",
+				Namespace: "argocd-image-updater",
 			},
 			Spec: v1alpha1.ApplicationSpec{
 				Source: &v1alpha1.ApplicationSource{
@@ -5555,7 +5557,8 @@ func Test_GetGitCreds(t *testing.T) {
 		}
 		app := v1alpha1.Application{
 			ObjectMeta: v1.ObjectMeta{
-				Name: "testapp",
+				Name:      "testapp",
+				Namespace: "argocd-image-updater",
 			},
 			Spec: v1alpha1.ApplicationSpec{
 				Source: &v1alpha1.ApplicationSource{
@@ -5788,7 +5791,8 @@ func Test_GetGitCreds(t *testing.T) {
 
 		app := v1alpha1.Application{
 			ObjectMeta: v1.ObjectMeta{
-				Name: "testapp",
+				Name:      "testapp",
+				Namespace: "argocd-image-updater",
 			},
 			Spec: v1alpha1.ApplicationSpec{
 				Source: &v1alpha1.ApplicationSource{

--- a/test/ginkgo/parallel/1-002-git-write-back-target_test.go
+++ b/test/ginkgo/parallel/1-002-git-write-back-target_test.go
@@ -170,6 +170,148 @@ var _ = Describe("ArgoCD Image Updater Parallel E2E Tests", func() {
 			By("creating ImageUpdater CR")
 			updateStrategy := "semver"
 			forceUpdate := false
+			method := fmt.Sprintf("git:secret:%s", iuFixture.Name)
+			branch := "master"
+			repository := fmt.Sprintf("https://%s.%s.svc.cluster.local:8081/testdata.git", iuFixture.Name, ns.Name)
+
+			imageUpdater = &imageUpdaterApi.ImageUpdater{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "image-updater",
+					Namespace: ns.Name,
+				},
+				Spec: imageUpdaterApi.ImageUpdaterSpec{
+					CommonUpdateSettings: &imageUpdaterApi.CommonUpdateSettings{
+						UpdateStrategy: &updateStrategy,
+						ForceUpdate:    &forceUpdate,
+					},
+					WriteBackConfig: &imageUpdaterApi.WriteBackConfig{
+						Method: &method,
+						GitConfig: &imageUpdaterApi.GitConfig{
+							Branch:     &branch,
+							Repository: &repository,
+						},
+					},
+					ApplicationRefs: []imageUpdaterApi.ApplicationRef{
+						{
+							NamePattern: "app*",
+							Images: []imageUpdaterApi.ImageConfig{
+								{
+									Alias:     "test",
+									ImageName: "quay.io/dkarpele/my-guestbook:29437546.X",
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, imageUpdater)).To(Succeed())
+
+			By("ensuring that the Application image has `29437546.0` version after update")
+			triggerRefresh := iuFixture.TriggerArgoCDRefresh(ctx, k8sClient, app)
+			Eventually(func() string {
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(app), app)
+
+				if err != nil {
+					return "" // Let Eventually retry on error
+				}
+
+				// Trigger ArgoCD refresh periodically to force immediate git check
+				triggerRefresh()
+
+				// For git write-back method, the image updater writes changes to git, and ArgoCD syncs from git.
+				// The image appears in Status.Summary.Images (not in Spec.Source.Kustomize.Images like argocd write-back).
+				if len(app.Status.Summary.Images) > 0 {
+					return app.Status.Summary.Images[0]
+				}
+
+				// Return an empty string to signify the condition is not yet met.
+				return ""
+			}, "5m", "3s").Should(Equal("quay.io/dkarpele/my-guestbook:29437546.0"))
+		})
+
+		It("ensures that Image Updater supports legacy namespace/secret format when secret namespace matches app namespace", func() {
+
+			By("creating simple namespace-scoped Argo CD instance with image updater enabled")
+			ns, cleanupFunc = fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
+
+			By("Creating local git repo")
+			iuFixture.CreateLocalGitRepo(ctx, k8sClient, ns.Name)
+
+			By("waiting for local git repo to be ready")
+			gitDepl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: iuFixture.Name, Namespace: ns.Name}}
+			Eventually(gitDepl).Should(k8sFixture.ExistByName())
+			Eventually(gitDepl, "2m", "3s").Should(deplFixture.HaveReadyReplicas(1), "git repo server was not ready")
+
+			argoCD = &argov1beta1api.ArgoCD{
+				ObjectMeta: metav1.ObjectMeta{Name: "argocd", Namespace: ns.Name},
+				Spec: argov1beta1api.ArgoCDSpec{
+					ImageUpdater: argov1beta1api.ArgoCDImageUpdaterSpec{
+						Env: []corev1.EnvVar{
+							{
+								Name:  "IMAGE_UPDATER_LOGLEVEL",
+								Value: "trace",
+							},
+							{
+								Name:  "IMAGE_UPDATER_INTERVAL",
+								Value: "0",
+							},
+						},
+						Enabled: true},
+				},
+			}
+			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
+
+			By("waiting for ArgoCD CR to be reconciled and the instance to be ready")
+			Eventually(argoCD, "5m", "3s").Should(argocdFixture.BeAvailable())
+
+			By("verifying all workloads are started")
+			deploymentsShouldExist := []string{"argocd-redis", "argocd-server", "argocd-repo-server", "argocd-argocd-image-updater-controller"}
+			for _, depl := range deploymentsShouldExist {
+				depl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: depl, Namespace: ns.Name}}
+				Eventually(depl).Should(k8sFixture.ExistByName())
+				Eventually(depl).Should(deplFixture.HaveReplicas(1))
+				Eventually(depl, "3m", "3s").Should(deplFixture.HaveReadyReplicas(1), depl.Name+" was not ready")
+			}
+
+			statefulSet := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "argocd-application-controller", Namespace: ns.Name}}
+			Eventually(statefulSet).Should(k8sFixture.ExistByName())
+			Eventually(statefulSet).Should(ssFixture.HaveReplicas(1))
+			Eventually(statefulSet, "3m", "3s").Should(ssFixture.HaveReadyReplicas(1))
+
+			By("creating Application")
+			app := &appv1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "app-01",
+					Namespace: ns.Name,
+				},
+				Spec: appv1alpha1.ApplicationSpec{
+					Project: "default",
+					Source: &appv1alpha1.ApplicationSource{
+						RepoURL:        fmt.Sprintf("https://%s.%s.svc.cluster.local:8081/testdata.git", iuFixture.Name, ns.Name),
+						Path:           "1-002-git-write-back-target-test",
+						TargetRevision: "HEAD",
+					},
+					Destination: appv1alpha1.ApplicationDestination{
+						Server:    "https://kubernetes.default.svc",
+						Namespace: ns.Name,
+					},
+					SyncPolicy: &appv1alpha1.SyncPolicy{
+						Automated: &appv1alpha1.SyncPolicyAutomated{
+							Prune: ptr.To(true),
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+
+			By("verifying deploying the Application succeeded")
+			Eventually(app, "4m", "3s").Should(applicationFixture.HaveHealthStatusCode(health.HealthStatusHealthy))
+			Eventually(app, "4m", "3s").Should(applicationFixture.HaveSyncStatusCode(appv1alpha1.SyncStatusCodeSynced))
+
+			By("creating ImageUpdater CR with legacy namespace/secret format where secret namespace equals app namespace")
+			updateStrategy := "semver"
+			forceUpdate := false
+			// Legacy format: namespace/secret — accepted because the namespace matches the CR's own namespace.
 			method := fmt.Sprintf("git:secret:%s/%s", ns.Name, iuFixture.Name)
 			branch := "master"
 			repository := fmt.Sprintf("https://%s.%s.svc.cluster.local:8081/testdata.git", iuFixture.Name, ns.Name)

--- a/test/ginkgo/parallel/1-003-multi-source-helm-kustomize_test.go
+++ b/test/ginkgo/parallel/1-003-multi-source-helm-kustomize_test.go
@@ -187,7 +187,7 @@ var _ = Describe("ArgoCD Image Updater Parallel E2E Tests", func() {
 			By("creating ImageUpdater CR with git write-back targeting the Helm values file")
 			updateStrategy := "semver"
 			forceUpdate := false
-			method := fmt.Sprintf("git:secret:%s/%s", ns.Name, iuFixture.Name)
+			method := fmt.Sprintf("git:secret:%s", iuFixture.Name)
 			branch := "master"
 			repository := gitRepoURL
 			// Target the external helm-overrides.yaml file - this tests the source type detection fix from PR #1443

--- a/test/ginkgo/parallel/1-004-git-helm_test.go
+++ b/test/ginkgo/parallel/1-004-git-helm_test.go
@@ -174,7 +174,7 @@ var _ = Describe("ArgoCD Image Updater Parallel E2E Tests", func() {
 			By("creating ImageUpdater CR with git write-back targeting the Helm values file")
 			updateStrategy := "semver"
 			forceUpdate := false
-			method := fmt.Sprintf("git:secret:%s/%s", ns.Name, iuFixture.Name)
+			method := fmt.Sprintf("git:secret:%s", iuFixture.Name)
 			branch := "master"
 			repository := gitRepoURL
 			// Target the helm values.yaml file directly

--- a/test/ginkgo/parallel/1-006-annotations-git_test.go
+++ b/test/ginkgo/parallel/1-006-annotations-git_test.go
@@ -138,7 +138,7 @@ var _ = Describe("ArgoCD Image Updater Parallel E2E Tests", func() {
 			Eventually(statefulSet, "3m", "3s").Should(ssFixture.HaveReadyReplicas(1))
 
 			By("creating Application")
-			method := fmt.Sprintf("git:secret:%s/%s", ns.Name, iuFixture.Name)
+			method := fmt.Sprintf("git:secret:%s", iuFixture.Name)
 			branch := "master"
 			repository := fmt.Sprintf("https://%s.%s.svc.cluster.local:8081/testdata.git", iuFixture.Name, ns.Name)
 

--- a/test/ginkgo/parallel/1-008-helmvalues-non-live-images_test.go
+++ b/test/ginkgo/parallel/1-008-helmvalues-non-live-images_test.go
@@ -192,7 +192,7 @@ var _ = Describe("ArgoCD Image Updater Parallel E2E Tests", func() {
 			By("creating ImageUpdater CR with three image aliases sharing one helmvalues write-back target")
 			updateStrategy := "semver"
 			forceUpdate := false
-			method := fmt.Sprintf("git:secret:%s/%s", ns.Name, iuFixture.Name)
+			method := fmt.Sprintf("git:secret:%s", iuFixture.Name)
 			branch := "master"
 			repository := gitRepoURL
 			// All three images share the same helmvalues target.

--- a/test/ginkgo/parallel/1-009-github-pull-request_test.go
+++ b/test/ginkgo/parallel/1-009-github-pull-request_test.go
@@ -285,7 +285,7 @@ var _ = Describe("ArgoCD Image Updater Parallel E2E Tests", func() {
 			By("creating ImageUpdater CR with GitHub pull-request write-back mode")
 			updateStrategy := "semver"
 			forceUpdate := false
-			method := fmt.Sprintf("git:secret:%s/%s", ns.Name, githubCredsSecretName)
+			method := fmt.Sprintf("git:secret:%s", githubCredsSecretName)
 
 			imageUpdater = &imageUpdaterApi.ImageUpdater{
 				ObjectMeta: metav1.ObjectMeta{

--- a/test/ginkgo/parallel/1-010-verify-image_test.go
+++ b/test/ginkgo/parallel/1-010-verify-image_test.go
@@ -215,7 +215,7 @@ var _ = Describe("ArgoCD Image Updater Parallel E2E Tests", func() {
 			updateStrategy := "semver"
 			forceUpdate := false
 			verificationEnabled := true
-			method := fmt.Sprintf("git:secret:%s/%s", ns.Name, iuFixture.Name)
+			method := fmt.Sprintf("git:secret:%s", iuFixture.Name)
 			branch := "master"
 			repository := fmt.Sprintf("https://%s.%s.svc.cluster.local:8081/testdata.git", iuFixture.Name, ns.Name)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Git write-back credentials now support `git:secret:<secret>` (secret name only), defaulting to the Image Updater namespace, while continuing to support `git:secret:<namespace>/<secret>`.
  * Updated sample Image Updater manifests to use the simplified format.
* **Bug Fixes**
  * Prevents cross-namespace Git credential secret references by rejecting mismatched secret namespaces.
* **Documentation**
  * Refreshed write-back credential docs and GitHub/GitLab PR examples with `git:secret:<secret>` plus an added cross-namespace warning.
* **Tests**
  * Updated unit and end-to-end scenarios to validate namespace-aware behavior and the new `git:secret:<secret>` formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->