### PR TITLE
fix(digest): pick the right live image when multiple containers share the same image

### DIFF
--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -199,6 +199,20 @@ func UpdateApplication(ctx context.Context, updateConf *UpdateConfiguration, sta
 			continue
 		}
 
+		// When several containers in the application reference the same image
+		// name, the live image list (Argo CD's alias-less, de-duplicated
+		// Status.Summary.Images) can cause the earlier ContainsImage lookup to
+		// resolve to a sibling container, hiding this image's pending update or
+		// triggering a spurious one. For digest strategy, re-select the live
+		// image that actually belongs to this alias (by tag, then by stale
+		// digest) so it is evaluated against its own container.
+		if vc.Strategy == image.StrategyDigest {
+			if m := applicationImages.MatchForDigestUpdate(applicationImage.ContainerImage, latest.TagDigest); m != nil && m != updateableImage {
+				imgCtx.Debugf("Multiple containers reference image '%s'; re-selected live image (tag '%s', digest '%s') for update evaluation", applicationImage.ImageName, m.ImageTag.TagName, m.ImageTag.TagDigest)
+				updateableImage = m
+			}
+		}
+
 		if needsUpdate(updateableImage, applicationImage.ContainerImage, latest, vc.Strategy) {
 			appImageWithTag := applicationImage.WithTag(latest)
 			appImageFullNameWithTag := appImageWithTag.GetFullNameWithTag()

--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -266,7 +266,22 @@ func UpdateApplication(ctx context.Context, updateConf *UpdateConfiguration, sta
 			// We need to explicitly set the up-to-date images in the spec too, so
 			// that we correctly marshal out the parameter overrides to include all
 			// images, regardless of those were updated or not.
-			err = setAppImage(imageOpCtx, &updateConf.UpdateApp.Application, applicationImage.WithTag(updateableImage.ImageTag), updateConf.UpdateApp.WriteBackConfig, applicationImage)
+			currentTag := updateableImage.ImageTag
+			// After a sync, Argo CD can record the running image in
+			// Status.Summary.Images as a bare digest with no tag name. For digest
+			// strategy, re-writing the image from that tag-less value drops the
+			// tracked tag name and degrades it to "latest@<digest>", corrupting the
+			// write-back and producing a commit every reconcile cycle. Preserve the
+			// alias's tracked tag name in that case.
+			if vc.Strategy == image.StrategyDigest && vc.Constraint != "" &&
+				(currentTag == nil || currentTag.TagName == "") {
+				digest := ""
+				if currentTag != nil {
+					digest = currentTag.TagDigest
+				}
+				currentTag = tag.NewImageTag(vc.Constraint, time.Unix(0, 0), digest)
+			}
+			err = setAppImage(imageOpCtx, &updateConf.UpdateApp.Application, applicationImage.WithTag(currentTag), updateConf.UpdateApp.WriteBackConfig, applicationImage)
 			if err != nil {
 				imgCtx.Errorf("Error while trying to update image: %v", err)
 				result.NumErrors += 1

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -2230,6 +2230,106 @@ registries:
 		assert.Equal(t, 0, res.NumErrors)
 		assert.Equal(t, 1, res.NumImagesUpdated)
 	})
+
+	// Regression test for #1547: when two containers share the same image name
+	// and tag but their digests have diverged, the live image list
+	// (Status.Summary.Images) is alias-less and de-duplicated by full reference.
+	// A plain ContainsImage lookup returns the first name match — a sibling
+	// container that was already updated — hiding the tracked container's pending
+	// update. Without the fix this reports images_updated=0; with it, the tracked
+	// container is updated to the new digest.
+	t.Run("Test digest update when a sibling container shares the image name and tag (#1547)", func(t *testing.T) {
+		newDigest := "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+		newDigestBytes := [32]byte{
+			0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef,
+			0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef,
+			0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef,
+			0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef,
+		}
+		// A different, older digest that our tracked container is still pinned to.
+		oldDigest := "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+
+		mockClientFn := func(endpoint *registry.RegistryEndpoint, username, password string) (registry.RegistryClient, error) {
+			regMock := regmock.RegistryClient{}
+			regMock.On("NewRepository", mock.Anything, mock.Anything).Return(nil)
+			regMock.On("Tags", mock.Anything).Return([]string{"latest"}, nil)
+			meta := &schema2.DeserializedManifest{}
+			regMock.On("ManifestForTag", mock.Anything, "latest").Return(meta, nil)
+			// The mutable "latest" tag now resolves to the NEW digest.
+			regMock.On("TagMetadata", mock.Anything, mock.Anything, mock.Anything).Return(&tag.TagInfo{
+				CreatedAt: time.Now(),
+				Digest:    newDigestBytes,
+			}, nil)
+			return &regMock, nil
+		}
+
+		argoClient := argomock.ArgoCD{}
+		argoClient.On("UpdateSpec", mock.Anything, mock.Anything).Return(nil, nil)
+
+		kubeClient := kube.ImageUpdaterKubernetesClient{
+			KubeClient: &registryKube.KubernetesClient{
+				Clientset: fake.NewFakeKubeClient(),
+			},
+		}
+
+		// We track one alias ("web"), still pinned to the old digest.
+		containerImg := image.NewFromIdentifier("web=docker.io/library/nginx:latest")
+		iuImg := NewImage(containerImg)
+		iuImg.UpdateStrategy = image.StrategyDigest
+
+		appImages := &ApplicationImages{
+			Application: v1alpha1.Application{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "guestbook",
+					Namespace: "guestbook",
+				},
+				Spec: v1alpha1.ApplicationSpec{
+					Source: &v1alpha1.ApplicationSource{
+						Kustomize: &v1alpha1.ApplicationSourceKustomize{
+							Images: v1alpha1.KustomizeImages{
+								// Our tracked container ("web") is still on the old digest.
+								v1alpha1.KustomizeImage("docker.io/library/nginx:latest@" + oldDigest),
+							},
+						},
+					},
+				},
+				Status: v1alpha1.ApplicationStatus{
+					SourceType: v1alpha1.ApplicationSourceTypeKustomize,
+					Summary: v1alpha1.ApplicationSummary{
+						// A sibling container ("worker") sharing the same image name and
+						// tag was already bumped to the new digest and is listed first;
+						// our tracked container is still on the old digest.
+						Images: []string{
+							"docker.io/library/nginx:latest@" + newDigest,
+							"docker.io/library/nginx:latest@" + oldDigest,
+						},
+					},
+				},
+			},
+			Images: ImageList{iuImg},
+			WriteBackConfig: &WriteBackConfig{
+				Method: WriteBackApplication,
+			},
+		}
+
+		res := UpdateApplication(context.Background(), &UpdateConfiguration{
+			NewRegFN:   mockClientFn,
+			ArgoClient: &argoClient,
+			KubeClient: &kubeClient,
+			UpdateApp:  appImages,
+			DryRun:     false,
+		}, NewSyncIterationState())
+
+		assert.Equal(t, 0, res.NumErrors)
+		assert.Equal(t, 1, res.NumImagesConsidered)
+		// The tracked container must be updated to the new digest, even though a
+		// sibling container already carries it in the (alias-less) live image list.
+		assert.Equal(t, 1, res.NumImagesUpdated,
+			"tracked container must be updated even when a sibling shares the image name and tag")
+		updatedImage := string(appImages.Application.Spec.Source.Kustomize.Images[0])
+		assert.Contains(t, updatedImage, "@"+newDigest,
+			"tracked container should be updated to the new digest")
+	})
 }
 
 func Test_MarshalParamsOverride(t *testing.T) {

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -2330,6 +2330,103 @@ registries:
 		assert.Contains(t, updatedImage, "@"+newDigest,
 			"tracked container should be updated to the new digest")
 	})
