### PR TITLE
feat: preserve YAML formatting when writing back to Helm values files

### DIFF
--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -465,6 +465,7 @@ func marshalParamsOverride(ctx context.Context, applicationImages *ApplicationIm
 				}
 			}
 
+			var writes []helmValueWrite
 			for _, c := range images {
 				if c == nil || c.ImageAlias == "" {
 					continue
@@ -495,10 +496,7 @@ func marshalParamsOverride(ctx context.Context, applicationImages *ApplicationIm
 					}
 					//Write tag in helm value file only if tag is not empty
 					if tagValue != "" {
-						err = setHelmValue(&helmNewValues, helmParamVersion, tagValue)
-						if err != nil {
-							return nil, fmt.Errorf("failed to set image parameter version value: %v", err)
-						}
+						writes = append(writes, helmValueWrite{kind: "version", path: helmParamVersion, value: tagValue})
 					}
 				}
 
@@ -529,13 +527,10 @@ func marshalParamsOverride(ctx context.Context, applicationImages *ApplicationIm
 					// If helmParamN.Value is already in short form or originalData is empty, use it as-is
 				}
 
-				err = setHelmValue(&helmNewValues, helmParamName, valueToSet)
-				if err != nil {
-					return nil, fmt.Errorf("failed to set image parameter name value: %v", err)
-				}
+				writes = append(writes, helmValueWrite{kind: "name", path: helmParamName, value: valueToSet})
 			}
 
