### PR TITLE
fix(kustomize): match images by alias to prevent cross-alias collisions

### DIFF
--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -964,7 +964,19 @@ func GetKustomizeImage(ctx context.Context, app *argocdapi.Application, wbc *Wri
 	}
 
 	for _, a := range ksImages {
-		if a.Match(argocdapi.KustomizeImage(ksImageName)) {
+		curr := image.NewFromIdentifier(string(a))
+
+		// Entries must always agree on ImageName (registry+repo). When
+		// manifestTargets.kustomize.name is set and the entry already carries
+		// an alias, that alias must also match - otherwise two entries that
+		// share the same ImageName but target different kustomize image
+		// aliases would be treated as the same entry.
+		matched := curr.ImageName == applicationImage.ImageName
+		if ksImageName != "" && curr.ImageAlias != "" {
+			matched = matched && curr.ImageAlias == ksImageName
+		}
+
+		if matched {
 			return string(a), nil
 		}
 	}
@@ -999,7 +1011,18 @@ func SetKustomizeImage(ctx context.Context, app *argocdapi.Application, newImage
 		curr := image.NewFromIdentifier(string(kImg))
 		override := image.NewFromIdentifier(ksImageParam)
 
-		if curr.ImageName == override.ImageName {
+		// Entries must always agree on ImageName (registry+repo). When
+		// manifestTargets.kustomize.name is set and the entry already carries
+		// an alias, that alias must also match - otherwise two entries that
+		// share the same ImageName but target different kustomize image
+		// aliases would collapse onto the same slot, silently dropping one of
+		// them.
+		matched := curr.ImageName == override.ImageName
+		if ksImageName != "" && curr.ImageAlias != "" {
+			matched = matched && curr.ImageAlias == ksImageName
+		}
+
+		if matched {
 			curr.ImageAlias = override.ImageAlias
 			appSource.Kustomize.Images[i] = argocdapi.KustomizeImage(override.String())
 		}

--- a/pkg/argocd/argocd_test.go
+++ b/pkg/argocd/argocd_test.go
@@ -1363,6 +1363,111 @@ func Test_SetKustomizeImage(t *testing.T) {
 		assert.Equal(t, v1alpha1.KustomizeImage("foobar=jannfis/foobar:1.0.1"), app.Spec.Source.Kustomize.Images[0])
 	})
 
+	t.Run("Test set Kustomize image parameters for two aliases sharing the same image name does not collide", func(t *testing.T) {
+		app := &v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "test-app",
+				Namespace: "testns",
+			},
+			Spec: v1alpha1.ApplicationSpec{
+				Source: &v1alpha1.ApplicationSource{
+					Kustomize: &v1alpha1.ApplicationSourceKustomize{
+						Images: v1alpha1.KustomizeImages{
+							"service-a=jannfis/foobar:tag-a",
+							"service-b=jannfis/foobar:tag-b",
+						},
+					},
+				},
+			},
+			Status: v1alpha1.ApplicationStatus{
+				SourceType: v1alpha1.ApplicationSourceTypeKustomize,
+			},
+		}
+		wbc := &WriteBackConfig{
+			Target: "kustomization:.",
+		}
+
+		imgA := image.NewFromIdentifier("service-a=jannfis/foobar:tag-a@sha256:digesta")
+		appImageA := &Image{KustomizeImageName: "service-a"}
+		err := SetKustomizeImage(context.Background(), app, imgA, wbc, appImageA)
+		require.NoError(t, err)
+
+		imgB := image.NewFromIdentifier("service-b=jannfis/foobar:tag-b@sha256:digestb")
+		appImageB := &Image{KustomizeImageName: "service-b"}
+		err = SetKustomizeImage(context.Background(), app, imgB, wbc, appImageB)
+		require.NoError(t, err)
+
+		require.NotNil(t, app.Spec.Source.Kustomize)
+		require.Len(t, app.Spec.Source.Kustomize.Images, 2)
+		assert.Equal(t, v1alpha1.KustomizeImage("service-a=jannfis/foobar:tag-a@sha256:digesta"), app.Spec.Source.Kustomize.Images[0])
+		assert.Equal(t, v1alpha1.KustomizeImage("service-b=jannfis/foobar:tag-b@sha256:digestb"), app.Spec.Source.Kustomize.Images[1])
+	})
+
+}
+
+func Test_GetKustomizeImage(t *testing.T) {
+	t.Run("Test get Kustomize image without alias name", func(t *testing.T) {
+		app := &v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "test-app",
+				Namespace: "testns",
+			},
+			Spec: v1alpha1.ApplicationSpec{
+				Source: &v1alpha1.ApplicationSource{
+					Kustomize: &v1alpha1.ApplicationSourceKustomize{
+						Images: v1alpha1.KustomizeImages{
+							"jannfis/foobar:1.0.0",
+						},
+					},
+				},
+			},
+			Status: v1alpha1.ApplicationStatus{
+				SourceType: v1alpha1.ApplicationSourceTypeKustomize,
+			},
+		}
+		appImage := &Image{ContainerImage: image.NewFromIdentifier("jannfis/foobar:1.0.0")}
+		result, err := GetKustomizeImage(context.Background(), app, nil, appImage)
+		require.NoError(t, err)
+		assert.Equal(t, "jannfis/foobar:1.0.0", result)
+	})
+
+	t.Run("Test get Kustomize image for two aliases sharing the same image name does not collide", func(t *testing.T) {
+		app := &v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "test-app",
+				Namespace: "testns",
+			},
+			Spec: v1alpha1.ApplicationSpec{
+				Source: &v1alpha1.ApplicationSource{
+					Kustomize: &v1alpha1.ApplicationSourceKustomize{
+						Images: v1alpha1.KustomizeImages{
+							"service-a=jannfis/foobar:tag-a",
+							"service-b=jannfis/foobar:tag-b",
+						},
+					},
+				},
+			},
+			Status: v1alpha1.ApplicationStatus{
+				SourceType: v1alpha1.ApplicationSourceTypeKustomize,
+			},
+		}
+
+		appImageA := &Image{
+			ContainerImage:     image.NewFromIdentifier("jannfis/foobar:tag-a"),
+			KustomizeImageName: "service-a",
+		}
+		resultA, err := GetKustomizeImage(context.Background(), app, nil, appImageA)
+		require.NoError(t, err)
+		assert.Equal(t, "service-a=jannfis/foobar:tag-a", resultA)
+
+		appImageB := &Image{
+			ContainerImage:     image.NewFromIdentifier("jannfis/foobar:tag-b"),
+			KustomizeImageName: "service-b",
+		}
+		resultB, err := GetKustomizeImage(context.Background(), app, nil, appImageB)
+		require.NoError(t, err)
+		assert.Equal(t, "service-b=jannfis/foobar:tag-b", resultB)
+	})
 }
 
 func Test_SetHelmImage(t *testing.T) {


### PR DESCRIPTION
Motivation:
When two aliases in an ImageUpdater CR share the same imageName
(registry+repo) but target distinct kustomize image entries via
manifestTargets.kustomize.name, SetKustomizeImage matched entries in
appSource.Kustomize.Images by ImageName alone, ignoring the kustomize
alias. This let the update for one alias stomp the slot belonging to a
different alias that happens to share the same image name, so a
second alias's write clobbered the first. The rendered
kustomization.yaml then ended up unchanged for one of the two images,
so the write-back commit for that image was silently skipped.

GetKustomizeImage had a related read-side bug: it relied on the
vendored KustomizeImage.Match() method, which compares both operands
up to their first delimiter. Since applicationImage.KustomizeImageName
has no delimiter character, that comparison never matched anything, so
GetKustomizeImage always returned an empty string, regardless of
whether the alias's image was already present in the app source.

Approach:
In both SetKustomizeImage and GetKustomizeImage, keep the existing
ImageName equality requirement, but additionally require alias
equality whenever the ImageUpdater config sets a kustomize alias
(manifestTargets.kustomize.name) and the candidate entry already
carries a non-empty alias. This keeps two differently-aliased entries
independent, while still letting a pre-existing unaliased entry (e.g.
one that predates manifestTargets.kustomize.name being configured for
that image) get adopted into an aliased entry, which an existing test
already depends on.

Validation:
- go test ./pkg/argocd/... - all pass. Added two new subtests to
  Test_SetKustomizeImage and a new Test_GetKustomizeImage (covering
  the no-alias and two-alias cases) that reproduce the scenario from
  the issue: two aliases sharing an imageName but distinct
  manifestTargets.kustomize.name values. Confirmed these three new
  subtests FAIL against the pre-fix code (by stashing only
  pkg/argocd/argocd.go) and PASS with the fix - a targeted regression
  test for the defect, not a live/e2e reproduction.
- go build ./... and go test ./... from the repo root - all pass
  except test/e2e, which fails only because kubectl is not available
  in this environment to install prometheus-operator; unrelated to
  this change.
- make lint (golangci-lint v2.12.2) - 0 issues.

Impact is scoped to Kustomize applications where
manifestTargets.kustomize.name is set for two or more aliases that
share the same imageName. Behavior is unchanged for the common case of
one alias per imageName, and for images with no kustomize alias
configured at all.

Report: https://github.com/argoproj-labs/argocd-image-updater/issues/1614
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

Fixes #1614

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kustomize image matching to distinguish entries that share the same image but use different aliases.
  * Preserved alias-specific image values and digests when retrieving or updating images.
  * Prevented updates from unintentionally combining or overwriting distinct aliased entries.

* **Tests**
  * Added coverage for aliased and non-aliased image lookups, updates, and digest preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->