+
+	// Regression test for #1547 Phase 3: after an Argo CD sync, the running image
+	// is recorded in Status.Summary.Images as a BARE digest (no tag name). For an
+	// up-to-date digest-strategy image, the "already up to date" branch re-writes
+	// the Helm tag parameter from the tag-less running image, so the tracked tag
+	// name (e.g. "develop") is lost and rewritten as "latest@<digest>" — data
+	// corruption that also produces a commit every reconcile cycle. The written
+	// tag must preserve the tracked tag name instead.
+	t.Run("Test digest up-to-date image keeps its tag when the running image is a bare digest (#1547 phase 3)", func(t *testing.T) {
+		digest := "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+		digestBytes := [32]byte{
+			0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef,
+			0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef,
+			0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef,
+			0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef,
+		}
+
+		mockClientFn := func(endpoint *registry.RegistryEndpoint, username, password string) (registry.RegistryClient, error) {
+			regMock := regmock.RegistryClient{}
+			regMock.On("NewRepository", mock.Anything, mock.Anything).Return(nil)
+			regMock.On("Tags", mock.Anything).Return([]string{"develop"}, nil)
+			meta := &schema2.DeserializedManifest{}
+			regMock.On("ManifestForTag", mock.Anything, "develop").Return(meta, nil)
+			regMock.On("TagMetadata", mock.Anything, mock.Anything, mock.Anything).Return(&tag.TagInfo{
+				CreatedAt: time.Now(),
+				Digest:    digestBytes,
+			}, nil)
+			return &regMock, nil
+		}
+
+		argoClient := argomock.ArgoCD{}
+		argoClient.On("UpdateSpec", mock.Anything, mock.Anything).Return(nil, nil)
+
+		kubeClient := kube.ImageUpdaterKubernetesClient{
+			KubeClient: &registryKube.KubernetesClient{
+				Clientset: fake.NewFakeKubeClient(),
+			},
+		}
+
+		containerImg := image.NewFromIdentifier("web=docker.io/library/nginx:develop")
+		iuImg := NewImage(containerImg)
+		iuImg.UpdateStrategy = image.StrategyDigest
+		iuImg.HelmImageName = "image.name"
+		iuImg.HelmImageTag = "image.tag"
+
+		appImages := &ApplicationImages{
+			Application: v1alpha1.Application{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "guestbook",
+					Namespace: "guestbook",
+				},
+				Spec: v1alpha1.ApplicationSpec{
+					Source: &v1alpha1.ApplicationSource{
+						Helm: &v1alpha1.ApplicationSourceHelm{
+							Parameters: []v1alpha1.HelmParameter{
+								// Current, correct state: tag name preserved with the digest.
+								{Name: "image.name", Value: "docker.io/library/nginx", ForceString: true},
+								{Name: "image.tag", Value: "develop@" + digest, ForceString: true},
+							},
+						},
+					},
+				},
+				Status: v1alpha1.ApplicationStatus{
+					SourceType: v1alpha1.ApplicationSourceTypeHelm,
+					Summary: v1alpha1.ApplicationSummary{
+						// Phase 3: Argo CD records the running image as a BARE digest,
+						// with no tag name.
+						Images: []string{"docker.io/library/nginx@" + digest},
+					},
+				},
+			},
+			Images: ImageList{iuImg},
+			WriteBackConfig: &WriteBackConfig{
+				Method: WriteBackApplication,
+			},
+		}
+
+		res := UpdateApplication(context.Background(), &UpdateConfiguration{
+			NewRegFN:   mockClientFn,
+			ArgoClient: &argoClient,
+			KubeClient: &kubeClient,
+			UpdateApp:  appImages,
+			DryRun:     false,
+		}, NewSyncIterationState())
+
+		require.Equal(t, 0, res.NumErrors)
+
+		var tagValue string
+		for _, p := range appImages.Application.Spec.Source.Helm.Parameters {
+			if p.Name == "image.tag" {
+				tagValue = p.Value
+			}
+		}
+		// The tracked tag name must survive; it must NOT be rewritten to "latest".
+		assert.Equal(t, "develop@"+digest, tagValue,
+			"up-to-date image must keep its tracked tag name, not degrade to latest@<digest>")
+	})
 }
 
 func Test_MarshalParamsOverride(t *testing.T) {

--- a/registry-scanner/pkg/image/image.go
+++ b/registry-scanner/pkg/image/image.go
@@ -179,6 +179,64 @@ func (list *ContainerImageList) ContainsImage(img *ContainerImage, checkVersion 
 	return nil
 }
 
+// MatchForDigestUpdate returns the live image that best represents the container
+// tracked by img, for digest-strategy update evaluation, when several containers
+// in the application share the same image name. It returns nil when there is no
+// better candidate than the caller's existing lookup.
+//
+// Argo CD's Status.Summary.Images (the source of the live image list) is
+// alias-less and deduplicated by full reference, so a plain ContainsImage lookup
+// (name + registry only, first match) can return a sibling container's live
+// image and either hide the tracked container's pending update or trigger a
+// spurious one. This narrows the match in two steps:
+//
+//  1. Prefer a live image whose tag name also matches img's tag name. This
+//     disambiguates aliases that share an image name but track different tags
+//     (e.g. tag-a vs tag-b), so each alias is evaluated against its own
+//     container instead of a sibling's.
+//  2. Among the candidates, prefer one whose digest differs from latestDigest —
+//     a container still on an older digest that needs updating. This
+//     disambiguates several containers that share both image name and tag (e.g.
+//     two deployments both on :develop) once their digests diverge.
+//
+// If no live image carries img's tag name (e.g. the summary lists digests
+// without tags), it falls back to a stale name+registry match, preserving the
+// previous name-only behavior.
+func (list *ContainerImageList) MatchForDigestUpdate(img *ContainerImage, latestDigest string) *ContainerImage {
+	wantTag := ""
+	if img.ImageTag != nil {
+		wantTag = img.ImageTag.TagName
+	}
+
+	var firstTagMatch, staleNameMatch *ContainerImage
+	for _, live := range *list {
+		if img.ImageName != live.ImageName || img.RegistryURL != live.RegistryURL {
+			continue
+		}
+		isStale := live.ImageTag != nil && live.ImageTag.IsDigest() && live.ImageTag.TagDigest != latestDigest
+		if isStale && staleNameMatch == nil {
+			staleNameMatch = live
+		}
+		if wantTag != "" && live.ImageTag != nil && live.ImageTag.TagName == wantTag {
+			if isStale {
+				// Same tag and still stale: this is exactly the container to update.
+				return live
+			}
+			if firstTagMatch == nil {
+				firstTagMatch = live
+			}
+		}
+	}
+
+	// Same tag but already current: return it so the caller evaluates this exact
+	// container (and correctly finds it up to date) rather than a sibling.
+	if firstTagMatch != nil {
+		return firstTagMatch
+	}
+	// No tag match available: fall back to a stale name+registry match if any.
+	return staleNameMatch
+}
+
 func (list *ContainerImageList) Originals() []string {
 	results := make([]string, len(*list))
 	for i, img := range *list {

--- a/registry-scanner/pkg/image/image_test.go
+++ b/registry-scanner/pkg/image/image_test.go
@@ -207,6 +207,78 @@ func Test_ContainerList(t *testing.T) {
 	})
 }
 
+func Test_MatchForDigestUpdate(t *testing.T) {
+	const (
+		imgRef  = "registry.example.com/org/app"
+		digNew  = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+		digOld  = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+		digTagB = "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+	)
+
+	t.Run("same tag: re-selects the stale digest when two containers share tag and name", func(t *testing.T) {
+		cfg := NewFromIdentifier(imgRef + ":develop")
+		live := ContainerImageList{
+			NewFromIdentifier(imgRef + ":develop@" + digNew), // sibling already updated, listed first
+			NewFromIdentifier(imgRef + ":develop@" + digOld), // our container, still stale
+		}
+		m := live.MatchForDigestUpdate(cfg, digNew)
+		require.NotNil(t, m)
+		assert.Equal(t, digOld, m.ImageTag.TagDigest)
+	})
+
+	t.Run("different tags: selects the container matching this alias's tag (#1547)", func(t *testing.T) {
+		cfg := NewFromIdentifier(imgRef + ":tag-a")
+		live := ContainerImageList{
+			NewFromIdentifier(imgRef + ":tag-b@" + digTagB), // sibling on a different tag, listed first
+			NewFromIdentifier(imgRef + ":tag-a@" + digOld),  // our container, still stale
+		}
+		m := live.MatchForDigestUpdate(cfg, digNew)
+		require.NotNil(t, m)
+		assert.Equal(t, "tag-a", m.ImageTag.TagName)
+		assert.Equal(t, digOld, m.ImageTag.TagDigest)
+	})
+
+	t.Run("different tags: returns this alias's own container even when current, not a sibling (#1547)", func(t *testing.T) {
+		// Our tag (tag-b) is unchanged (latest == digTagB); a sibling on tag-a differs.
+		// We must not pick the sibling, which would cause a spurious update.
+		cfg := NewFromIdentifier(imgRef + ":tag-b")
+		live := ContainerImageList{
+			NewFromIdentifier(imgRef + ":tag-a@" + digNew),  // sibling, different digest, listed first
+			NewFromIdentifier(imgRef + ":tag-b@" + digTagB), // our container, already current
+		}
+		m := live.MatchForDigestUpdate(cfg, digTagB)
+		require.NotNil(t, m)
+		assert.Equal(t, "tag-b", m.ImageTag.TagName)
+		assert.Equal(t, digTagB, m.ImageTag.TagDigest)
+	})
+
+	t.Run("falls back to a stale name match when no live image carries the tag", func(t *testing.T) {
+		cfg := NewFromIdentifier(imgRef + ":develop")
+		live := ContainerImageList{
+			NewFromIdentifier(imgRef + "@" + digOld), // digest-only, no tag name
+		}
+		m := live.MatchForDigestUpdate(cfg, digNew)
+		require.NotNil(t, m)
+		assert.Equal(t, digOld, m.ImageTag.TagDigest)
+	})
+
+	t.Run("returns nil when no image name matches", func(t *testing.T) {
+		cfg := NewFromIdentifier(imgRef + ":develop")
+		live := ContainerImageList{
+			NewFromIdentifier("registry.example.com/org/other:develop@" + digOld),
+		}
+		assert.Nil(t, live.MatchForDigestUpdate(cfg, digNew))
+	})
+
+	t.Run("returns nil when the only match is a different tag already at the latest digest", func(t *testing.T) {
+		cfg := NewFromIdentifier(imgRef + ":develop")
+		live := ContainerImageList{
+			NewFromIdentifier(imgRef + ":other@" + digNew),
+		}
+		assert.Nil(t, live.MatchForDigestUpdate(cfg, digNew))
+	})
+}
+
 func Test_getImageDigestFromTag(t *testing.T) {
 	tagAndDigest := "test-tag@sha256:abcde"
 	tagName, tagDigest := getImageDigestFromTag(tagAndDigest)


### PR DESCRIPTION
Fixes #1547 

## The problem
When several containers in an Application reference the same image name (registry + repository) with `updateStrategy: digest`, a container can be evaluated against a sibling's live image instead of its own - either missing an update or making a spurious one.

**Root cause**. The current live image for an alias is resolved via `ContainerImageList.ContainsImage`, which matches on `image name + registry only` and returns the first match. The live list comes from Argo CD's `Status.Summary.Images`, which is alias-less and de-duplicated by full reference. So when two containers share an image name, the lookup for one alias can return the other's live image. Two observed cases:

- **Same tag (e.g. two deployments both on `:develop`)**: once a sibling is bumped, the tracked container matches the sibling's already-updated digest, is considered up to date, and is never updated (`images_updated=0`, permanently stuck).
- **Different tags (e.g. `tag-a / tag-b`, #1547)**: the tracked alias reads the wrong container's digest, leading to wrong writes / churn.

## Fix
Add `ContainerImageList.MatchForDigestUpdate(img, latestDigest)`, used for digest strategy, which re-selects the live image that actually belongs to the alias:

1. Prefer a live image whose tag name matches the alias's  tag - so aliases that share an image name but track different tags are matched to the right container.
2. Among those, prefer one whose digest differs from the latest - so when two containers share both name and tag, the one still on the old digest is the one that gets updated.
3. Fall back to a stale name+registry match when the summary has no matching tag (previous behavior).

Tests
`registry-scanner/pkg/image: Test_MatchForDigestUpdate ` - same-tag stale selection, different-tag selection (both aliases), fallback, and nil cases.
`pkg/argocd: Test_UpdateApplication regression` -  a tracked container is updated even when a sibling shares the image name and tag; fails without the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved digest-based image updates when multiple containers share an image name.
  * Ensured updates select the correct image across differing tags and digests.
  * Added fallback handling for digest-only image references.
  * Preserved configured image tags when the live image is already up to date.

* **Tests**
  * Added coverage for shared image names, tag variations, stale digests, digest-only references, and unmatched images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->