### PR TITLE
feat: support custom CA certificates for registries

### DIFF
--- a/docs/configuration/registries.md
+++ b/docs/configuration/registries.md
@@ -145,6 +145,13 @@ properties are optional, unless otherwise stated:
 
     Example value: `true`
 
+  * `ca_file` - Path to a PEM-encoded CA certificate bundle to trust for this
+    registry in addition to certificates from the system trust store.
+
+    Default value: _none_
+
+    Example value: `/app/config/certs/registry-ca.pem`
+
   * `limit` - The rate limit (max. number of requests per second) to use for
     this registry, specified as integer.
 
@@ -169,7 +176,7 @@ registries:
 - name: RedHat Quay
   api_url: https://quay.io
   prefix: quay.io
-  insecure: yes
+  ca_file: /app/config/certs/quay-ca.pem
   credentials: env:REGISTRY_SECRET
 ```
 

--- a/docs/configuration/registries.md
+++ b/docs/configuration/registries.md
@@ -148,9 +148,24 @@ properties are optional, unless otherwise stated:
   * `ca_file` - Path to a PEM-encoded CA certificate bundle to trust for this
     registry in addition to certificates from the system trust store.
 
+    When `ca_file` is omitted, Image Updater also checks
+    `/app/config/tls/<registry-hostname>` so certificates mounted from Argo CD's
+    `argocd-tls-certs-cm` are discovered automatically.
+
     Default value: _none_
 
     Example value: `/app/config/certs/registry-ca.pem`
+
+  * `ca_data` - PEM-encoded CA certificate data embedded directly in the
+    registry configuration. This can be used instead of mounting a certificate
+    file.
+
+    Default value: _none_
+
+    Example value: `-----BEGIN CERTIFICATE-----...`
+
+    CA file discovery and `ca_data` processing are skipped when `insecure` is
+    set to `true`.
 
   * `limit` - The rate limit (max. number of requests per second) to use for
     this registry, specified as integer.

--- a/registry-scanner/pkg/registry/config.go
+++ b/registry-scanner/pkg/registry/config.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"context"
+	"crypto/x509"
 	"fmt"
 	"os"
 	"time"
@@ -22,6 +23,7 @@ type RegistryConfiguration struct {
 	TagSortMode string        `yaml:"tagsortmode,omitempty"`
 	Prefix      string        `yaml:"prefix,omitempty"`
 	Insecure    bool          `yaml:"insecure,omitempty"`
+	CAFile      string        `yaml:"ca_file,omitempty"`
 	DefaultNS   string        `yaml:"defaultns,omitempty"`
 	Limit       int           `yaml:"limit,omitempty"`
 	IsDefault   bool          `yaml:"default,omitempty"`
@@ -30,6 +32,36 @@ type RegistryConfiguration struct {
 // RegistryList contains multiple RegistryConfiguration items
 type RegistryList struct {
 	Items []RegistryConfiguration `yaml:"registries"`
+}
+
+func newRegistryEndpointFromConfig(config RegistryConfiguration) (*RegistryEndpoint, error) {
+	endpoint := NewRegistryEndpoint(config.Prefix, config.Name, config.ApiURL, config.Credentials, config.DefaultNS, config.Insecure, TagListSortFromString(config.TagSortMode), config.Limit, config.CredsExpire)
+	rootCAs, err := loadRootCAs(config.CAFile)
+	if err != nil {
+		return nil, fmt.Errorf("could not configure CA certificates for registry %s: %w", config.Name, err)
+	}
+	endpoint.CAFile = config.CAFile
+	endpoint.rootCAs = rootCAs
+	return endpoint, nil
+}
+
+func loadRootCAs(caFile string) (*x509.CertPool, error) {
+	rootCAs, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, fmt.Errorf("could not load system certificate pool: %w", err)
+	}
+	if caFile == "" {
+		return rootCAs, nil
+	}
+
+	certificates, err := os.ReadFile(caFile)
+	if err != nil {
+		return nil, fmt.Errorf("could not read CA file %s: %w", caFile, err)
+	}
+	if !rootCAs.AppendCertsFromPEM(certificates) {
+		return nil, fmt.Errorf("CA file %s does not contain a valid PEM certificate", caFile)
+	}
+	return rootCAs, nil
 }
 
 func clearRegistries() {
@@ -67,7 +99,10 @@ func LoadRegistryConfiguration(ctx context.Context, path string, clear bool) err
 		if tagSortMode != TagListSortUnsorted {
 			logCtx.Warnf("Registry %s has tag sort mode set to %s, meta data retrieval will be disabled for this registry.", reg.ApiURL, tagSortMode)
 		}
-		ep := NewRegistryEndpoint(reg.Prefix, reg.Name, reg.ApiURL, reg.Credentials, reg.DefaultNS, reg.Insecure, tagSortMode, reg.Limit, reg.CredsExpire)
+		ep, err := newRegistryEndpointFromConfig(reg)
+		if err != nil {
+			return err
+		}
 		if reg.IsDefault {
 			if haveDefault {
 				dep := GetDefaultRegistry(ctx)

--- a/registry-scanner/pkg/registry/config.go
+++ b/registry-scanner/pkg/registry/config.go
@@ -37,7 +37,10 @@ type RegistryList struct {
 	Items []RegistryConfiguration `yaml:"registries"`
 }
 
-var argoCDTLSCertsPath = "/app/config/tls"
+var (
+	argoCDTLSCertsPath = "/app/config/tls"
+	systemCertPool     = x509.SystemCertPool
+)
 
 func newRegistryEndpointFromConfig(config RegistryConfiguration) (*RegistryEndpoint, error) {
 	endpoint := NewRegistryEndpoint(config.Prefix, config.Name, config.ApiURL, config.Credentials, config.DefaultNS, config.Insecure, TagListSortFromString(config.TagSortMode), config.Limit, config.CredsExpire)
@@ -77,9 +80,10 @@ func loadRootCAs(caFile, caData string) (*x509.CertPool, error) {
 		return nil, nil
 	}
 
-	rootCAs, err := x509.SystemCertPool()
+	rootCAs, err := systemCertPool()
 	if err != nil {
-		return nil, fmt.Errorf("could not load system certificate pool: %w", err)
+		log.Warnf("Could not load system certificate pool, using empty pool: %v", err)
+		rootCAs = x509.NewCertPool()
 	}
 	if caData != "" && !rootCAs.AppendCertsFromPEM([]byte(caData)) {
 		return nil, fmt.Errorf("ca_data does not contain a valid PEM certificate")

--- a/registry-scanner/pkg/registry/config.go
+++ b/registry-scanner/pkg/registry/config.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
+	"net/url"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/argoproj-labs/argocd-image-updater/registry-scanner/pkg/log"
@@ -24,6 +26,7 @@ type RegistryConfiguration struct {
 	Prefix      string        `yaml:"prefix,omitempty"`
 	Insecure    bool          `yaml:"insecure,omitempty"`
 	CAFile      string        `yaml:"ca_file,omitempty"`
+	CAData      string        `yaml:"ca_data,omitempty"`
 	DefaultNS   string        `yaml:"defaultns,omitempty"`
 	Limit       int           `yaml:"limit,omitempty"`
 	IsDefault   bool          `yaml:"default,omitempty"`
@@ -34,32 +37,62 @@ type RegistryList struct {
 	Items []RegistryConfiguration `yaml:"registries"`
 }
 
+var argoCDTLSCertsPath = "/app/config/tls"
+
 func newRegistryEndpointFromConfig(config RegistryConfiguration) (*RegistryEndpoint, error) {
 	endpoint := NewRegistryEndpoint(config.Prefix, config.Name, config.ApiURL, config.Credentials, config.DefaultNS, config.Insecure, TagListSortFromString(config.TagSortMode), config.Limit, config.CredsExpire)
-	rootCAs, err := loadRootCAs(config.CAFile)
+	endpoint.CAFile = config.CAFile
+	endpoint.CAData = config.CAData
+	if config.Insecure {
+		return endpoint, nil
+	}
+
+	caFile := config.CAFile
+	if caFile == "" {
+		caFile = discoverArgoCDCAFile(config.ApiURL)
+	}
+	rootCAs, err := loadRootCAs(caFile, config.CAData)
 	if err != nil {
 		return nil, fmt.Errorf("could not configure CA certificates for registry %s: %w", config.Name, err)
 	}
-	endpoint.CAFile = config.CAFile
+	endpoint.CAFile = caFile
 	endpoint.rootCAs = rootCAs
 	return endpoint, nil
 }
 
-func loadRootCAs(caFile string) (*x509.CertPool, error) {
+func discoverArgoCDCAFile(apiURL string) string {
+	parsedURL, err := url.Parse(apiURL)
+	if err != nil || parsedURL.Hostname() == "" {
+		return ""
+	}
+	caFile := filepath.Join(argoCDTLSCertsPath, parsedURL.Hostname())
+	if _, err := os.Stat(caFile); err != nil {
+		return ""
+	}
+	return caFile
+}
+
+func loadRootCAs(caFile, caData string) (*x509.CertPool, error) {
+	if caFile == "" && caData == "" {
+		return nil, nil
+	}
+
 	rootCAs, err := x509.SystemCertPool()
 	if err != nil {
 		return nil, fmt.Errorf("could not load system certificate pool: %w", err)
 	}
-	if caFile == "" {
-		return rootCAs, nil
+	if caData != "" && !rootCAs.AppendCertsFromPEM([]byte(caData)) {
+		return nil, fmt.Errorf("ca_data does not contain a valid PEM certificate")
 	}
 
-	certificates, err := os.ReadFile(caFile)
-	if err != nil {
-		return nil, fmt.Errorf("could not read CA file %s: %w", caFile, err)
-	}
-	if !rootCAs.AppendCertsFromPEM(certificates) {
-		return nil, fmt.Errorf("CA file %s does not contain a valid PEM certificate", caFile)
+	if caFile != "" {
+		certificates, err := os.ReadFile(caFile)
+		if err != nil {
+			return nil, fmt.Errorf("could not read CA file %s: %w", caFile, err)
+		}
+		if !rootCAs.AppendCertsFromPEM(certificates) {
+			return nil, fmt.Errorf("CA file %s does not contain a valid PEM certificate", caFile)
+		}
 	}
 	return rootCAs, nil
 }

--- a/registry-scanner/pkg/registry/config_test.go
+++ b/registry-scanner/pkg/registry/config_test.go
@@ -20,6 +20,20 @@ func Test_ParseRegistryConfFromYaml(t *testing.T) {
 		assert.Len(t, regList.Items, 4)
 	})
 
+	t.Run("Parse CA file from valid YAML", func(t *testing.T) {
+		registries := `
+registries:
+- name: Private Registry
+  api_url: https://registry.example.com
+  prefix: registry.example.com
+  ca_file: /app/config/certs/registry-ca.pem
+`
+		regList, err := ParseRegistryConfiguration(registries)
+		require.NoError(t, err)
+		require.Len(t, regList.Items, 1)
+		assert.Equal(t, "/app/config/certs/registry-ca.pem", regList.Items[0].CAFile)
+	})
+
 	t.Run("Parse from invalid YAML: no name found", func(t *testing.T) {
 		registries := `
 registries:

