### PR TITLE
fix(docs): use current values of updateStrategy (semver, newest-build, digest and alphabetical) and de-emphasize deprecated values

### DIFF
--- a/config/samples/argocd-image-updater_v1alpha1_imageupdater.yaml
+++ b/config/samples/argocd-image-updater_v1alpha1_imageupdater.yaml
@@ -32,7 +32,7 @@ spec:
           imageName: "test:1.1.0"
     - namePattern: "app-002"
       commonUpdateSettings:
-        updateStrategy: "latest" # Default strategy if not specified per image
+        updateStrategy: "newest-build" # Default strategy if not specified per image
         forceUpdate: true
         allowTags: "regexp:^[0-9a-f]{7}$"
         ignoreTags: [ "latest", "master" ]
@@ -84,7 +84,7 @@ spec:
         - alias: "nginx"
           imageName: "nginx:1.17.10"
       commonUpdateSettings:
-        updateStrategy: "latest" # Default strategy if not specified per image
+        updateStrategy: "newest-build" # Default strategy if not specified per image
         forceUpdate: true
         allowTags: "regexp:^[0-9a-f]{7}$"
         ignoreTags: [ "latest", "master" ]

--- a/docs/basics/update-strategies.md
+++ b/docs/basics/update-strategies.md
@@ -268,15 +268,6 @@ images:
   - alias: "alias"
     imageName: "some/image"
     commonUpdateSettings:
-      updateStrategy: "name"
-```
-or
-
-```yaml
-images:
-  - alias: "alias"
-    imageName: "some/image"
-    commonUpdateSettings:
       updateStrategy: "alphabetical"
 ```
 

--- a/docs/basics/update-strategies.md
+++ b/docs/basics/update-strategies.md
@@ -25,9 +25,9 @@ The following update strategies are currently supported:
 
 * [semver](#strategy-semver) - Update to the latest version of an image
   considering semantic versioning constraints
-* [latest/newest-build](#strategy-latest) - Update to the most recently built image found in a registry
+* [newest-build](#strategy-latest) - Update to the most recently built image found in a registry (deprecated alias: `latest` — still accepted but may be removed in a future release)
 * [digest](#strategy-digest) - Update to the latest version of a given version (tag), using the tag's SHA digest
-* [name/alphabetical](#strategy-name) - Sorts tags alphabetically and update to the one with the highest cardinality
+* [alphabetical](#strategy-name) - Sorts tags alphabetically and update to the one with the highest cardinality (deprecated alias: `name` — still accepted but may be removed in a future release)
 
 !!!warning "Renamed image update strategies"
     The `latest` strategy has been renamed to `newest-build`, and `name` strategy has been renamed to `alphabetical`. 
@@ -130,7 +130,7 @@ a semantic version when using the `semver` update strategy.
 
 
 
-### <a name="strategy-latest"></a>latest/newest-build - Update to the most recently built image
+### <a name="strategy-latest"></a>newest-build - Update to the most recently built image
 
 
 !!!warning "Renamed image update strategies"
@@ -152,7 +152,7 @@ a semantic version when using the `semver` update strategy.
     value), the `latest` or `newest-build` strategy will not be able to determine which tag to
     update to.
 
-Strategy name: `latest` or `newest-build`
+Strategy name: `newest-build` (deprecated alias: `latest`)
 
 Basic configuration:
 
@@ -259,7 +259,7 @@ images:
     Detected usage of `name` will result in a warning message within the image-updater controller logs.
 
 
-Strategy name: `name` or `alphabetical`
+Strategy name: `alphabetical` (deprecated alias: `name`)
 
 Basic configuration:
 

--- a/docs/configuration/applications.md
+++ b/docs/configuration/applications.md
@@ -286,7 +286,7 @@ spec:
   applicationRefs:
     - namePattern: "production-*"
       commonUpdateSettings:
-        updateStrategy: "latest"  # Override for production apps
+        updateStrategy: "newest-build"  # Override for production apps
         forceUpdate: true
       images:
         - alias: "app"
@@ -311,7 +311,7 @@ spec:
         - alias: "app"
           imageName: "myregistry/myapp:1.0"
           commonUpdateSettings:
-            updateStrategy: "latest"  # Override for this specific image
+            updateStrategy: "newest-build"  # Override for this specific image
         - alias: "database"
           imageName: "postgres:13"
           # Uses global semver strategy
@@ -415,7 +415,7 @@ spec:
         matchLabels:
           environment: "production"
       commonUpdateSettings:
-        updateStrategy: "latest"
+        updateStrategy: "newest-build"
         forceUpdate: true
       writeBackConfig:
         method: "git"
@@ -443,7 +443,7 @@ spec:
 This configuration:
 
 - Sets global defaults for semver updates
-- Overrides frontend applications to use latest strategy and Git write-back
+- Overrides frontend applications to use newest-build strategy and Git write-back
 - Uses specific update strategies for individual images
 - Combines name patterns with label selectors for precise targeting
 

--- a/docs/configuration/images.md
+++ b/docs/configuration/images.md
@@ -115,8 +115,8 @@ Argo CD Image Updater can update images according to the following strategies:
 | Strategy              | Description                                                                |
 |-----------------------|----------------------------------------------------------------------------|
 | `semver`              | Update to the tag with the highest allowed semantic version                |
-| `latest/newest-build` | Update to the tag with the most recent creation date                       |
-| `name/alphabetical`   | Update to the tag with the latest entry from an alphabetically sorted list |
+| `newest-build`        | Update to the tag with the most recent creation date (deprecated alias: `latest`) |
+| `alphabetical`        | Update to the tag with the latest entry from an alphabetically sorted list (deprecated alias: `name`) |
 | `digest`              | Update to the most recent pushed version of a mutable tag                  |
 
 You can define the update strategy for each image independently by setting the
@@ -141,11 +141,11 @@ strategy `semver` will be used.
 
 !!!warning
     As of November 2020, Docker Hub has introduced pull limits for accounts on
-    the free plan and unauthenticated requests. The `latest/newest-build` update
+    the free plan and unauthenticated requests. The `newest-build` update
     strategy will perform manifest pulls for determining the most recently
     pushed tags, and these will count into your pull limits. So unless you are
     not affected by these pull limits, it is **not recommended** to use the
-    `latest/newest-build` update strategy with images hosted on Docker Hub.
+    `newest-build` update strategy with images hosted on Docker Hub.
 
 ## Filtering tags
 
@@ -702,7 +702,7 @@ update strategies and set options for images.
 
 | Field            | Type     | Default    | Description                                                                     |
 |------------------|----------|------------|---------------------------------------------------------------------------------|
-| `updateStrategy` | string   | `"semver"` | Update strategy: `semver`, `latest/newest-build`, `digest`, `name/alphabetical` |
+| `updateStrategy` | string   | `"semver"` | Update strategy: `semver`, `newest-build`, `digest`, `alphabetical`. Deprecated aliases `latest` (for `newest-build`) and `name` (for `alphabetical`) are still accepted but may be removed in a future release. |
 | `forceUpdate`    | bool     | `false`    | Force updates even if image is not currently deployed                           |
 | `allowTags`      | string   | *none*     | Regex pattern for tags to allow                                                 |
 | `ignoreTags`     | []string | *none*     | List of glob patterns for tags to ignore                                        |
@@ -797,4 +797,4 @@ Settings can be configured at multiple levels with the following precedence (hig
 3. **ImageUpdater level** - Global defaults for all applications
 
 For example, if you set `updateStrategy: "semver"` at the global level but 
-`updateStrategy: "latest"` at the image level, the image will use `"latest"`.
+`updateStrategy: "newest-build"` at the image level, the image will use `"newest-build"`.

--- a/docs/configuration/images.md
+++ b/docs/configuration/images.md
@@ -575,7 +575,7 @@ images:
   - alias: "yourtool"
     imageName: "yourorg/yourimage"
     commonUpdateSettings:
-      updateStrategy: "latest"
+      updateStrategy: "newest-build"
       allowTags: "regexp:^v1.0.0-[0-9a-zA-Z]+$"
 ```
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -42,7 +42,7 @@ spec:
         - alias: "app"
           imageName: "myapp:latest"
           commonUpdateSettings:
