### PR TITLE
feat(pr): skip git clone, checkout, commit and PR/MR creation if it already exists in the remote github or gitlab

### DIFF
--- a/docs/basics/update-methods.md
+++ b/docs/basics/update-methods.md
@@ -471,9 +471,9 @@ of pushing directly to the tracking branch, Argo CD Image Updater:
 If a pull request for the same head → base pair already exists, the controller
 treats the situation as a successful no-op and does not open a duplicate.
 When reconciling, the controller first queries the SCM provider for an existing
-open PR before cloning the repository. If one is found, the entire git clone,
-commit, push, and PR creation cycle is skipped, reducing unnecessary work while
-a PR is pending review.
+open PR/MR before cloning the repository. If one is found, the entire git clone,
+commit, push, and PR/MR creation cycle is skipped, reducing unnecessary work
+while an open PR/MR already exists.
 
 #### When to use Pull Request mode
 

--- a/docs/basics/update-methods.md
+++ b/docs/basics/update-methods.md
@@ -470,6 +470,10 @@ of pushing directly to the tracking branch, Argo CD Image Updater:
 
 If a pull request for the same head → base pair already exists, the controller
 treats the situation as a successful no-op and does not open a duplicate.
+When reconciling, the controller first queries the SCM provider for an existing
+open PR before cloning the repository. If one is found, the entire git clone,
+commit, push, and PR creation cycle is skipped, reducing unnecessary work while
+a PR is pending review.
 
 #### When to use Pull Request mode
 

--- a/pkg/argocd/git.go
+++ b/pkg/argocd/git.go
@@ -232,7 +232,7 @@ func commitChangesGit(ctx context.Context, applicationImages *ApplicationImages,
 
 	// Set custom pushBranch name for PR/MR mode
 	if wbc.PRProvider > 0 {
-		customTemplate := "image-updater-{{.TargetKey}}-{{.SHA256}}"
+		customTemplate := PRBranchTemplate
 		logCtx.Tracef("setting git push branch for PR/MR mode using custom template '%s'", customTemplate)
 		pushBranch = TemplateBranchName(ctx, customTemplate, app.Namespace, app.Name, wbc.WriteBackTargetKey(), changeList)
 		if pushBranch == "" {

--- a/pkg/argocd/mr_gitlab.go
+++ b/pkg/argocd/mr_gitlab.go
@@ -62,8 +62,15 @@ func (g *GitLabMRService) create(ctx context.Context) error {
 // list returns true if there is already an open MR from pushBranch into
 // checkOutBranch.
 func (g *GitLabMRService) list(ctx context.Context, checkOutBranch, pushBranch string) (bool, error) {
-	// TODO: implement MR listing for idempotency check
-	return false, nil
+	mrs, _, err := g.client.MergeRequests.ListProjectMergeRequests(g.projectID, &gitlab.ListProjectMergeRequestsOptions{
+		SourceBranch: gitlab.Ptr(pushBranch),
+		TargetBranch: gitlab.Ptr(checkOutBranch),
+		State:        gitlab.Ptr("opened"),
+	}, gitlab.WithContext(ctx))
+	if err != nil {
+		return false, fmt.Errorf("could not list MRs for %s: %w", g.projectID, err)
+	}
+	return len(mrs) > 0, nil
 }
 
 // NewGitLabMRService builds a GitLabMRService from the resolved write-back config

--- a/pkg/argocd/mr_gitlab.go
+++ b/pkg/argocd/mr_gitlab.go
@@ -59,9 +59,9 @@ func (g *GitLabMRService) create(ctx context.Context) error {
 	return nil
 }
 
-// list returns true if there is already an open MR from pushBranch into
+// exists returns true if there is already an open MR from pushBranch into
 // checkOutBranch.
-func (g *GitLabMRService) list(ctx context.Context, checkOutBranch, pushBranch string) (bool, error) {
+func (g *GitLabMRService) exists(ctx context.Context, checkOutBranch, pushBranch string) (bool, error) {
 	mrs, _, err := g.client.MergeRequests.ListProjectMergeRequests(g.projectID, &gitlab.ListProjectMergeRequestsOptions{
 		SourceBranch: gitlab.Ptr(pushBranch),
 		TargetBranch: gitlab.Ptr(checkOutBranch),

--- a/pkg/argocd/mr_gitlab_test.go
+++ b/pkg/argocd/mr_gitlab_test.go
@@ -247,6 +247,77 @@ func Test_GitLabMRService_create(t *testing.T) {
 	}
 }
 
+func Test_GitLabMRService_list(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name       string
+		handler    http.HandlerFunc
+		wantExists bool
+		wantErrMsg string
+	}{
+		{
+			name: "no open MRs — returns false",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, "image-updater-branch", r.URL.Query().Get("source_branch"))
+				assert.Equal(t, "main", r.URL.Query().Get("target_branch"))
+				assert.Equal(t, "opened", r.URL.Query().Get("state"))
+
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode([]map[string]any{})
+			},
+			wantExists: false,
+		},
+		{
+			name: "one open MR — returns true",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode([]map[string]any{
+					{"iid": 1},
+				})
+			},
+			wantExists: true,
+		},
+		{
+			name: "multiple open MRs — returns true",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode([]map[string]any{
+					{"iid": 1},
+					{"iid": 2},
+				})
+			},
+			wantExists: true,
+		},
+		{
+			name: "API error — returns error",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			wantErrMsg: "could not list MRs for group/repo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			svc := newTestGitLabMRService(server, nil)
+			exists, err := svc.list(ctx, "main", "image-updater-branch")
+
+			if tt.wantErrMsg != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrMsg)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantExists, exists)
+			}
+		})
+	}
+}
+
 func Test_NewGitLabMRService(t *testing.T) {
 	ctx := context.Background()
 

--- a/pkg/argocd/mr_gitlab_test.go
+++ b/pkg/argocd/mr_gitlab_test.go
@@ -247,7 +247,7 @@ func Test_GitLabMRService_create(t *testing.T) {
 	}
 }
 