--- a/registry-scanner/pkg/registry/config_test.go
+++ b/registry-scanner/pkg/registry/config_test.go
@@ -34,6 +34,23 @@ registries:
 		assert.Equal(t, "/app/config/certs/registry-ca.pem", regList.Items[0].CAFile)
 	})
 
+	t.Run("Parse inline CA data from valid YAML", func(t *testing.T) {
+		registries := `
+registries:
+- name: Private Registry
+  api_url: https://registry.example.com
+  prefix: registry.example.com
+  ca_data: |
+    -----BEGIN CERTIFICATE-----
+    certificate data
+    -----END CERTIFICATE-----
+`
+		regList, err := ParseRegistryConfiguration(registries)
+		require.NoError(t, err)
+		require.Len(t, regList.Items, 1)
+		assert.Contains(t, regList.Items[0].CAData, "BEGIN CERTIFICATE")
+	})
+
 	t.Run("Parse from invalid YAML: no name found", func(t *testing.T) {
 		registries := `
 registries:

--- a/registry-scanner/pkg/registry/endpoints.go
+++ b/registry-scanner/pkg/registry/endpoints.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"math"
 	"net/http"
@@ -83,6 +84,7 @@ type RegistryEndpoint struct {
 	Ping           bool
 	Credentials    string
 	Insecure       bool
+	CAFile         string
 	DefaultNS      string
 	CredsExpire    time.Duration
 	CredsUpdated   time.Time
@@ -92,6 +94,7 @@ type RegistryEndpoint struct {
 	IsDefault      bool
 	lock           sync.RWMutex
 	limit          int
+	rootCAs        *x509.CertPool
 }
 
 // registryTweaks should contain a list of registries whose settings cannot be
@@ -129,7 +132,10 @@ var credentialGroup singleflight.Group
 var transportCache = memcache.New(30*time.Minute, 10*time.Minute)
 
 func AddRegistryEndpointFromConfig(ctx context.Context, epc RegistryConfiguration) error {
-	ep := NewRegistryEndpoint(epc.Prefix, epc.Name, epc.ApiURL, epc.Credentials, epc.DefaultNS, epc.Insecure, TagListSortFromString(epc.TagSortMode), epc.Limit, epc.CredsExpire)
+	ep, err := newRegistryEndpointFromConfig(epc)
+	if err != nil {
+		return err
+	}
 	return AddRegistryEndpoint(ctx, ep)
 }
 
@@ -310,12 +316,14 @@ func (ep *RegistryEndpoint) DeepCopy() *RegistryEndpoint {
 	newEp.TagListSort = ep.TagListSort
 	newEp.Cache = cache.NewMemCache()
 	newEp.Insecure = ep.Insecure
+	newEp.CAFile = ep.CAFile
 	newEp.DefaultNS = ep.DefaultNS
 	newEp.Limiter = ep.Limiter
 	newEp.CredsExpire = ep.CredsExpire
 	newEp.CredsUpdated = ep.CredsUpdated
 	newEp.IsDefault = ep.IsDefault
 	newEp.limit = ep.limit
+	newEp.rootCAs = ep.rootCAs
 	ep.lock.RUnlock()
 	return newEp
 }
@@ -349,7 +357,15 @@ func (ep *RegistryEndpoint) GetTransport(ctx context.Context) *http.Transport {
 	logCtx.Debugf("Transport cache MISS for %s", ep.RegistryAPI)
 
 	// Create a new transport with optimized connection pool settings
-	tlsC := &tls.Config{}
+	rootCAs := ep.rootCAs
+	if rootCAs == nil {
+		var err error
+		rootCAs, err = x509.SystemCertPool()
+		if err != nil {
+			logCtx.Warnf("Could not load system certificate pool for %s: %v", ep.RegistryAPI, err)
+		}
+	}
+	tlsC := &tls.Config{RootCAs: rootCAs}
 	if ep.Insecure {
 		tlsC.InsecureSkipVerify = true
 	}

--- a/registry-scanner/pkg/registry/endpoints.go
+++ b/registry-scanner/pkg/registry/endpoints.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -85,6 +86,7 @@ type RegistryEndpoint struct {
 	Credentials    string
 	Insecure       bool
 	CAFile         string
+	CAData         string
 	DefaultNS      string
 	CredsExpire    time.Duration
 	CredsUpdated   time.Time
@@ -317,6 +319,7 @@ func (ep *RegistryEndpoint) DeepCopy() *RegistryEndpoint {
 	newEp.Cache = cache.NewMemCache()
 	newEp.Insecure = ep.Insecure
 	newEp.CAFile = ep.CAFile
+	newEp.CAData = ep.CAData
 	newEp.DefaultNS = ep.DefaultNS
 	newEp.Limiter = ep.Limiter
 	newEp.CredsExpire = ep.CredsExpire
@@ -334,13 +337,19 @@ func ClearTransportCache() {
 	transportCache.Flush()
 }
 
+func (ep *RegistryEndpoint) transportCacheKey() string {
+	caDataHash := sha256.Sum256([]byte(ep.CAData))
+	return fmt.Sprintf("%s\x00%s\x00%s\x00%t\x00%x", ep.RegistryAPI, ep.RegistryPrefix, ep.CAFile, ep.Insecure, caDataHash)
+}
+
 // GetTransport returns a transport object for this endpoint
 // Implements connection pooling and reuse to avoid creating new transports for each request
 func (ep *RegistryEndpoint) GetTransport(ctx context.Context) *http.Transport {
 	logCtx := log.LoggerFromContext(ctx)
+	cacheKey := ep.transportCacheKey()
 
 	// Check if we have a cached transport for this registry
-	if cachedTransport, found := transportCache.Get(ep.RegistryAPI); found {
+	if cachedTransport, found := transportCache.Get(cacheKey); found {
 		transport := cachedTransport.(*http.Transport)
 		logCtx.Debugf("Transport cache HIT for %s: %p", ep.RegistryAPI, transport)
 
@@ -351,21 +360,16 @@ func (ep *RegistryEndpoint) GetTransport(ctx context.Context) *http.Transport {
 
 		// Transport is stale, remove it from cache
 		logCtx.Debugf("Transport for %s is stale, removing from cache", ep.RegistryAPI)
-		transportCache.Delete(ep.RegistryAPI)
+		transportCache.Delete(cacheKey)
 	}
 
 	logCtx.Debugf("Transport cache MISS for %s", ep.RegistryAPI)
 
 	// Create a new transport with optimized connection pool settings
-	rootCAs := ep.rootCAs
-	if rootCAs == nil {
-		var err error
-		rootCAs, err = x509.SystemCertPool()
-		if err != nil {
-			logCtx.Warnf("Could not load system certificate pool for %s: %v", ep.RegistryAPI, err)
-		}
+	tlsC := &tls.Config{}
+	if ep.rootCAs != nil {
+		tlsC.RootCAs = ep.rootCAs
 	}
-	tlsC := &tls.Config{RootCAs: rootCAs}
 	if ep.Insecure {
 		tlsC.InsecureSkipVerify = true
 	}
@@ -387,7 +391,7 @@ func (ep *RegistryEndpoint) GetTransport(ctx context.Context) *http.Transport {
 	}
 
 	// Cache the transport for reuse with default expiration (30 minutes)
-	transportCache.Set(ep.RegistryAPI, transport, memcache.DefaultExpiration)
+	transportCache.Set(cacheKey, transport, memcache.DefaultExpiration)
 	logCtx.Debugf("Cached NEW transport for %s: %p", ep.RegistryAPI, transport)
 
 	return transport

--- a/registry-scanner/pkg/registry/endpoints_test.go
+++ b/registry-scanner/pkg/registry/endpoints_test.go
@@ -2,7 +2,10 @@ package registry
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -370,6 +373,32 @@ func TestGetTransport(t *testing.T) {
 		require.NoError(t, err)
 
 		client := &http.Client{Transport: endpoint.GetTransport(context.Background())}
+		response, err := client.Get(server.URL)
+		require.NoError(t, err)
+		defer response.Body.Close()
+		assert.Equal(t, http.StatusOK, response.StatusCode)
+	})
+
+	t.Run("uses custom certificates when the system pool is unavailable", func(t *testing.T) {
+		server := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			writer.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		originalSystemCertPool := systemCertPool
+		systemCertPool = func() (*x509.CertPool, error) {
+			return nil, errors.New("system certificate pool unavailable")
+		}
+		t.Cleanup(func() { systemCertPool = originalSystemCertPool })
+
+		certificate := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw})
+		rootCAs, err := loadRootCAs("", string(certificate))
+		require.NoError(t, err)
+
+		client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{
+			MinVersion: tls.VersionTLS12,
+			RootCAs:    rootCAs,
+		}}}
 		response, err := client.Get(server.URL)
 		require.NoError(t, err)
 		defer response.Body.Close()

--- a/registry-scanner/pkg/registry/endpoints_test.go
+++ b/registry-scanner/pkg/registry/endpoints_test.go
@@ -325,7 +325,7 @@ func TestGetTransport(t *testing.T) {
 
 		assert.NotNil(t, transport)
 		assert.NotNil(t, transport.TLSClientConfig)
-		assert.NotNil(t, transport.TLSClientConfig.RootCAs)
+		assert.Nil(t, transport.TLSClientConfig.RootCAs)
 		assert.False(t, transport.TLSClientConfig.InsecureSkipVerify)
 	})
 
@@ -354,6 +354,56 @@ func TestGetTransport(t *testing.T) {
 		assert.Equal(t, http.StatusOK, response.StatusCode)
 	})
 
+	t.Run("trusts certificates from inline registry CA data", func(t *testing.T) {
+		server := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			writer.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		certificate := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw})
+		endpoint, err := newRegistryEndpointFromConfig(RegistryConfiguration{
+			Name:   "private registry",
+			Prefix: "private.example.com",
+			ApiURL: server.URL,
+			CAData: string(certificate),
+		})
+		require.NoError(t, err)
+
+		client := &http.Client{Transport: endpoint.GetTransport(context.Background())}
+		response, err := client.Get(server.URL)
+		require.NoError(t, err)
+		defer response.Body.Close()
+		assert.Equal(t, http.StatusOK, response.StatusCode)
+	})
+
+	t.Run("auto-discovers Argo CD registry certificates", func(t *testing.T) {
+		server := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			writer.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		certificate := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw})
+		originalPath := argoCDTLSCertsPath
+		argoCDTLSCertsPath = t.TempDir()
+		t.Cleanup(func() { argoCDTLSCertsPath = originalPath })
+		caFile := filepath.Join(argoCDTLSCertsPath, "127.0.0.1")
+		require.NoError(t, os.WriteFile(caFile, certificate, 0600))
+
+		endpoint, err := newRegistryEndpointFromConfig(RegistryConfiguration{
+			Name:   "private registry",
+			Prefix: "private.example.com",
+			ApiURL: server.URL,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, caFile, endpoint.CAFile)
+
+		client := &http.Client{Transport: endpoint.GetTransport(context.Background())}
+		response, err := client.Get(server.URL)
+		require.NoError(t, err)
+		defer response.Body.Close()
+		assert.Equal(t, http.StatusOK, response.StatusCode)
+	})
+
 	t.Run("rejects an invalid registry CA file", func(t *testing.T) {
 		caFile := filepath.Join(t.TempDir(), "invalid-ca.pem")
 		require.NoError(t, os.WriteFile(caFile, []byte("not a certificate"), 0600))
@@ -365,6 +415,30 @@ func TestGetTransport(t *testing.T) {
 			CAFile: caFile,
 		})
 		require.ErrorContains(t, err, "does not contain a valid PEM certificate")
+	})
+
+	t.Run("rejects invalid inline registry CA data", func(t *testing.T) {
+		_, err := newRegistryEndpointFromConfig(RegistryConfiguration{
+			Name:   "private registry",
+			Prefix: "private.example.com",
+			ApiURL: "https://private.example.com",
+			CAData: "not a certificate",
+		})
+		require.ErrorContains(t, err, "ca_data does not contain a valid PEM certificate")
+	})
+
+	t.Run("skips CA processing when insecure is true", func(t *testing.T) {
+		endpoint, err := newRegistryEndpointFromConfig(RegistryConfiguration{
+			Name:     "insecure registry",
+			Prefix:   "insecure.example.com",
+			ApiURL:   "https://insecure.example.com",
+			Insecure: true,
+			CAFile:   filepath.Join(t.TempDir(), "missing.pem"),
+			CAData:   "not a certificate",
+		})
+		require.NoError(t, err)
+		assert.Nil(t, endpoint.rootCAs)
+		assert.True(t, endpoint.GetTransport(context.Background()).TLSClientConfig.InsecureSkipVerify)
 	})
 
 	t.Run("returns transport with insecure TLS config when Insecure is true", func(t *testing.T) {
@@ -447,6 +521,15 @@ func TestTransportCache(t *testing.T) {
 	ClearTransportCache()
 	transport3 := endpoint.GetTransport(context.Background())
 	assert.NotSame(t, transport1, transport3, "Should create a new transport after cache is cleared")
+
+	// 4. Endpoints that share an API URL but have different TLS settings must not share transports.
+	endpointWithCustomCA := &RegistryEndpoint{
+		RegistryAPI:    endpoint.RegistryAPI,
+		RegistryPrefix: endpoint.RegistryPrefix,
+		CAFile:         "/different/ca.pem",
+	}
+	transport4 := endpointWithCustomCA.GetTransport(context.Background())
+	assert.NotSame(t, transport3, transport4, "Should not share transports across TLS settings")
 }
 
 // Test for transport validation logic

--- a/registry-scanner/pkg/registry/endpoints_test.go
+++ b/registry-scanner/pkg/registry/endpoints_test.go
@@ -2,8 +2,12 @@ package registry
 
 import (
 	"context"
+	"encoding/pem"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -321,7 +325,46 @@ func TestGetTransport(t *testing.T) {
 
 		assert.NotNil(t, transport)
 		assert.NotNil(t, transport.TLSClientConfig)
+		assert.NotNil(t, transport.TLSClientConfig.RootCAs)
 		assert.False(t, transport.TLSClientConfig.InsecureSkipVerify)
+	})
+
+	t.Run("trusts certificates from a registry CA file", func(t *testing.T) {
+		server := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			writer.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		certificate := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw})
+		caFile := filepath.Join(t.TempDir(), "registry-ca.pem")
+		require.NoError(t, os.WriteFile(caFile, certificate, 0600))
+
+		endpoint, err := newRegistryEndpointFromConfig(RegistryConfiguration{
+			Name:   "private registry",
+			Prefix: "private.example.com",
+			ApiURL: server.URL,
+			CAFile: caFile,
+		})
+		require.NoError(t, err)
+
+		client := &http.Client{Transport: endpoint.GetTransport(context.Background())}
+		response, err := client.Get(server.URL)
+		require.NoError(t, err)
+		defer response.Body.Close()
+		assert.Equal(t, http.StatusOK, response.StatusCode)
+	})
+
+	t.Run("rejects an invalid registry CA file", func(t *testing.T) {
+		caFile := filepath.Join(t.TempDir(), "invalid-ca.pem")
+		require.NoError(t, os.WriteFile(caFile, []byte("not a certificate"), 0600))
+
+		_, err := newRegistryEndpointFromConfig(RegistryConfiguration{
+			Name:   "private registry",
+			Prefix: "private.example.com",
+			ApiURL: "https://private.example.com",
+			CAFile: caFile,
+		})
+		require.ErrorContains(t, err, "does not contain a valid PEM certificate")
 	})
 
 	t.Run("returns transport with insecure TLS config when Insecure is true", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- I initialize registry transports with the system certificate pool.
- I added an optional per-registry `ca_file` setting that appends PEM certificates to the system trust store.
- I validate CA files while loading registry configuration and documented the new setting.
- I added coverage for configuration parsing, invalid bundles, system roots, and a successful TLS connection using a custom CA.

## Validation

- `cd registry-scanner && GOMAXPROCS=2 go test -p 2 ./pkg/registry -count=1`
- `cd registry-scanner && GOMAXPROCS=2 go vet ./pkg/registry`
- `gofmt -l` on the changed Go files
- `git diff --check origin/master...HEAD`

I did not run the full repository suite locally because it is disproportionate for this focused registry-scanner change; CI can cover the broader modules.

Fixes #1739


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for custom CA certificate files and inline certificates when connecting to registries.
  * Secure connections now use configured certificates, automatically discovered Argo CD certificates, or system trust stores.
  * Insecure registries skip CA certificate processing.

* **Bug Fixes**
  * Improved validation and error reporting for invalid or unavailable certificates.
  * Isolated connections with different certificate settings.

* **Documentation**
  * Added configuration guidance and updated the Red Hat Quay example to use a CA certificate file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->