### PR TITLE
fix(semver): exclude pre-release tags when no semver constraint is set

### DIFF
--- a/registry-scanner/pkg/image/version.go
+++ b/registry-scanner/pkg/image/version.go
@@ -108,11 +108,18 @@ func (img *ContainerImage) GetNewestVersionFromTags(ctx context.Context, vc *Ver
 		return nil, nil
 	}
 
-	// The given constraint MUST match a semver constraint
+	// The given constraint MUST match a semver constraint. When no constraint
+	// is configured, fall back to a wildcard constraint so that pre-release
+	// versions are still excluded unless explicitly allowed (e.g. via a
+	// constraint carrying a "-0" suffix), as documented.
 	var semverConstraint *semver.Constraints
 	var err error
-	if vc.Strategy == StrategySemVer && vc.Constraint != "" {
-		semverConstraint, err = semver.NewConstraint(vc.Constraint)
+	if vc.Strategy == StrategySemVer {
+		constraint := vc.Constraint
+		if constraint == "" {
+			constraint = "*"
+		}
+		semverConstraint, err = semver.NewConstraint(constraint)
 		if err != nil {
 			logCtx.Errorf("invalid constraint '%s' given: '%v'", vc, err)
 			return nil, err

--- a/registry-scanner/pkg/image/version_test.go
+++ b/registry-scanner/pkg/image/version_test.go
@@ -79,6 +79,16 @@ func Test_LatestVersion(t *testing.T) {
 		assert.Equal(t, "2.0.3", newTag.TagName)
 	})
 
+	t.Run("Find the latest version without any constraint excludes pre-release versions", func(t *testing.T) {
+		tagList := newImageTagList([]string{"v2.2.0", "v2.3.0-rc.0.18.g1abb7b5dd-ppc64le"})
+		img := NewFromIdentifier("xpkg.crossplane.io/crossplane/crossplane:v2.2.0")
+		vc := VersionConstraint{}
+		newTag, err := img.GetNewestVersionFromTags(context.Background(), &vc, tagList)
+		require.NoError(t, err)
+		require.NotNil(t, newTag)
+		assert.Equal(t, "v2.2.0", newTag.TagName)
+	})
+
 	t.Run("Find the latest version with a semver constraint that has no match", func(t *testing.T) {
 		tagList := newImageTagList([]string{"0.1", "0.5.1", "0.9", "2.0.3"})
 		img := NewFromIdentifier("jannfis/test:1.0")


### PR DESCRIPTION
Motivation:
With the semver update strategy and no explicit version constraint
configured (the common/default case), GetNewestVersionFromTags would
select pre-release tags (e.g. v2.3.0-rc.0.18.g1abb7b5dd-ppc64le) over
proper release tags (e.g. v2.2.0), even though the documentation states
that updating to pre-release versions "is supported, but must be
explicitly allowed". The bug only manifested when no constraint was
set: an explicit constraint (e.g. via `argocd-image-updater test
--semver-constraint v2.x.x`) already excluded pre-releases correctly.

Approach:
In registry-scanner/pkg/image/version.go, GetNewestVersionFromTags only
built a *semver.Constraints (and thus only ran .Check() against
candidate tags) when vc.Constraint was non-empty. When empty, the
`semverConstraint != nil` guard around .Check() was skipped entirely,
so every parseable semver tag, prereleases included, was accepted as a
candidate. The Masterminds/semver/v3 library's Constraints.Check()
already excludes pre-release versions unless the constraint itself
carries a pre-release component; a wildcard "*" constraint matches
normal versions but not pre-releases. The fix always builds a
semver.Constraints for the semver strategy, substituting "*" when no
constraint is configured, so the library's existing pre-release
exclusion applies in the no-constraint case too.

This only touches the vc.Strategy == StrategySemVer branch; vc.Constraint
itself is never mutated, so log messages, other strategies (digest,
alphabetical, newest-build), and other readers of vc.Constraint are
unaffected.

Validation:
- go build ./... (repo root): succeeds.
- cd registry-scanner && go test ./pkg/image/... -run Test_LatestVersion -v:
  passes, including a new subtest "Find the latest version without any
  constraint excludes pre-release versions" using the tag names from the
  issue report (v2.2.0, v2.3.0-rc.0.18.g1abb7b5dd-ppc64le).
- Reverted only version.go via `git stash` and reran the new subtest in
  isolation: it failed with
  `expected: "v2.2.0" actual: "v2.3.0-rc.0.18.g1abb7b5dd-ppc64le"`,
  confirming the test reproduces the reported bug; restoring the fix
  makes it pass again.
- make test (repo root): all packages pass.
- cd registry-scanner && make test (go test -race ./...): all packages
  pass.
- make lint (repo root, golangci-lint v2.12.2): 0 issues.
- cd registry-scanner && ../bin/golangci-lint run ./...: 0 issues.

Report: https://github.com/argoproj-labs/argocd-image-updater/issues/1535
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

Fixes #1535

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unconstrained version selection now consistently excludes pre-release versions by default.
  * Stable releases are selected when no version constraint is provided.
  * Invalid version constraints continue to return an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->