-func Test_GitLabMRService_list(t *testing.T) {
+func Test_GitLabMRService_exists(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
@@ -305,7 +305,7 @@ func Test_GitLabMRService_list(t *testing.T) {
 			defer server.Close()
 
 			svc := newTestGitLabMRService(server, nil)
-			exists, err := svc.list(ctx, "main", "image-updater-branch")
+			exists, err := svc.exists(ctx, "main", "image-updater-branch")
 
 			if tt.wantErrMsg != "" {
 				require.Error(t, err)

--- a/pkg/argocd/pr_github.go
+++ b/pkg/argocd/pr_github.go
@@ -87,9 +87,9 @@ func isAlreadyExistsError(err error) bool {
 	return false
 }
 
-// list returns true if there is already an open PR from pushBranch into
+// exists returns true if there is already an open PR from pushBranch into
 // checkOutBranch.
-func (g *GithubPRService) list(ctx context.Context, checkOutBranch, pushBranch string) (bool, error) {
+func (g *GithubPRService) exists(ctx context.Context, checkOutBranch, pushBranch string) (bool, error) {
 	prs, _, err := g.client.PullRequests.List(ctx, g.owner, g.repo, &github.PullRequestListOptions{
 		Head:  g.owner + ":" + pushBranch,
 		Base:  checkOutBranch,

--- a/pkg/argocd/pr_github.go
+++ b/pkg/argocd/pr_github.go
@@ -90,8 +90,15 @@ func isAlreadyExistsError(err error) bool {
 // list returns true if there is already an open PR from pushBranch into
 // checkOutBranch.
 func (g *GithubPRService) list(ctx context.Context, checkOutBranch, pushBranch string) (bool, error) {
-	// TODO: implement PR listing for idempotency check
-	return false, nil
+	prs, _, err := g.client.PullRequests.List(ctx, g.owner, g.repo, &github.PullRequestListOptions{
+		Head:  g.owner + ":" + pushBranch,
+		Base:  checkOutBranch,
+		State: "open",
+	})
+	if err != nil {
+		return false, fmt.Errorf("could not list PRs for %s/%s: %w", g.owner, g.repo, err)
+	}
+	return len(prs) > 0, nil
 }
 
 // NewGithubPRService builds a GithubPRService from the resolved write-back config

--- a/pkg/argocd/pr_github_test.go
+++ b/pkg/argocd/pr_github_test.go
@@ -273,6 +273,77 @@ func Test_GithubPRService_create(t *testing.T) {
 	}
 }
 
+func Test_GithubPRService_list(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name       string
+		handler    http.HandlerFunc
+		wantExists bool
+		wantErrMsg string
+	}{
+		{
+			name: "no open PRs — returns false",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, "org:image-updater-branch", r.URL.Query().Get("head"))
+				assert.Equal(t, "main", r.URL.Query().Get("base"))
+				assert.Equal(t, "open", r.URL.Query().Get("state"))
+
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode([]*github.PullRequest{})
+			},
+			wantExists: false,
+		},
+		{
+			name: "one open PR — returns true",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode([]*github.PullRequest{
+					{Number: github.Ptr(42)},
+				})
+			},
+			wantExists: true,
+		},
+		{
+			name: "multiple open PRs — returns true",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode([]*github.PullRequest{
+					{Number: github.Ptr(42)},
+					{Number: github.Ptr(43)},
+				})
+			},
+			wantExists: true,
+		},
+		{
+			name: "API error — returns error",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			wantErrMsg: "could not list PRs for org/repo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			svc := newTestGithubPRService(server, nil)
+			exists, err := svc.list(ctx, "main", "image-updater-branch")
+
+			if tt.wantErrMsg != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrMsg)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantExists, exists)
+			}
+		})
+	}
+}
+
 func Test_NewGithubPRService(t *testing.T) {
 	ctx := context.Background()
 

--- a/pkg/argocd/pr_github_test.go
+++ b/pkg/argocd/pr_github_test.go
@@ -273,7 +273,7 @@ func Test_GithubPRService_create(t *testing.T) {
 	}
 }
 
