### PR TITLE
test: add regression coverage for force-update image with empty registry tags

### DIFF
--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -1588,6 +1588,71 @@ registries:
 		assert.Equal(t, 0, res.NumImagesUpdated)
 	})
 
+	t.Run("Test skip when force-update image has no live tag and registry returns empty tags (issue #1218)", func(t *testing.T) {
+		mockClientFn := func(endpoint *registry.RegistryEndpoint, username, password string) (registry.RegistryClient, error) {
+			regMock := regmock.RegistryClient{}
+			regMock.On("NewRepository", mock.Anything, mock.Anything).Return(nil)
+			regMock.On("Tags", mock.Anything).Return([]string{}, nil)
+			return &regMock, nil
+		}
+
+		argoClient := argomock.ArgoCD{}
+		argoClient.On("UpdateSpec", mock.Anything, mock.Anything).Return(nil, nil)
+
+		kubeClient := kube.ImageUpdaterKubernetesClient{
+			KubeClient: &registryKube.KubernetesClient{
+				Clientset: fake.NewFakeKubeClient(),
+			},
+		}
+
+		// db-migrations is not part of the application's live image summary (e.g. an
+		// initContainer image pointed at a different registry than what's currently
+		// deployed). force-update is required for it to be considered at all, which
+		// makes GetImagesFromApplication add it with a nil live tag.
+		dbMigrationsImage := NewImage(image.NewFromIdentifier("jannfis/db-migrations"))
+		dbMigrationsImage.ForceUpdate = true
+
+		appImages := &ApplicationImages{
+			Application: v1alpha1.Application{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "guestbook",
+					Namespace: "guestbook",
+				},
+				Spec: v1alpha1.ApplicationSpec{
+					Source: &v1alpha1.ApplicationSource{
+						Kustomize: &v1alpha1.ApplicationSourceKustomize{
+							Images: v1alpha1.KustomizeImages{},
+						},
+					},
+				},
+				Status: v1alpha1.ApplicationStatus{
+					SourceType: v1alpha1.ApplicationSourceTypeKustomize,
+					Summary: v1alpha1.ApplicationSummary{
+						Images: []string{},
+					},
+				},
+			},
+			WriteBackConfig: &WriteBackConfig{
+				Method: WriteBackApplication,
+			},
+			Images: ImageList{dbMigrationsImage},
+		}
+		res := UpdateApplication(context.Background(), &UpdateConfiguration{
+			NewRegFN:   mockClientFn,
+			ArgoClient: &argoClient,
+			KubeClient: &kubeClient,
+			UpdateApp:  appImages,
+			DryRun:     false,
+		}, NewSyncIterationState())
+		assert.Equal(t, 0, res.NumErrors)
+		assert.Equal(t, 1, res.NumSkipped)
+		assert.Equal(t, 1, res.NumApplicationsProcessed)
+		assert.Equal(t, 1, res.NumImagesConsidered)
+		assert.Equal(t, 0, res.NumImagesUpdated)
+		// No blank-tag image parameter should be written to the application spec.
+		assert.Empty(t, appImages.Application.Spec.Source.Kustomize.Images)
+	})
+
 	t.Run("Test error on improper semver in tag", func(t *testing.T) {
 		mockClientFn := func(endpoint *registry.RegistryEndpoint, username, password string) (registry.RegistryClient, error) {
 			regMock := regmock.RegistryClient{}


### PR DESCRIPTION
Motivation:
Issue https://github.com/argoproj-labs/argocd-image-updater/issues/1218
reports that an Application with multiple images can end up with a
blank image tag written into the spec when one image (added via
force-update, with no previously-live tag) matches zero tags in its
registry. The reporter traced this to GetNewestVersionFromTags in
registry-scanner/pkg/image/version.go returning the image's own
(possibly empty/dummy) current tag instead of nil when the registry
has no tags, which let the "already on latest allowed version" branch
in UpdateApplication write that empty tag back into the app spec.

That root cause was already fixed by a prior commit ("fix: don't write
empty tag when registry returns no tags"), which changed
GetNewestVersionFromTags to return nil when no tags are available and
added a regression test for the case of an already-tagged image with
an empty registry response (a separate but same-root-cause report at
https://github.com/argoproj-labs/argocd-image-updater/issues/1242).
However, the specific combination described in issue 1218 - a
force-update image whose live tag is nil (dummy tag path) plus an
empty registry response - was not covered by any existing test.

Approach:
Add a test in pkg/argocd/update_test.go that reproduces the issue 1218
scenario: an Image with ForceUpdate=true that is not part of the
application's live image summary (so GetImagesFromApplication injects
it with a nil tag, which UpdateApplication then replaces with a dummy
empty-string tag), combined with a registry mock that returns zero
tags. It asserts the image is skipped (NumSkipped=1, NumImagesUpdated=0)
and that no blank-tag entry is written into the Kustomize images list.
No production code was changed since the underlying defect is already
fixed on master.

Validation:
- go build ./... succeeds.
- go test ./pkg/argocd/... passes (full package, including the new test).
- Confirmed the new test is a true regression guard: temporarily
  reverted registry-scanner/pkg/image/version.go to the commit just
  before the one that fixed issue 1242 (same root cause), and reran
  the new test in isolation - it failed with the log line "Image
  '...' already on latest allowed version" and a blank-tag entry
  written into the spec, matching the symptom reported in issue 1218.
  Restored version.go afterward (git diff on that file is now empty).
- gofmt -l and go vet ./pkg/argocd/... are clean.

Report: https://github.com/argoproj-labs/argocd-image-updater/issues/1218
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

Fixes #1218

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of images when the registry returns no available tags.
  * Prevented invalid blank-tag images from being written to deployment configuration.
  * Ensured unaffected images are skipped without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->