-			override, err = marshalWithIndent(&helmNewValues, defaultIndent)
+			override, err = applyHelmValueWrites(&helmNewValues, originalData, writes)
 		} else {
 			if appSource.Helm == nil {
 				return []byte{}, nil
@@ -764,95 +759,195 @@ func setHelmValue(currentValues *yaml.Node, key string, value interface{}) error
 }
 
 // getHelmValue retrieves a value from a yaml.Node using a key path.
-// The key can be in the form of "a.b.c" which can be:
+// See resolveHelmScalarNode for how the key is interpreted.
+func getHelmValue(values *yaml.Node, key string) (string, error) {
+	node, err := resolveHelmScalarNode(values, key)
+	if err != nil {
+		return "", err
+	}
+	return node.Value, nil
+}
+
+// resolveHelmScalarNode resolves a key path to its scalar yaml.Node. The key
+// can be in the form of "a.b.c" which can be:
 // 1. A nested hierarchy where "a" has "b" which has "c"
 // 2. A literal key "a.b.c" if the nested structure doesn't exist
-// Returns the value as a string and an error if the key is not found.
-func getHelmValue(values *yaml.Node, key string) (string, error) {
+// Returning the node (rather than just its value) lets callers read its source
+// Line/Column for in-place patching. Returns an error if the key is not found.
+func resolveHelmScalarNode(values *yaml.Node, key string) (*yaml.Node, error) {
 	current := values
 
 	// an unmarshalled document has a DocumentNode at the root, but
 	// we navigate from a MappingNode.
 	if current.Kind == yaml.DocumentNode {
 		if len(current.Content) == 0 {
-			return "", fmt.Errorf("empty document node")
+			return nil, fmt.Errorf("empty document node")
 		}
 		current = current.Content[0]
 	}
 
 	if current.Kind != yaml.MappingNode {
-		return "", fmt.Errorf("unexpected type %s for root", nodeKindString(current.Kind))
+		return nil, fmt.Errorf("unexpected type %s for root", nodeKindString(current.Kind))
 	}
 
 	// First, try to navigate as nested path (a.b.c)
 	keys := strings.Split(key, ".")
-	currentForNested := current
+	node := current
 
 	for i, k := range keys {
 		var idPtr *int
 		// Handle array indexing pattern like "key[0]"
 		keyPart := k
-		matches := re.FindStringSubmatch(k)
-		if matches != nil {
-			idStr := matches[2]
-			id, err := strconv.Atoi(idStr)
+		if matches := re.FindStringSubmatch(k); matches != nil {
+			id, err := strconv.Atoi(matches[2])
 			if err != nil {
-				return "", fmt.Errorf("id \"%s\" in yaml array must match pattern ^(.*)\\[(.*)\\]$", idStr)
+				return nil, fmt.Errorf("id \"%s\" in yaml array must match pattern ^(.*)\\[(.*)\\]$", matches[2])
 			}
 			idPtr = &id
 			keyPart = matches[1]
 		}
 
-		if idx, found := findHelmValuesKey(currentForNested, keyPart); found {
-			// Navigate deeper into the map
-			currentForNested = currentForNested.Content[idx]
-			// unpack one level of alias; an alias of an alias is not supported
-			if currentForNested.Kind == yaml.AliasNode {
-				currentForNested = currentForNested.Alias
-			}
-
-			if currentForNested.Kind == yaml.SequenceNode {
-				if idPtr == nil {
-					// Can't navigate into sequence without index
-					break
-				}
-				if *idPtr < 0 || *idPtr >= len(currentForNested.Content) {
-					break
-				}
-				currentForNested = currentForNested.Content[*idPtr]
-			}
-
-			if i == len(keys)-1 {
-				// If we're at the final key, return the value
-				if currentForNested.Kind == yaml.ScalarNode {
-					return currentForNested.Value, nil
-				}
-				// If it's not a scalar, the nested path doesn't match, fall through to literal check
-				break
-			} else if currentForNested.Kind != yaml.MappingNode {
-				// Can't navigate further, nested path doesn't exist
+		idx, found := findHelmValuesKey(node, keyPart)
+		if !found {
+			break // fall through to literal check
+		}
+		node = node.Content[idx]
+		// unpack one level of alias; an alias of an alias is not supported
+		if node.Kind == yaml.AliasNode {
+			node = node.Alias
+		}
+		if node.Kind == yaml.SequenceNode {
+			if idPtr == nil || *idPtr < 0 || *idPtr >= len(node.Content) {
 				break
 			}
-		} else {
-			// Key not found in nested path, fall through to literal check
-			break
+			node = node.Content[*idPtr]
+		}
+
+		if i == len(keys)-1 {
+			if node.Kind == yaml.ScalarNode {
+				return node, nil
+			}
+			break // not a scalar, fall through to literal check
+		} else if node.Kind != yaml.MappingNode {
+			break // can't navigate further
 		}
 	}
 
 	// If nested path didn't work, try as a literal key "a.b.c"
 	if idx, found := findHelmValuesKey(current, key); found {
 		valueNode := current.Content[idx]
-		// unpack one level of alias
 		if valueNode.Kind == yaml.AliasNode {
 			valueNode = valueNode.Alias
 		}
 		if valueNode.Kind == yaml.ScalarNode {
-			return valueNode.Value, nil
+			return valueNode, nil
 		}
-		return "", fmt.Errorf("literal key \"%s\" found but is not a scalar value", key)
+		return nil, fmt.Errorf("literal key \"%s\" found but is not a scalar value", key)
 	}
 
-	return "", fmt.Errorf("key \"%s\" not found as nested path or literal key", key)
+	return nil, fmt.Errorf("key \"%s\" not found as nested path or literal key", key)
+}
+
+// helmValueWrite is a single parameter value to write into a Helm values
+// document. kind ("name" or "version") is used only for error context.
+type helmValueWrite struct {
+	kind  string
+	path  string
+	value string
+}
+
+// applyHelmValueWrites writes the given parameter values into a Helm values
+// document. When every write updates a value that already exists in the
+// original file as a plain scalar, it patches those values in place, preserving
+// the file's exact formatting (comments, blank lines, indentation, anchors,
+// inline-comment alignment). If any key must be created or cannot be safely
+// rewritten, it falls back to mutating the YAML node tree and re-marshalling,
+// which preserves comments and key order but not blank lines.
+func applyHelmValueWrites(root *yaml.Node, originalData []byte, writes []helmValueWrite) ([]byte, error) {
+	if patched, ok := patchHelmValuesInPlace(root, originalData, writes); ok {
+		return patched, nil
+	}
+	for _, w := range writes {
+		if err := setHelmValue(root, w.path, w.value); err != nil {
+			return nil, fmt.Errorf("failed to set image parameter %s value: %v", w.kind, err)
+		}
+	}
+	return marshalWithIndent(root, defaultIndent)
+}
+
+// patchHelmValuesInPlace edits value text directly in originalData. It succeeds
+// only when every write targets an existing plain scalar that can be safely
+// rewritten; otherwise it returns (nil, false) so the caller falls back to
+// re-marshalling. Because it never re-serialises untouched lines, all original
+// formatting outside the changed values is preserved byte-for-byte.
+func patchHelmValuesInPlace(root *yaml.Node, originalData []byte, writes []helmValueWrite) ([]byte, bool) {
+	if isOnlyWhitespace(originalData) {
+		return nil, false
+	}
+	type patch struct {
+		node  *yaml.Node
+		value string
+	}
+	patches := make([]patch, 0, len(writes))
+	for _, w := range writes {
+		node, err := resolveHelmScalarNode(root, w.path)
+		if err != nil {
+			return nil, false // key must be created -> fall back
+		}
+		patches = append(patches, patch{node: node, value: w.value})
+	}
+	lines := strings.Split(string(originalData), "\n")
+	for _, p := range patches {
+		if !patchScalarValue(lines, p.node, p.value) {
+			return nil, false // value not safely rewritable -> fall back
+		}
+	}
+	return []byte(strings.Join(lines, "\n")), true
+}
+
+// patchScalarValue replaces the value text of a scalar node at its recorded
+// Line/Column in lines, leaving the remainder of the line (trailing comments
+// and their alignment) untouched. It returns false when the raw text at that
+// position does not match the node's decoded value (e.g. quoted or block
+// scalars) or when the replacement would not be a safe plain scalar.
+func patchScalarValue(lines []string, node *yaml.Node, newValue string) bool {
+	if node == nil || node.Line < 1 || node.Line > len(lines) {
+		return false
+	}
+	line := lines[node.Line-1]
+	col := node.Column - 1
+	if col < 0 || col > len(line) {
+		return false
+	}
+	old := node.Value
+	if old == "" || !strings.HasPrefix(line[col:], old) {
+		return false
+	}
+	if !isSafePlainScalar(newValue) {
+		return false
+	}
+	lines[node.Line-1] = line[:col] + newValue + line[col+len(old):]
+	return true
+}
+
+// isSafePlainScalar reports whether s can be written as an unquoted YAML plain
+// scalar without changing tokenisation. Conservative: anything that could need
+// quoting returns false, causing a fall back to re-marshalling.
+func isSafePlainScalar(s string) bool {
+	if s == "" || strings.ContainsAny(s, "\n\t") {
+		return false
+	}
+	if strings.Contains(s, ": ") || strings.Contains(s, " #") {
+		return false
+	}
+	if strings.HasPrefix(s, " ") || strings.HasSuffix(s, " ") || strings.HasSuffix(s, ":") {
+		return false
+	}
+	switch s[0] {
+	case '!', '&', '*', '?', '|', '>', '%', '@', '`', '"', '\'', '#', ',', '[', ']', '{', '}', '-':
+		return false
+	}
+	return true
 }
 
 func parseDefaultTarget(appNamespace string, appName string, path string, kubeClient *kube.ImageUpdaterKubernetesClient) string {

--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -816,11 +816,15 @@ func resolveHelmScalarNode(values *yaml.Node, key string) (*yaml.Node, error) {
 		if node.Kind == yaml.AliasNode {
 			node = node.Alias
 		}
-		if node.Kind == yaml.SequenceNode {
-			if idPtr == nil || *idPtr < 0 || *idPtr >= len(node.Content) {
+		if idPtr != nil {
+			// an index was requested, so the node must be a sequence; otherwise
+			// bail so the caller falls back rather than silently ignoring it
+			if node.Kind != yaml.SequenceNode || *idPtr < 0 || *idPtr >= len(node.Content) {
 				break
 			}
 			node = node.Content[*idPtr]
+		} else if node.Kind == yaml.SequenceNode {
+			break // can't navigate into a sequence without an index
 		}
 
 		if i == len(keys)-1 {
@@ -931,8 +935,9 @@ func patchScalarValue(lines []string, node *yaml.Node, newValue string) bool {
 }
 
 // isSafePlainScalar reports whether s can be written as an unquoted YAML plain
-// scalar without changing tokenisation. Conservative: anything that could need
-// quoting returns false, causing a fall back to re-marshalling.
+// scalar without changing tokenisation or its resolved type. Conservative:
+// anything that could need quoting returns false, causing a fall back to
+// re-marshalling.
 func isSafePlainScalar(s string) bool {
 	if s == "" || strings.ContainsAny(s, "\n\t") {
 		return false
@@ -945,6 +950,22 @@ func isSafePlainScalar(s string) bool {
 	}
 	switch s[0] {
 	case '!', '&', '*', '?', '|', '>', '%', '@', '`', '"', '\'', '#', ',', '[', ']', '{', '}', '-':
+		return false
+	}
+	// Reject values a YAML parser resolves as a non-string (int, float, bool,
+	// null): written unquoted, an image tag like "1.20" or "true" would
+	// round-trip as a float/bool instead of a string.
+	var v interface{}
+	if err := yaml.Unmarshal([]byte(s), &v); err != nil {
+		return false
+	}
+	if _, ok := v.(string); !ok {
+		return false
+	}
+	// goyaml.v3 follows the YAML 1.2 core schema, so it decodes these as
+	// strings, but 1.1 consumers (e.g. Helm) treat them as booleans/null.
+	switch strings.ToLower(s) {
+	case "yes", "no", "on", "off", "y", "n", "null", "~":
 		return false
 	}
 	return true

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -7086,3 +7086,87 @@ func TestResolveHelmScalarNode_ArrayIndexMismatch(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "v1.0.0", node.Value)
 }
+
+// TestMarshalParamsOverride_FallsBackForQuotedTarget verifies that when the
+// value being updated is itself a quoted scalar (which the in-place patcher
+// cannot rewrite safely), marshalParamsOverride falls back to re-marshalling
+// and still updates the value to the new tag.
+func TestMarshalParamsOverride_FallsBackForQuotedTarget(t *testing.T) {
+	originalData := []byte(`config:
+  image:
+    repository: myapp
+    tag: "v1.0.0"
+`)
+
+	app := v1alpha1.Application{
+		ObjectMeta: v1.ObjectMeta{Name: "testapp"},
+		Spec: v1alpha1.ApplicationSpec{
+			Sources: []v1alpha1.ApplicationSource{
+				{
+					Chart: "my-app",
+					Helm: &v1alpha1.ApplicationSourceHelm{
+						ReleaseName: "my-app",
+						ValueFiles:  []string{"$values/some/dir/values.yaml"},
+						Parameters: []v1alpha1.HelmParameter{
+							{Name: "config.image.repository", Value: "myapp", ForceString: true},
+							{Name: "config.image.tag", Value: "v2.0.0", ForceString: true},
+						},
+					},
+					RepoURL:        "https://example.com/example",
+					TargetRevision: "main",
+				},
+				{Ref: "values", RepoURL: "https://example.com/example2", TargetRevision: "main"},
+			},
+		},
+		Status: v1alpha1.ApplicationStatus{
+			SourceTypes: []v1alpha1.ApplicationSourceType{v1alpha1.ApplicationSourceTypeHelm, ""},
+			Summary:     v1alpha1.ApplicationSummary{Images: []string{"myapp:v1.0.0"}},
+		},
+	}
+
+	im := NewImage(image.NewFromIdentifier("app=myapp"))
+	im.HelmImageName = "config.image.repository"
+	im.HelmImageTag = "config.image.tag"
+
+	applicationImages := &ApplicationImages{
+		Application:     app,
+		Images:          ImageList{im},
+		WriteBackConfig: &WriteBackConfig{Target: "./test-values.yaml"},
+	}
+
+	out, err := marshalParamsOverride(context.Background(), applicationImages, originalData)
+	require.NoError(t, err)
+
+	// The fallback re-marshals the document, so assert on the parsed value
+	// rather than on exact bytes.
+	var got yaml.Node
+	require.NoError(t, yaml.Unmarshal(out, &got))
+	tag, err := getHelmValue(&got, "config.image.tag")
+	require.NoError(t, err)
+	assert.Equal(t, "v2.0.0", tag)
+}
+
+// TestApplyHelmValueWrites_ArrayIndexMismatchDoesNotPatch exercises the write
+// path (not just the resolver): an indexed path against a non-sequence node
+// must neither be patched in place nor set via the fallback, so the write
+// errors instead of silently rewriting an unrelated scalar.
+func TestApplyHelmValueWrites_ArrayIndexMismatchDoesNotPatch(t *testing.T) {
+	originalData := []byte("foo:\n  tag: v1.0.0\n")
+	var root yaml.Node
+	require.NoError(t, yaml.Unmarshal(originalData, &root))
+
+	writes := []helmValueWrite{{kind: "version", path: "foo[2].tag", value: "v2.0.0"}}
+
+	// the in-place patch path must decline (not patch the unrelated foo.tag)...
+	_, ok := patchHelmValuesInPlace(&root, originalData, writes)
+	assert.False(t, ok, "indexed path against a non-sequence must not patch in place")
+
+	// ...and the full write path must surface an error rather than mis-write.
+	_, err := applyHelmValueWrites(&root, originalData, writes)
+	assert.Error(t, err, "indexed path against a non-sequence must error")
+
+	// the unrelated value must be untouched.
+	tag, err := getHelmValue(&root, "foo.tag")
+	require.NoError(t, err)
+	assert.Equal(t, "v1.0.0", tag)
+}

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -6856,3 +6856,190 @@ func Test_sortHelmParameters(t *testing.T) {
 func stringPtr(s string) *string {
 	return &s
 }
+
+// TestMarshalParamsOverride_PreservesFormatting verifies that when every write
+// updates an existing key, the values file is patched in place with byte-exact
+// preservation of comments, blank lines, indentation, anchors and inline
+// comment alignment.
+func TestMarshalParamsOverride_PreservesFormatting(t *testing.T) {
+	originalData := []byte(`# This is a header comment describing the values file
+# It spans multiple lines
+
+# Global settings section
+global:
+  # Environment configuration
+  environment: production
+  debug: false
+
+# Image configuration with anchors
+images:
+  # Primary application image
+  app: &app-image
+    repository: myapp
+    tag: v1.0.0  # Current version
+    pullPolicy: IfNotPresent
+
+  # Sidecar image using alias
+  sidecar:
+    <<: *app-image
+    tag: v1.0.0
+
+# Database settings
+database:
+  host: localhost
+  port: 5432
+
+  # Connection pool settings
+  pool:
+    minSize: 5
+    maxSize: 20
+`)
+
+	// Only tag updates; the repository keys already exist and are unchanged.
+	// Every write targets an existing scalar => in-place patch path.
+	expected := `# This is a header comment describing the values file
+# It spans multiple lines
+
+# Global settings section
+global:
+  # Environment configuration
+  environment: production
+  debug: false
+
+# Image configuration with anchors
+images:
+  # Primary application image
+  app: &app-image
+    repository: myapp
+    tag: v2.0.0  # Current version
+    pullPolicy: IfNotPresent
+
+  # Sidecar image using alias
+  sidecar:
+    <<: *app-image
+    tag: v2.0.0
+
+# Database settings
+database:
+  host: localhost
+  port: 5432
+
+  # Connection pool settings
+  pool:
+    minSize: 5
+    maxSize: 20
+`
+
+	app := v1alpha1.Application{
+		ObjectMeta: v1.ObjectMeta{Name: "testapp"},
+		Spec: v1alpha1.ApplicationSpec{
+			Sources: []v1alpha1.ApplicationSource{
+				{
+					Chart: "my-app",
+					Helm: &v1alpha1.ApplicationSourceHelm{
+						ReleaseName: "my-app",
+						ValueFiles:  []string{"$values/some/dir/values.yaml"},
+						Parameters: []v1alpha1.HelmParameter{
+							{Name: "images.app.repository", Value: "myapp", ForceString: true},
+							{Name: "images.app.tag", Value: "v2.0.0", ForceString: true},
+							{Name: "images.sidecar.tag", Value: "v2.0.0", ForceString: true},
+						},
+					},
+					RepoURL:        "https://example.com/example",
+					TargetRevision: "main",
+				},
+				{Ref: "values", RepoURL: "https://example.com/example2", TargetRevision: "main"},
+			},
+		},
+		Status: v1alpha1.ApplicationStatus{
+			SourceTypes: []v1alpha1.ApplicationSourceType{v1alpha1.ApplicationSourceTypeHelm, ""},
+			Summary:     v1alpha1.ApplicationSummary{Images: []string{"myapp:v1.0.0"}},
+		},
+	}
+
+	imApp := NewImage(image.NewFromIdentifier("app=myapp"))
+	imApp.HelmImageName = "images.app.repository"
+	imApp.HelmImageTag = "images.app.tag"
+	// sidecar: track only the tag, whose key exists; reuse an existing name key
+	// so no key needs creating.
+	imSidecar := NewImage(image.NewFromIdentifier("sidecar=myapp"))
+	imSidecar.HelmImageName = "images.app.repository"
+	imSidecar.HelmImageTag = "images.sidecar.tag"
+
+	applicationImages := &ApplicationImages{
+		Application:     app,
+		Images:          ImageList{imApp, imSidecar},
+		WriteBackConfig: &WriteBackConfig{Target: "./test-values.yaml"},
+	}
+
+	out, err := marshalParamsOverride(context.Background(), applicationImages, originalData)
+	require.NoError(t, err)
+	assert.Equal(t, expected, string(out), "in-place patch should preserve formatting byte-for-byte")
+}
+
+// TestMarshalParamsOverride_PreservesBlockScalars verifies that updating a tag
+// does not corrupt an unrelated multiline block scalar (with its own blank
+// lines) elsewhere in the file.
+func TestMarshalParamsOverride_PreservesBlockScalars(t *testing.T) {
+	originalData := []byte(`config:
+  # a multiline message with an internal blank line
+  motd: |
+    Welcome to the app.
+
+    Please log in.
+  image:
+    repository: myapp
+    tag: v1.0.0
+`)
+
+	expected := `config:
+  # a multiline message with an internal blank line
+  motd: |
+    Welcome to the app.
+
+    Please log in.
+  image:
+    repository: myapp
+    tag: v2.0.0
+`
+
+	app := v1alpha1.Application{
+		ObjectMeta: v1.ObjectMeta{Name: "testapp"},
+		Spec: v1alpha1.ApplicationSpec{
+			Sources: []v1alpha1.ApplicationSource{
+				{
+					Chart: "my-app",
+					Helm: &v1alpha1.ApplicationSourceHelm{
+						ReleaseName: "my-app",
+						ValueFiles:  []string{"$values/some/dir/values.yaml"},
+						Parameters: []v1alpha1.HelmParameter{
+							{Name: "config.image.repository", Value: "myapp", ForceString: true},
+							{Name: "config.image.tag", Value: "v2.0.0", ForceString: true},
+						},
+					},
+					RepoURL:        "https://example.com/example",
+					TargetRevision: "main",
+				},
+				{Ref: "values", RepoURL: "https://example.com/example2", TargetRevision: "main"},
+			},
+		},
+		Status: v1alpha1.ApplicationStatus{
+			SourceTypes: []v1alpha1.ApplicationSourceType{v1alpha1.ApplicationSourceTypeHelm, ""},
+			Summary:     v1alpha1.ApplicationSummary{Images: []string{"myapp:v1.0.0"}},
+		},
+	}
+
+	im := NewImage(image.NewFromIdentifier("app=myapp"))
+	im.HelmImageName = "config.image.repository"
+	im.HelmImageTag = "config.image.tag"
+
+	applicationImages := &ApplicationImages{
+		Application:     app,
+		Images:          ImageList{im},
+		WriteBackConfig: &WriteBackConfig{Target: "./test-values.yaml"},
+	}
+
+	out, err := marshalParamsOverride(context.Background(), applicationImages, originalData)
+	require.NoError(t, err)
+	assert.Equal(t, expected, string(out), "block scalar and its internal blank line must be preserved")
+}

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -7043,3 +7043,46 @@ func TestMarshalParamsOverride_PreservesBlockScalars(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, expected, string(out), "block scalar and its internal blank line must be preserved")
 }
+
+// TestIsSafePlainScalar covers the values that may be patched in place as
+// unquoted plain scalars versus those that must fall back to re-marshalling
+// (so they get quoted). In particular, strings a YAML parser would resolve as
+// a number, bool or null must be rejected.
+func TestIsSafePlainScalar(t *testing.T) {
+	safe := []string{"v1.0.0", "myapp", "1.2.3", "sha256-abc", "release-2024"}
+	for _, s := range safe {
+		assert.True(t, isSafePlainScalar(s), "%q should be safe to write unquoted", s)
+	}
+
+	unsafe := []string{
+		"",                   // empty
+		"1.20", "16", "0755", // numbers (would round-trip as int/float)
+		"true", "false", // 1.2 booleans
+		"yes", "no", "on", "off", "y", "n", // 1.1 booleans
+		"null", "~", // null
+		"a: b",                                  // mapping-like
+		"tag #1",                                // trailing-comment-like
+		"-latest", "*anchor", "&anchor", "@ref", // reserved leading chars
+	}
+	for _, s := range unsafe {
+		assert.False(t, isSafePlainScalar(s), "%q should fall back to re-marshalling", s)
+	}
+}
+
+// TestResolveHelmScalarNode_ArrayIndexMismatch verifies that requesting an
+// array index against a node that is not a sequence fails to resolve (rather
+// than silently ignoring the index and patching an unrelated node), matching
+// setHelmValue's stricter behavior.
+func TestResolveHelmScalarNode_ArrayIndexMismatch(t *testing.T) {
+	var root yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte("foo:\n  tag: v1.0.0\n"), &root))
+
+	// foo is a mapping, not a sequence, so "foo[2].tag" must not resolve.
+	_, err := resolveHelmScalarNode(&root, "foo[2].tag")
+	assert.Error(t, err, "index against a non-sequence node should not resolve")
+
+	// sanity check: the plain nested path still resolves.
+	node, err := resolveHelmScalarNode(&root, "foo.tag")
+	require.NoError(t, err)
+	assert.Equal(t, "v1.0.0", node.Value)
+}


### PR DESCRIPTION
This is a follow-up to the now-closed #1489 (and the earlier #1166), taking a smaller, more surgical approach to the same problem: preserving formatting when a Helm values file is used as the git write-back target.

Currently the values file is unmarshalled into a YAML node tree, mutated, and re-marshalled. Comments survive, but blank lines are dropped, inline-comment alignment is collapsed, and merge keys are rewritten (`<<` becomes `!!merge <<`). Instead of introducing a new YAML values abstraction, this PR collects the parameter updates and attempts an in-place text patch: when every update targets an existing plain scalar, only that value's text is rewritten at its source line/column and every other byte is left untouched. If any key must be created, or a value can't be safely written as a plain scalar, it falls back to the existing re-marshalling path, so behavior is unchanged for those cases.

Given this input:

<details><summary>Input</summary>

```yaml
# This is a header comment describing the values file
# It spans multiple lines

# Global settings section
global:
  # Environment configuration
  environment: production
  debug: false

# Image configuration with anchors
images:
  # Primary application image
  app: &app-image
    repository: myapp
    tag: v1.0.0  # Current version
    pullPolicy: IfNotPresent

  # Sidecar image using alias
  sidecar:
    <<: *app-image
    tag: v1.0.0

# Database settings
database:
  host: localhost
  port: 5432

  # Connection pool settings
  pool:
    minSize: 5
    maxSize: 20
```
</details>

bumping the images to `v2.0.0`:

<details><summary>Current update result</summary>

```yaml
# This is a header comment describing the values file
# It spans multiple lines

# Global settings section
global:
  # Environment configuration
  environment: production
  debug: false
# Image configuration with anchors
images:
  # Primary application image
  app: &app-image
    repository: myapp
    tag: v2.0.0 # Current version
    pullPolicy: IfNotPresent
  # Sidecar image using alias
  sidecar:
    !!merge <<: *app-image
    tag: v2.0.0
# Database settings
database:
  host: localhost
  port: 5432
  # Connection pool settings
  pool:
    minSize: 5
    maxSize: 20
```
</details>

<details><summary>New update result</summary>

```yaml
# This is a header comment describing the values file
# It spans multiple lines

# Global settings section
global:
  # Environment configuration
  environment: production
  debug: false

# Image configuration with anchors
images:
  # Primary application image
  app: &app-image
    repository: myapp
    tag: v2.0.0  # Current version
    pullPolicy: IfNotPresent

  # Sidecar image using alias
  sidecar:
    <<: *app-image
    tag: v2.0.0

# Database settings
database:
  host: localhost
  port: 5432

  # Connection pool settings
  pool:
    minSize: 5
    maxSize: 20
```
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Helm parameter updates to better preserve existing YAML formatting (comments, spacing, indentation, anchors/aliases) and multiline blocks.
  - Updates are now applied directly to the targeted scalar values when it’s safe, reducing unrelated formatting changes.
  - If in-place rewriting isn’t possible (for example, quoted/non-safe scalars or mismatched paths), the update automatically falls back to the prior re-rendering behavior.
  - Expanded test coverage to verify formatting preservation and safe indexed/key-path resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->