### PR TITLE
chore(ci): change to run CodeQL on cron schedule only

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,8 +12,8 @@
 name: "CodeQL"
 
 on:
-  pull_request:
-    branches: [ master, master-annotation-based ]
+  schedule:
+    - cron: '40 3 20 * *'
 
 jobs:
   analyze:


### PR DESCRIPTION
This PR changes to run CodeQL workflow on cron schedule only (20th of each month at 03:40 UTC), instead of on every PR.

This workflow usually takes about 12 minutes, the second longest workflow. It is not necessary to run it for every change to every PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security analysis to run automatically on a monthly schedule.
  * Removed the previous pull-request-based analysis trigger.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->