### PR TITLE
fix: reject cross-namespace secret references in commonUpdateSettings.pullSecret

### DIFF
--- a/docs/configuration/images.md
+++ b/docs/configuration/images.md
@@ -281,6 +281,13 @@ Valid values for `secret_ref` are:
   secret, that is, it must have a valid Docker config in JSON format in the
   field `.dockerconfigjson`.
 
+!!!warning "Cross-namespace secret references are rejected"
+    For `secret:` and `pullsecret:` references, the `namespace` in the
+    reference **must** match the namespace of the `ImageUpdater` CR. Referencing
+    a secret from a different namespace (e.g. specifying `other-team/my-secret`
+    while the CR runs in `my-team`) is rejected with an error and the image is
+    skipped. This prevents tenants from reading secrets they do not own.
+
 * `env:<variable_name>` - Use credentials supplied by the environment variable
   named `variable_name`. This can be a variable that is i.e. bound from a
   secret within your pod spec.

--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -43,6 +43,8 @@ func UpdateApplication(ctx context.Context, updateConf *UpdateConfiguration, sta
 	var needUpdate bool = false
 	result := ImageUpdaterResult{}
 	app := updateConf.UpdateApp.Application.GetName()
+	appNs := updateConf.UpdateApp.Application.GetNamespace()
+
 	changeList := make([]ChangeEntry, 0)
 
 	// Get all images that are deployed with the current application
@@ -117,6 +119,21 @@ func UpdateApplication(ctx context.Context, updateConf *UpdateConfiguration, sta
 		if secretVal == "" {
 			imgCtx.Tracef("No pull secret configured for this image")
 		}
+
+		// reject cross-namespace secret references in commonUpdateSettings.pullSecret
+		if strings.HasPrefix(secretVal, "pullsecret:") || strings.HasPrefix(secretVal, "secret:") {
+			// Strip "pullsecret:" or "secret:" prefix before splitting on "/" to isolate the namespace.
+			_, ref, _ := strings.Cut(secretVal, ":")
+			s := strings.SplitN(ref, "/", 2)
+			if len(s) == 2 {
+				if s[0] != appNs {
+					imgCtx.Errorf("commonUpdateSettings.pullSecret namespace '%s' differs from app namespace '%s'", s[0], appNs)
+					result.NumErrors += 1
+					continue
+				}
+			}
+		}
+
 		// The endpoint can provide default credentials for pulling images
 		creds, err := rep.SetEndpointCredentials(imageOpCtx, updateConf.KubeClient.KubeClient, secretVal)
 		if err != nil {

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -550,12 +550,12 @@ func Test_UpdateApplication(t *testing.T) {
 
 		kubeClient := kube.ImageUpdaterKubernetesClient{
 			KubeClient: &registryKube.KubernetesClient{
-				Clientset: fake.NewFakeClientsetWithResources(fixture.NewSecret("foo", "bar", map[string][]byte{"creds": []byte("myuser:mypass")})),
+				Clientset: fake.NewFakeClientsetWithResources(fixture.NewSecret("guestbook", "bar", map[string][]byte{"creds": []byte("myuser:mypass")})),
 			},
 		}
 
 		img := NewImage(image.NewFromIdentifier("dummy=jannfis/foobar:1.0.1"))
-		img.PullSecret = "secret:foo/bar#creds"
+		img.PullSecret = "secret:guestbook/bar#creds"
 
 		appImages := &ApplicationImages{
 			Application: v1alpha1.Application{
@@ -598,6 +598,132 @@ func Test_UpdateApplication(t *testing.T) {
 		assert.Equal(t, 1, res.NumApplicationsProcessed)
 		assert.Equal(t, 1, res.NumImagesConsidered)
 		assert.Equal(t, 1, res.NumImagesUpdated)
+	})
+
+	t.Run("Test cross-namespace secret reference is rejected", func(t *testing.T) {
+		mockClientFn := func(endpoint *registry.RegistryEndpoint, username, password string) (registry.RegistryClient, error) {
+			regMock := regmock.RegistryClient{}
+			regMock.On("NewRepository", mock.Anything).Return(nil)
+			regMock.On("Tags", mock.Anything).Return([]string{"1.0.1"}, nil)
+			return &regMock, nil
+		}
+
+		argoClient := argomock.ArgoCD{}
+		argoClient.On("UpdateSpec", mock.Anything, mock.Anything).Return(nil, nil)
+
+		kubeClient := kube.ImageUpdaterKubernetesClient{
+			KubeClient: &registryKube.KubernetesClient{
+				Clientset: fake.NewFakeClientsetWithResources(fixture.NewSecret("other-ns", "bar", map[string][]byte{"creds": []byte("myuser:mypass")})),
+			},
+		}
+
+		img := NewImage(image.NewFromIdentifier("dummy=jannfis/foobar:1.0.1"))
+		img.PullSecret = "secret:other-ns/bar#creds"
+
+		appImages := &ApplicationImages{
+			Application: v1alpha1.Application{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "guestbook",
+					Namespace: "guestbook",
+				},
+				Spec: v1alpha1.ApplicationSpec{
+					Source: &v1alpha1.ApplicationSource{
+						Kustomize: &v1alpha1.ApplicationSourceKustomize{
+							Images: v1alpha1.KustomizeImages{
+								"jannfis/foobar:1.0.0",
+							},
+						},
+					},
+				},
+				Status: v1alpha1.ApplicationStatus{
+					SourceType: v1alpha1.ApplicationSourceTypeKustomize,
+					Summary: v1alpha1.ApplicationSummary{
+						Images: []string{
+							"jannfis/foobar:1.0.0",
+						},
+					},
+				},
+			},
+			Images: ImageList{img},
+			WriteBackConfig: &WriteBackConfig{
+				Method: WriteBackApplication,
+			},
+		}
+		res := UpdateApplication(context.Background(), &UpdateConfiguration{
+			NewRegFN:   mockClientFn,
+			ArgoClient: &argoClient,
+			KubeClient: &kubeClient,
+			UpdateApp:  appImages,
+			DryRun:     false,
+		}, NewSyncIterationState())
+		assert.Equal(t, 1, res.NumErrors)
+		assert.Equal(t, 0, res.NumSkipped)
+		assert.Equal(t, 1, res.NumApplicationsProcessed)
+		assert.Equal(t, 1, res.NumImagesConsidered)
+		assert.Equal(t, 0, res.NumImagesUpdated)
+	})
+
+	t.Run("Test cross-namespace pullsecret reference is rejected", func(t *testing.T) {
+		mockClientFn := func(endpoint *registry.RegistryEndpoint, username, password string) (registry.RegistryClient, error) {
+			regMock := regmock.RegistryClient{}
+			regMock.On("NewRepository", mock.Anything).Return(nil)
+			regMock.On("Tags", mock.Anything).Return([]string{"1.0.1"}, nil)
+			return &regMock, nil
+		}
+
+		argoClient := argomock.ArgoCD{}
+		argoClient.On("UpdateSpec", mock.Anything, mock.Anything).Return(nil, nil)
+
+		kubeClient := kube.ImageUpdaterKubernetesClient{
+			KubeClient: &registryKube.KubernetesClient{
+				Clientset: fake.NewFakeClientsetWithResources(),
+			},
+		}
+
+		img := NewImage(image.NewFromIdentifier("dummy=jannfis/foobar:1.0.1"))
+		img.PullSecret = "pullsecret:other-ns/docker-pull-secret"
+
+		appImages := &ApplicationImages{
+			Application: v1alpha1.Application{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "guestbook",
+					Namespace: "guestbook",
+				},
+				Spec: v1alpha1.ApplicationSpec{
+					Source: &v1alpha1.ApplicationSource{
+						Kustomize: &v1alpha1.ApplicationSourceKustomize{
+							Images: v1alpha1.KustomizeImages{
+								"jannfis/foobar:1.0.0",
+							},
+						},
+					},
+				},
+				Status: v1alpha1.ApplicationStatus{
+					SourceType: v1alpha1.ApplicationSourceTypeKustomize,
+					Summary: v1alpha1.ApplicationSummary{
+						Images: []string{
+							"jannfis/foobar:1.0.0",
+						},
+					},
+				},
+			},
+			Images: ImageList{img},
+			WriteBackConfig: &WriteBackConfig{
+				Method: WriteBackApplication,
+			},
+		}
+		res := UpdateApplication(context.Background(), &UpdateConfiguration{
+			NewRegFN:   mockClientFn,
+			ArgoClient: &argoClient,
+			KubeClient: &kubeClient,
+			UpdateApp:  appImages,
+			DryRun:     false,
+		}, NewSyncIterationState())
+		assert.Equal(t, 1, res.NumErrors)
+		assert.Equal(t, 0, res.NumSkipped)
+		assert.Equal(t, 1, res.NumApplicationsProcessed)
+		assert.Equal(t, 1, res.NumImagesConsidered)
+		assert.Equal(t, 0, res.NumImagesUpdated)
 	})
 
 	// ErrCredentialsInvalid retry: first GetTags returns 401, refetch creds and retry, second GetTags succeeds.


### PR DESCRIPTION
I don't introduce simplified format (`pullsecret:<secret>`) - without namespace, because it's required complicated changes in many functions, including registry-scanner. And the value of this enhancement is almost 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Image updates now reject image pull credential references that point to secrets in a different namespace.
  * Affected images are skipped and reported as errors instead of being updated incorrectly.

* **Documentation**
  * Added guidance clarifying that image pull secrets must be located in the same namespace as the associated image updater resource.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->