-            updateStrategy: "latest"  # Override for this specific image
+            updateStrategy: "newest-build"  # Override for this specific image
 ```
 
 ## ImageUpdater with Git write-back

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,8 +65,8 @@ RBAC authorization on Application resources etc. are fully supported.
   [update strategies](./basics/update-strategies.md)
     * `semver`: update to highest allowed version according to given image
     constraint,
-    * `latest/newest-build`: update to the most recently created image tag,
-    * `name/alphabetical`: update to the last tag in an alphabetically sorted list
+    * `newest-build`: update to the most recently created image tag (deprecated alias: `latest`),
+    * `alphabetical`: update to the last tag in an alphabetically sorted list (deprecated alias: `name`)
     * `digest`: update to the most recent pushed version of a mutable tag
 * Support for 
   [widely used container registries](./configuration/registries.md#supported-registries)

--- a/test/e2e/suite/003-invalid-image-specified/01-install.yaml
+++ b/test/e2e/suite/003-invalid-image-specified/01-install.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: argocd-image-updater-e2e
 spec:
   commonUpdateSettings:
-    updateStrategy: "latest"
+    updateStrategy: "newest-build"
   applicationRefs:
     - namePattern: "image-updater-003"
       images:

--- a/test/e2e/suite/005-app-wide-update-strategy/01-install.yaml
+++ b/test/e2e/suite/005-app-wide-update-strategy/01-install.yaml
@@ -72,4 +72,4 @@ spec:
         - alias: "guestbook"
           imageName: "quay.io/dkarpele/my-guestbook:latest"
           commonUpdateSettings:
-            updateStrategy: "latest"
+            updateStrategy: "newest-build"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to use `newest-build` and `alphabetical` as the primary image update strategies.
  * Marked `latest` and `name` as deprecated aliases and clarified them in strategy listings and details.
  * Revised configuration guidance and YAML examples to prefer `newest-build` over `latest`.
* **Tests**
  * Updated e2e test manifests to use `newest-build` instead of `latest`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->