-func Test_GithubPRService_list(t *testing.T) {
+func Test_GithubPRService_exists(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
@@ -331,7 +331,7 @@ func Test_GithubPRService_list(t *testing.T) {
 			defer server.Close()
 
 			svc := newTestGithubPRService(server, nil)
-			exists, err := svc.list(ctx, "main", "image-updater-branch")
+			exists, err := svc.exists(ctx, "main", "image-updater-branch")
 
 			if tt.wantErrMsg != "" {
 				require.Error(t, err)

--- a/pkg/argocd/pr_service.go
+++ b/pkg/argocd/pr_service.go
@@ -34,9 +34,9 @@ type PullRequestService interface {
 	// create opens a new pull/merge request using the metadata stored in the
 	// service at construction time (title, head, base, body).
 	create(ctx context.Context) error
-	// list returns true if an open PR from pushBranch → checkOutBranch already
+	// exists returns true if an open PR from pushBranch → checkOutBranch already
 	// exists, preventing duplicate PR creation on repeated reconciliation cycles.
-	list(ctx context.Context, checkOutBranch, pushBranch string) (bool, error)
+	exists(ctx context.Context, checkOutBranch, pushBranch string) (bool, error)
 }
 
 // PullRequest holds the metadata required to open a pull/merge request.
@@ -209,7 +209,7 @@ func skipIfPRExists(ctx context.Context, wbc *WriteBackConfig, tokenProvider git
 		return false, svcErr
 	}
 
-	exists, err := svc.list(ctx, checkOutBranch, pushBranch)
+	exists, err := svc.exists(ctx, checkOutBranch, pushBranch)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/argocd/pr_service.go
+++ b/pkg/argocd/pr_service.go
@@ -23,6 +23,11 @@ const (
 	PRProviderGitLab
 )
 
+// PRBranchTemplate is the Go template used to produce a deterministic head
+// branch name for pull/merge requests. It is shared between commitChangesGit
+// (which creates the branch) and skipIfPRExists (which checks for it early).
+const PRBranchTemplate = "image-updater-{{.TargetKey}}-{{.SHA256}}"
+
 // PullRequestService is implemented by each SCM provider that supports
 // opening pull/merge requests.
 type PullRequestService interface {
@@ -94,7 +99,14 @@ func buildPullRequest(ctx context.Context, wbc *WriteBackConfig, appNamespace, a
 // branch via commitChangesGit (which also populates wbc.PullRequest), then opens
 // a pull/merge request from head → base. The provider and credential checks run
 // first so configuration errors are caught before an orphaned branch is pushed.
+//
+// Before cloning the repository, commitChangesPR attempts to resolve the head
+// and base branch names without a git client and queries the SCM provider for
+// an existing open PR. When one is found the entire clone/marshal/push cycle
+// is skipped, avoiding unnecessary work on every reconciliation while a PR is
+// pending review.
 func commitChangesPR(ctx context.Context, applicationImages *ApplicationImages, changeList []ChangeEntry, write changeWriter) error {
+	logCtx := log.LoggerFromContext(ctx)
 	app := applicationImages.Application
 	wbc := applicationImages.WriteBackConfig
 
@@ -109,6 +121,21 @@ func commitChangesPR(ctx context.Context, applicationImages *ApplicationImages, 
 	tokenProvider, ok := creds.(git.SCMTokenProvider)
 	if !ok {
 		return fmt.Errorf("credentials type %T do not support PR creation (use HTTPS or GitHub App credentials)", creds)
+	}
+
+	// Try to detect an existing open PR before cloning and pushing to avoid
+	// unnecessary git clone, override marshalling, commit, push, and API
+	// calls on every reconciliation cycle while a PR is pending review.
+	checkOutBranch := wbc.GitBranch
+	if checkOutBranch == "" {
+		checkOutBranch = getWriteBackBranch(ctx, &app, wbc)
+	}
+	if checkOutBranch != "" && checkOutBranch != "HEAD" {
+		if skipped, skipErr := skipIfPRExists(ctx, wbc, tokenProvider, checkOutBranch, app.Namespace, app.Name, changeList); skipErr != nil {
+			logCtx.Warnf("could not check for existing PR, proceeding with update: %v", skipErr)
+		} else if skipped {
+			return nil
+		}
 	}
 
 	// Push the image update commit to the head branch first.
@@ -153,4 +180,42 @@ func commitChangesPR(ctx context.Context, applicationImages *ApplicationImages, 
 	default:
 		return fmt.Errorf("unsupported PR provider: %d", wbc.PRProvider)
 	}
+}
+
+// skipIfPRExists resolves the push branch name from the template and queries
+// the SCM provider for an open PR from pushBranch → checkOutBranch. It returns
+// (true, nil) when an open PR is found and the caller should skip the update.
+// On any error it returns (false, err) so the caller can log a warning and
+// fall through to the normal code path.
+func skipIfPRExists(ctx context.Context, wbc *WriteBackConfig, tokenProvider git.SCMTokenProvider, checkOutBranch, appNamespace, appName string, changeList []ChangeEntry) (bool, error) {
+	logCtx := log.LoggerFromContext(ctx)
+
+	pushBranch := TemplateBranchName(ctx, PRBranchTemplate, appNamespace, appName, wbc.WriteBackTargetKey(), changeList)
+	if pushBranch == "" {
+		return false, fmt.Errorf("could not compute push branch name from template")
+	}
+
+	var svc PullRequestService
+	var svcErr error
+	switch wbc.PRProvider {
+	case PRProviderGitHub:
+		svc, svcErr = NewGithubPRService(ctx, wbc, tokenProvider)
+	case PRProviderGitLab:
+		svc, svcErr = NewGitLabMRService(ctx, wbc, tokenProvider)
+	default:
+		return false, fmt.Errorf("unsupported PR provider: %d", wbc.PRProvider)
+	}
+	if svcErr != nil {
+		return false, svcErr
+	}
+
+	exists, err := svc.list(ctx, checkOutBranch, pushBranch)
+	if err != nil {
+		return false, err
+	}
+	if exists {
+		logCtx.Infof("open PR from %q to %q already exists, skipping update", pushBranch, checkOutBranch)
+		return true, nil
+	}
+	return false, nil
 }

--- a/pkg/argocd/pr_service_test.go
+++ b/pkg/argocd/pr_service_test.go
@@ -248,6 +248,12 @@ func Test_commitChangesPR(t *testing.T) {
 
 	t.Run("GitHub: PR created successfully", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodGet {
+				// list: no existing PRs
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode([]*gogithub.PullRequest{})
+				return
+			}
 			assert.Equal(t, http.MethodPost, r.Method)
 			w.WriteHeader(http.StatusCreated)
 			_ = json.NewEncoder(w).Encode(gogithub.PullRequest{
@@ -272,11 +278,14 @@ func Test_commitChangesPR(t *testing.T) {
 
 	t.Run("GitHub: PR already exists — treated as no-op, no error", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusUnprocessableEntity)
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"message": "Validation Failed",
-				"errors":  []map[string]string{{"message": "A pull request already exists for org:image-updater-branch."}},
-			})
+			if r.Method == http.MethodGet {
+				// list: an existing open PR
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode([]*gogithub.PullRequest{{Number: gogithub.Ptr(42)}})
+				return
+			}
+			// create should not be reached because list found an existing PR
+			t.Error("create should not be called when list finds an existing PR")
 		}))
 		defer server.Close()
 
@@ -295,6 +304,12 @@ func Test_commitChangesPR(t *testing.T) {
 
 	t.Run("GitHub: create fails with 422", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodGet {
+				// list: no existing PRs
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode([]*gogithub.PullRequest{})
+				return
+			}
 			w.WriteHeader(http.StatusUnprocessableEntity)
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"message": "Validation Failed",
@@ -321,6 +336,12 @@ func Test_commitChangesPR(t *testing.T) {
 
 	t.Run("GitLab: MR created successfully", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodGet {
+				// list: no existing MRs
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode([]map[string]any{})
+				return
+			}
 			assert.Equal(t, http.MethodPost, r.Method)
 			w.WriteHeader(http.StatusCreated)
 			_ = json.NewEncoder(w).Encode(map[string]any{
@@ -345,10 +366,14 @@ func Test_commitChangesPR(t *testing.T) {
 
 	t.Run("GitLab: MR already exists — treated as no-op, no error", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusConflict)
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"message": []string{"Another open merge request already exists for this source branch: !1"},
-			})
+			if r.Method == http.MethodGet {
+				// list: an existing open MR
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode([]map[string]any{{"iid": 1}})
+				return
+			}
+			// create should not be reached because list found an existing MR
+			t.Error("create should not be called when list finds an existing MR")
 		}))
 		defer server.Close()
 
@@ -367,6 +392,12 @@ func Test_commitChangesPR(t *testing.T) {
 
 	t.Run("GitLab: create fails with 422", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodGet {
+				// list: no existing MRs
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode([]map[string]any{})
+				return
+			}
 			w.WriteHeader(http.StatusUnprocessableEntity)
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"message": "some validation error",

--- a/pkg/argocd/pr_service_test.go
+++ b/pkg/argocd/pr_service_test.go
@@ -249,7 +249,7 @@ func Test_commitChangesPR(t *testing.T) {
 	t.Run("GitHub: PR created successfully", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.Method == http.MethodGet {
-				// list: no existing PRs
+				// exists: no existing PRs
 				w.WriteHeader(http.StatusOK)
 				_ = json.NewEncoder(w).Encode([]*gogithub.PullRequest{})
 				return
@@ -279,13 +279,13 @@ func Test_commitChangesPR(t *testing.T) {
 	t.Run("GitHub: PR already exists — treated as no-op, no error", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.Method == http.MethodGet {
-				// list: an existing open PR
+				// exists: an existing open PR
 				w.WriteHeader(http.StatusOK)
 				_ = json.NewEncoder(w).Encode([]*gogithub.PullRequest{{Number: gogithub.Ptr(42)}})
 				return
 			}
-			// create should not be reached because list found an existing PR
-			t.Error("create should not be called when list finds an existing PR")
+			// create should not be reached because exists found an existing PR
+			t.Error("create should not be called when exists finds an existing PR")
 		}))
 		defer server.Close()
 
@@ -305,7 +305,7 @@ func Test_commitChangesPR(t *testing.T) {
 	t.Run("GitHub: create fails with 422", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.Method == http.MethodGet {
-				// list: no existing PRs
+				// exists: no existing PRs
 				w.WriteHeader(http.StatusOK)
 				_ = json.NewEncoder(w).Encode([]*gogithub.PullRequest{})
 				return
@@ -337,7 +337,7 @@ func Test_commitChangesPR(t *testing.T) {
 	t.Run("GitLab: MR created successfully", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.Method == http.MethodGet {
-				// list: no existing MRs
+				// exists: no existing MRs
 				w.WriteHeader(http.StatusOK)
 				_ = json.NewEncoder(w).Encode([]map[string]any{})
 				return
@@ -367,13 +367,13 @@ func Test_commitChangesPR(t *testing.T) {
 	t.Run("GitLab: MR already exists — treated as no-op, no error", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.Method == http.MethodGet {
-				// list: an existing open MR
+				// exists: an existing open MR
 				w.WriteHeader(http.StatusOK)
 				_ = json.NewEncoder(w).Encode([]map[string]any{{"iid": 1}})
 				return
 			}
-			// create should not be reached because list found an existing MR
-			t.Error("create should not be called when list finds an existing MR")
+			// create should not be reached because exists found an existing MR
+			t.Error("create should not be called when exists finds an existing MR")
 		}))
 		defer server.Close()
 
@@ -393,7 +393,7 @@ func Test_commitChangesPR(t *testing.T) {
 	t.Run("GitLab: create fails with 422", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.Method == http.MethodGet {
-				// list: no existing MRs
+				// exists: no existing MRs
 				w.WriteHeader(http.StatusOK)
 				_ = json.NewEncoder(w).Encode([]map[string]any{})
 				return


### PR DESCRIPTION
With this feature, image-updater with git pull request write-back-method creates a PR during the first reconciliation, and skips the PR creation during the second reconciliation if the first PR is still open:

INFO[0033] created PR #1 "image-updater-8fbe32c5-e40015ce7a393fce349aba39fdad24288eefd4db2e1d57ab850cdd5fbedcc38c" → "main": https://github.com/chengfang/image-updater-examples/pull/1  application=argocd/kustomize-helmvalues controller=imageupdater controllerGroup=argocd-image-updater.argoproj.io controllerKind=ImageUpdater imageUpdater_name=kustomize-helmvalues imageUpdater_namespace=argocd logger=reconcile
...
INFO[0154] open PR from "image-updater-8fbe32c5-e40015ce7a393fce349aba39fdad24288eefd4db2e1d57ab850cdd5fbedcc38c" to "main" already exists, skipping update  application=argocd/kustomize-helmvalues controller=imageupdater controllerGroup=argocd-image-updater.argoproj.io controllerKind=ImageUpdater imageUpdater_name=kustomize-helmvalues imageUpdater_namespace=argocd logger=reconcile


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Prevents duplicate open pull requests and merge requests by checking for an existing match before cloning/committing/pushing.
  * Introduces configurable deterministic branch naming for generated PR/MR heads.
* **Bug Fixes**
  * Improves idempotency checks by using real GitHub/GitLab lookups, including better error reporting when listing requests fails.
* **Documentation**
  * Updates guidance for Git pull request write-back reconciliation behavior (skips work when a PR/MR already exists).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->