### PR TITLE
chore(doc): remove obsolete breaking change labels

### DIFF
--- a/docs/basics/update-methods.md
+++ b/docs/basics/update-methods.md
@@ -208,7 +208,7 @@ kubectl -n argocd-image-updater create secret generic git-creds \
   --from-literal=insecure='true'
 ```
 
-!!!warning "Breaking change: `insecure` default"
+!!!warning
     In previous versions, TLS verification was always skipped (`insecure` was
     hardcoded to `true`) when using secret-based GitHub App credentials. This
     has been fixed to default to `false`, matching the behavior of repository

--- a/docs/configuration/webhook.md
+++ b/docs/configuration/webhook.md
@@ -1,7 +1,7 @@
 # Webhook Configuration
 
-!!!warning "Breaking Change"
-    Starting with this release, the webhook server runs with **TLS enabled by default**.
+!!!warning
+    The webhook server runs with **TLS enabled by default**.
     If you previously relied on plain HTTP, you must explicitly opt out by setting the
     `--disable-tls` flag or the `DISABLE_TLS` environment variable. For details, see
     [TLS Configuration](#tls-configuration) below.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ A tool to automatically update the container images of Kubernetes workloads
 that are managed by
 [Argo CD](https://github.com/argoproj/argo-cd).
 
-!!!warning "Breaking Change: spec.namespace Field Removed"
+!!!warning "spec.namespace Field Removed"
     The `spec.namespace` field has been removed from the `ImageUpdater` API. Any CR that includes `spec.namespace` will fail validation. The controller uses the ImageUpdater CR's `metadata.namespace` to determine which namespace to search for applications. For details and migration examples, see [Namespace Field Removal](#namespace-field-removal) below.
 
 !!!warning "A note on the current status"

--- a/docs/install/installation.md
+++ b/docs/install/installation.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-!!!warning "Breaking Change: Default watch scope is now namespace-scoped"
+!!!warning "Default watch scope is now namespace-scoped"
     Previously, the controller operated in cluster-wide mode by default, watching
     all namespaces using a `ClusterRole` and `ClusterRoleBinding`. The default is
     now **namespace-scoped**: the controller watches only its own namespace using a


### PR DESCRIPTION
I removed phrase "breaking change" from the breaking changes labels related to the previous IU releases. But I kept the warnings texts as they have a useful information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration and installation documentation to clarify current defaults and migration notices.
  * Removed outdated “Breaking Change” labels from warnings about Git credentials, TLS, namespace removal, and namespace-scoped watch behavior.
  * Retained the underlying guidance, including TLS disablement options and namespace-related notices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->