### PR TITLE
fix(argocd): retain yaml document start if exists

### DIFF
--- a/pkg/argocd/git.go
+++ b/pkg/argocd/git.go
@@ -646,8 +646,8 @@ func leadingCommentPrefixLen(data []byte) int {
 // single-byte separator, and reports whether a newline was actually found
 // (data with no trailing newline is still one "line" for this purpose).
 func bytesCutNewline(data []byte) (line, rest []byte, found bool) {
-	if i := bytes.IndexByte(data, '\n'); i >= 0 {
-		return data[:i], data[i+1:], true
+	if before, after, ok := bytes.Cut(data, []byte{'\n'}); ok {
+		return before, after, true
 	}
 	return data, nil, false
 }

--- a/pkg/argocd/git.go
+++ b/pkg/argocd/git.go
@@ -434,7 +434,7 @@ func writeKustomization(ctx context.Context, applicationImages *ApplicationImage
 
 // updateKustomizeFile reads the kustomization file at path, applies the filter to it, and writes the result back
 // to the file. This is the same behavior as kyaml.UpdateFile, but it preserves the original order of YAML fields,
-// indentation of YAML sequences, and blank lines to minimize git diffs.
+// indentation of YAML sequences, blank lines, and a leading document-start marker to minimize git diffs.
 func updateKustomizeFile(ctx context.Context, filter kyaml.Filter, path string) (error, bool) {
 	log := log.LoggerFromContext(ctx)
 
@@ -444,13 +444,32 @@ func updateKustomizeFile(ctx context.Context, filter kyaml.Filter, path string) 
 		return err, false
 	}
 
+	// kio's ByteReadWriter discards a leading "---" document-start marker
+	// while parsing and never re-emits one for a single document. Detected
+	// after the leading run of blank lines/comments, not just at byte 0, so a
+	// marker preceded by a header comment is still found - that whole prefix
+	// (comments, blank lines, and the marker itself) sits outside any
+	// document node in kyaml's model and is dropped during parsing too, so
+	// both are restored together, verbatim, from these captured original
+	// bytes rather than from anything kyaml round-trips.
+	yPrefixLen := leadingCommentPrefixLen(yRaw)
+	hadDocStart := hasDocumentStartAt(yRaw, yPrefixLen)
+
 	// Encode blank lines as marker comments so they survive the kyaml round-trip.
 	// kyaml (go.yaml.in/yaml/v3) discards blank lines during parsing but preserves
 	// head comments, so we convert blank lines to comments and restore them afterward.
 	yEncoded := encodeBlankLines(yRaw)
 
+	// kio's YAML parser hard-errors on any input containing a "%YAML"/"%TAG"
+	// directive line, even though that content sits outside any document node
+	// and would otherwise just be dropped. Strip the whole leading prefix
+	// (comments, blank-line markers, and directives alike) before handing
+	// input to kio, since it's restored verbatim from yRaw at write time
+	// regardless of what kio does with it.
+	yBody := yEncoded[leadingCommentPrefixLen(yEncoded):]
+
 	// Read the yaml document from bytes (use encoded to keep comparison consistent)
-	originalYSlice, err := kio.FromBytes(yEncoded)
+	originalYSlice, err := kio.FromBytes(yBody)
 	if err != nil {
 		return err, false
 	}
@@ -470,7 +489,7 @@ func updateKustomizeFile(ctx context.Context, filter kyaml.Filter, path string) 
 	// Create a reader, preserving indentation of sequences
 	var out bytes.Buffer
 	rw := &kio.ByteReadWriter{
-		Reader:            bytes.NewBuffer(yEncoded),
+		Reader:            bytes.NewBuffer(yBody),
 		Writer:            &out,
 		PreserveSeqIndent: true,
 	}
@@ -515,8 +534,24 @@ func updateKustomizeFile(ctx context.Context, filter kyaml.Filter, path string) 
 		return nil, true
 	}
 
-	// Write to file the changes, restoring blank lines from the marker comments
-	if err := os.WriteFile(path, decodeBlankLines(out.Bytes()), 0600); err != nil {
+	// Write to file the changes, restoring blank lines from the marker comments,
+	// the leading comment/blank-line prefix, and the document-start marker, if
+	// the original had one. Content before "---" sits outside any document node
+	// in kyaml's model - it's dropped entirely during parsing, not merely
+	// un-preserved, so it never resurfaces in out.Bytes() no matter what
+	// encodeBlankLines does. It has to be spliced back in verbatim from the
+	// original bytes rather than searched for in the output. This applies
+	// whether or not the original had a document-start marker - a leading
+	// comment on a markerless file is just as much a part of the dropped
+	// prefix as one before "---".
+	outBytes := decodeBlankLines(out.Bytes())
+	restored := make([]byte, 0, yPrefixLen+4+len(outBytes))
+	restored = append(restored, yRaw[:yPrefixLen]...)
+	if hadDocStart && !bytes.HasPrefix(outBytes, []byte("---")) {
+		restored = append(restored, "---\n"...)
+	}
+	outBytes = append(restored, outBytes...)
+	if err := os.WriteFile(path, outBytes, 0600); err != nil {
 		return err, false
 	}
 
@@ -581,6 +616,55 @@ func encodeBlankLines(data []byte) []byte {
 // decodeBlankLines converts blank line markers back to actual blank lines.
 func decodeBlankLines(data []byte) []byte {
 	return bytes.ReplaceAll(data, []byte(blankLineMarker+"\n"), []byte("\n"))
+}
+
+// leadingCommentPrefixLen returns the byte length of data's leading run of
+// blank lines, "#"-comment lines, and "%YAML"/"%TAG" directive lines - all of
+// which sit outside any document node in kyaml's model and are dropped
+// entirely during parsing, along with a "---" marker they precede. Used so
+// that whole prefix can be located, captured, and spliced back in verbatim
+// rather than searched for in kyaml's output.
+func leadingCommentPrefixLen(data []byte) int {
+	offset := 0
+	for {
+		line, rest, found := bytesCutNewline(data[offset:])
+		trimmed := bytes.TrimSpace(line)
+		if len(trimmed) != 0 && trimmed[0] != '#' && trimmed[0] != '%' {
+			return offset
+		}
+		if !found {
+			return len(data)
+		}
+		// rest is a suffix of the original data slice (bytesCutNewline was
+		// given data[offset:], a suffix of data), so this is the byte index
+		// right after the newline just consumed.
+		offset = len(data) - len(rest)
+	}
+}
+
+// bytesCutNewline splits data at its first '\n', mirroring bytes.Cut for a
+// single-byte separator, and reports whether a newline was actually found
+// (data with no trailing newline is still one "line" for this purpose).
+func bytesCutNewline(data []byte) (line, rest []byte, found bool) {
+	if i := bytes.IndexByte(data, '\n'); i >= 0 {
+		return data[:i], data[i+1:], true
+	}
+	return data, nil, false
+}
+
+// hasDocumentStartAt reports whether data's line starting at byte offset
+// prefixLen is a YAML document-start marker ("---"), optionally followed by
+// whitespace and a trailing comment (e.g. "--- # header").
+func hasDocumentStartAt(data []byte, prefixLen int) bool {
+	line, _, _ := bytesCutNewline(data[prefixLen:])
+	// A document-start marker is only valid at column 0, so trim only
+	// trailing whitespace here - an indented "---" is ordinary scalar
+	// content, not a marker.
+	line = bytes.TrimRight(line, " \t\r\n")
+	if len(line) < 3 || string(line[:3]) != "---" {
+		return false
+	}
+	return len(line) == 3 || line[3] == ' ' || line[3] == '\t'
 }
 
 func findKustomization(base string) string {

--- a/pkg/argocd/git_test.go
+++ b/pkg/argocd/git_test.go
@@ -474,6 +474,108 @@ images:
 `,
 			filter: filter,
 		},
+		{
+			name: "preserves leading document-start marker",
+			content: `---
+images:
+- name: foo
+  digest: sha12345
+`,
+			wantContent: `---
+images:
+- name: foo
+  digest: sha23456
+`,
+			filter: filter,
+		},
+		{
+			name: "does not add a document-start marker when absent",
+			content: `images:
+- name: foo
+  digest: sha12345
+`,
+			wantContent: `images:
+- name: foo
+  digest: sha23456
+`,
+			filter: filter,
+		},
+		{
+			name: "preserves marker after a leading comment",
+			content: `# leading comment
+---
+images:
+- name: foo
+  digest: sha12345
+`,
+			wantContent: `# leading comment
+---
+images:
+- name: foo
+  digest: sha23456
+`,
+			filter: filter,
+		},
+		{
+			name: "preserves a leading comment when no marker is present",
+			content: `# leading comment
+images:
+- name: foo
+  digest: sha12345
+`,
+			wantContent: `# leading comment
+images:
+- name: foo
+  digest: sha23456
+`,
+			filter: filter,
+		},
+		{
+			name: "preserves a leading blank line when no marker is present",
+			content: `
+images:
+- name: foo
+  digest: sha12345
+`,
+			wantContent: `
+images:
+- name: foo
+  digest: sha23456
+`,
+			filter: filter,
+		},
+		{
+			name: "preserves marker after a leading blank line",
+			content: `
+---
+images:
+- name: foo
+  digest: sha12345
+`,
+			wantContent: `
+---
+images:
+- name: foo
+  digest: sha23456
+`,
+			filter: filter,
+		},
+		{
+			name: "preserves marker after a leading YAML directive",
+			content: `%YAML 1.2
+---
+images:
+- name: foo
+  digest: sha12345
+`,
+			wantContent: `%YAML 1.2
+---
+images:
+- name: foo
+  digest: sha23456
+`,
+			filter: filter,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -666,4 +768,23 @@ func Test_commitChangesGit_APIMethodFallsBackWithoutAppCreds(t *testing.T) {
 	gitMock.AssertCalled(t, "Push", "origin", "main", false)
 	// The API commit path must not have been taken.
 	gitMock.AssertNotCalled(t, "WorkingTreeChanges")
+}
+
+func Test_hasDocumentStartAt(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want bool
+	}{
+		{name: "marker at column 0", data: "---\nfoo: bar\n", want: true},
+		{name: "marker at column 0 with trailing comment", data: "--- # header\nfoo: bar\n", want: true},
+		{name: "indented marker is not a document start", data: "   ---\nfoo: bar\n", want: false},
+		{name: "tab-indented marker is not a document start", data: "\t---\nfoo: bar\n", want: false},
+		{name: "no marker", data: "foo: bar\n", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, hasDocumentStartAt([]byte(tt.data), 0))
+		})
+	}
 }

--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -414,7 +414,11 @@ func setAppImage(ctx context.Context, app *v1alpha1.Application, img *image.Cont
 	}
 }
 
-func marshalWithIndent(in any, indent int) (out []byte, err error) {
+// marshalWithIndent marshals in to YAML with the given indent, optionally
+// prepending an explicit "---" document-start marker. See
+// hasExplicitDocumentStart for why callers track and pass that bit through
+// explicitly rather than relying on the encoder to preserve it.
+func marshalWithIndent(in interface{}, indent int, explicitStart bool) (out []byte, err error) {
 	var b bytes.Buffer
 	encoder := yaml.NewEncoder(&b)
 	defer encoder.Close()
@@ -427,7 +431,34 @@ func marshalWithIndent(in any, indent int) (out []byte, err error) {
 	if err = encoder.Close(); err != nil {
 		return nil, err
 	}
-	return b.Bytes(), nil
+	out = b.Bytes()
+	if explicitStart {
+		out = append([]byte("---\n"), out...)
+	}
+	return out, nil
+}
+
+// hasExplicitDocumentStart reports whether raw's first line that isn't
+// blank, a "#" comment, or a "%YAML"/"%TAG" directive is a YAML
+// document-start marker ("---"). Directives are only ever valid directly
+// before a document-start marker, so skipping them is required for
+// correctness, not just leniency. Write-back re-marshals the target file
+// through an Encoder that has no memory of the source's original formatting,
+// so callers use this to carry that one bit of information through the
+// round-trip explicitly, rather than always adding or always dropping the
+// marker regardless of what the file looked like before.
+func hasExplicitDocumentStart(raw []byte) bool {
+	for _, line := range strings.Split(string(raw), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "%") {
+			continue
+		}
+		// A document-start marker is only valid at column 0, so check the
+		// untrimmed line rather than trimmed - an indented "---" is ordinary
+		// scalar content, not a marker.
+		return line == "---" || strings.HasPrefix(line, "--- ") || strings.HasPrefix(line, "---\t")
+	}
+	return false
 }
 
 // marshalParamsOverride marshals the parameter overrides of a given application
@@ -438,6 +469,7 @@ func marshalParamsOverride(ctx context.Context, applicationImages *ApplicationIm
 	var err error
 	app := &applicationImages.Application
 	wbc := applicationImages.WriteBackConfig
+	explicitStart := hasExplicitDocumentStart(originalData)
 
 	appSource := GetApplicationSource(ctx, app, wbc)
 
@@ -472,14 +504,14 @@ func marshalParamsOverride(ctx context.Context, applicationImages *ApplicationIm
 		}
 
 		if len(originalData) == 0 {
-			override, err = marshalWithIndent(newParams, defaultIndent)
+			override, err = marshalWithIndent(newParams, defaultIndent, explicitStart)
 		} else {
 			var params pluginOverride
 			if unmarshalErr := yaml.Unmarshal(originalData, &params); unmarshalErr != nil {
-				override, err = marshalWithIndent(newParams, defaultIndent)
+				override, err = marshalWithIndent(newParams, defaultIndent, explicitStart)
 			} else {
 				mergePluginOverride(&params, &newParams)
-				override, err = marshalWithIndent(params, defaultIndent)
+				override, err = marshalWithIndent(params, defaultIndent, explicitStart)
 			}
 		}
 		if err != nil {
@@ -504,16 +536,16 @@ func marshalParamsOverride(ctx context.Context, applicationImages *ApplicationIm
 		}
 
 		if len(originalData) == 0 {
-			override, err = marshalWithIndent(newParams, defaultIndent)
+			override, err = marshalWithIndent(newParams, defaultIndent, explicitStart)
 			break
 		}
 		err = yaml.Unmarshal(originalData, &params)
 		if err != nil {
-			override, err = marshalWithIndent(newParams, defaultIndent)
+			override, err = marshalWithIndent(newParams, defaultIndent, explicitStart)
 			break
 		}
 		mergeKustomizeOverride(&params, &newParams)
-		override, err = marshalWithIndent(params, defaultIndent)
+		override, err = marshalWithIndent(params, defaultIndent, explicitStart)
 	case ApplicationTypeHelm:
 		// Extract Helm parameters safely; Helm may be nil for SourceHydrator apps
 		// where the source type is auto-detected from files rather than set in the spec.
@@ -631,18 +663,18 @@ func marshalParamsOverride(ctx context.Context, applicationImages *ApplicationIm
 
 			if len(originalData) == 0 {
 				sortHelmParameters(newParams.Helm.Parameters)
-				override, err = marshalWithIndent(newParams, defaultIndent)
+				override, err = marshalWithIndent(newParams, defaultIndent, explicitStart)
 				break
 			}
 			err = yaml.Unmarshal(originalData, &params)
 			if err != nil {
 				sortHelmParameters(newParams.Helm.Parameters)
-				override, err = marshalWithIndent(newParams, defaultIndent)
+				override, err = marshalWithIndent(newParams, defaultIndent, explicitStart)
 				break
 			}
 			mergeHelmOverride(&params, &newParams)
 			sortHelmParameters(params.Helm.Parameters)
-			override, err = marshalWithIndent(params, defaultIndent)
+			override, err = marshalWithIndent(params, defaultIndent, explicitStart)
 		}
 	default:
 		err = fmt.Errorf("unsupported application type")
@@ -754,7 +786,7 @@ func nodeKindString(k yaml.Kind) string {
 }
 
 // setHelmValue sets value of the parameter passed from the CRD configuration.
-func setHelmValue(currentValues *yaml.Node, key string, value any) error {
+func setHelmValue(currentValues *yaml.Node, key string, value interface{}) error {
 	current := currentValues
 
 	// an unmarshalled document has a DocumentNode at the root, but
@@ -976,7 +1008,7 @@ func applyHelmValueWrites(root *yaml.Node, originalData []byte, writes []helmVal
 			return nil, fmt.Errorf("failed to set image parameter %s value: %v", w.kind, err)
 		}
 	}
-	return marshalWithIndent(root, defaultIndent)
+	return marshalWithIndent(root, defaultIndent, hasExplicitDocumentStart(originalData))
 }
 
 // patchHelmValuesInPlace edits value text directly in originalData. It succeeds
@@ -1055,7 +1087,7 @@ func isSafePlainScalar(s string) bool {
 	// Reject values a YAML parser resolves as a non-string (int, float, bool,
 	// null): written unquoted, an image tag like "1.20" or "true" would
 	// round-trip as a float/bool instead of a string.
-	var v any
+	var v interface{}
 	if err := yaml.Unmarshal([]byte(s), &v); err != nil {
 		return false
 	}

--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -415,10 +415,10 @@ func setAppImage(ctx context.Context, app *v1alpha1.Application, img *image.Cont
 }
 
 // marshalWithIndent marshals in to YAML with the given indent, optionally
-// prepending an explicit "---" document-start marker. See
-// hasExplicitDocumentStart for why callers track and pass that bit through
-// explicitly rather than relying on the encoder to preserve it.
-func marshalWithIndent(in interface{}, indent int, explicitStart bool) (out []byte, err error) {
+// prepending docStartPrefix verbatim. See leadingDocumentStartPrefix for why
+// callers track and pass that prefix through explicitly rather than relying
+// on the encoder to preserve it.
+func marshalWithIndent(in any, indent int, docStartPrefix []byte) (out []byte, err error) {
 	var b bytes.Buffer
 	encoder := yaml.NewEncoder(&b)
 	defer encoder.Close()
@@ -432,33 +432,45 @@ func marshalWithIndent(in interface{}, indent int, explicitStart bool) (out []by
 		return nil, err
 	}
 	out = b.Bytes()
-	if explicitStart {
-		out = append([]byte("---\n"), out...)
+	if len(docStartPrefix) > 0 {
+		out = append(append([]byte{}, docStartPrefix...), out...)
 	}
 	return out, nil
 }
 
-// hasExplicitDocumentStart reports whether raw's first line that isn't
-// blank, a "#" comment, or a "%YAML"/"%TAG" directive is a YAML
-// document-start marker ("---"). Directives are only ever valid directly
+// leadingDocumentStartPrefix returns raw's leading run of blank lines, "#"
+// comments, and "%YAML"/"%TAG" directives, together with the "---"
+// document-start marker that follows them, verbatim and including its
+// trailing newline - or nil if that leading run isn't followed by an
+// explicit document-start marker. Directives are only ever valid directly
 // before a document-start marker, so skipping them is required for
 // correctness, not just leniency. Write-back re-marshals the target file
 // through an Encoder that has no memory of the source's original formatting,
-// so callers use this to carry that one bit of information through the
-// round-trip explicitly, rather than always adding or always dropping the
-// marker regardless of what the file looked like before.
-func hasExplicitDocumentStart(raw []byte) bool {
-	for _, line := range strings.Split(string(raw), "\n") {
-		trimmed := strings.TrimSpace(line)
+// so callers use this to carry that whole prefix through the round-trip
+// verbatim, rather than always adding or always dropping it regardless of
+// what the file looked like before.
+func leadingDocumentStartPrefix(raw []byte) []byte {
+	lines := strings.Split(string(raw), "\n")
+	n := 0
+	for n < len(lines) {
+		trimmed := strings.TrimSpace(lines[n])
 		if trimmed == "" || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "%") {
+			n++
 			continue
 		}
-		// A document-start marker is only valid at column 0, so check the
-		// untrimmed line rather than trimmed - an indented "---" is ordinary
-		// scalar content, not a marker.
-		return line == "---" || strings.HasPrefix(line, "--- ") || strings.HasPrefix(line, "---\t")
+		break
 	}
-	return false
+	if n >= len(lines) {
+		return nil
+	}
+	// A document-start marker is only valid at column 0, so check the
+	// untrimmed line rather than trimmed - an indented "---" is ordinary
+	// scalar content, not a marker.
+	marker := lines[n]
+	if marker != "---" && !strings.HasPrefix(marker, "--- ") && !strings.HasPrefix(marker, "---\t") {
+		return nil
+	}
+	return []byte(strings.Join(lines[:n+1], "\n") + "\n")
 }
 
 // marshalParamsOverride marshals the parameter overrides of a given application
@@ -469,7 +481,7 @@ func marshalParamsOverride(ctx context.Context, applicationImages *ApplicationIm
 	var err error
 	app := &applicationImages.Application
 	wbc := applicationImages.WriteBackConfig
-	explicitStart := hasExplicitDocumentStart(originalData)
+	docStartPrefix := leadingDocumentStartPrefix(originalData)
 
 	appSource := GetApplicationSource(ctx, app, wbc)
 
@@ -504,14 +516,14 @@ func marshalParamsOverride(ctx context.Context, applicationImages *ApplicationIm
 		}
 
 		if len(originalData) == 0 {
-			override, err = marshalWithIndent(newParams, defaultIndent, explicitStart)
+			override, err = marshalWithIndent(newParams, defaultIndent, docStartPrefix)
 		} else {
 			var params pluginOverride
 			if unmarshalErr := yaml.Unmarshal(originalData, &params); unmarshalErr != nil {
-				override, err = marshalWithIndent(newParams, defaultIndent, explicitStart)
+				override, err = marshalWithIndent(newParams, defaultIndent, docStartPrefix)
 			} else {
 				mergePluginOverride(&params, &newParams)
-				override, err = marshalWithIndent(params, defaultIndent, explicitStart)
+				override, err = marshalWithIndent(params, defaultIndent, docStartPrefix)
 			}
 		}
 		if err != nil {
@@ -536,16 +548,16 @@ func marshalParamsOverride(ctx context.Context, applicationImages *ApplicationIm
 		}
 
 		if len(originalData) == 0 {
-			override, err = marshalWithIndent(newParams, defaultIndent, explicitStart)
+			override, err = marshalWithIndent(newParams, defaultIndent, docStartPrefix)
 			break
 		}
 		err = yaml.Unmarshal(originalData, &params)
 		if err != nil {
-			override, err = marshalWithIndent(newParams, defaultIndent, explicitStart)
+			override, err = marshalWithIndent(newParams, defaultIndent, docStartPrefix)
 			break
 		}
 		mergeKustomizeOverride(&params, &newParams)
-		override, err = marshalWithIndent(params, defaultIndent, explicitStart)
+		override, err = marshalWithIndent(params, defaultIndent, docStartPrefix)
 	case ApplicationTypeHelm:
 		// Extract Helm parameters safely; Helm may be nil for SourceHydrator apps
 		// where the source type is auto-detected from files rather than set in the spec.
@@ -663,18 +675,18 @@ func marshalParamsOverride(ctx context.Context, applicationImages *ApplicationIm
 
 			if len(originalData) == 0 {
 				sortHelmParameters(newParams.Helm.Parameters)
-				override, err = marshalWithIndent(newParams, defaultIndent, explicitStart)
+				override, err = marshalWithIndent(newParams, defaultIndent, docStartPrefix)
 				break
 			}
 			err = yaml.Unmarshal(originalData, &params)
 			if err != nil {
 				sortHelmParameters(newParams.Helm.Parameters)
-				override, err = marshalWithIndent(newParams, defaultIndent, explicitStart)
+				override, err = marshalWithIndent(newParams, defaultIndent, docStartPrefix)
 				break
 			}
 			mergeHelmOverride(&params, &newParams)
 			sortHelmParameters(params.Helm.Parameters)
-			override, err = marshalWithIndent(params, defaultIndent, explicitStart)
+			override, err = marshalWithIndent(params, defaultIndent, docStartPrefix)
 		}
 	default:
 		err = fmt.Errorf("unsupported application type")
@@ -786,7 +798,7 @@ func nodeKindString(k yaml.Kind) string {
 }
 
 // setHelmValue sets value of the parameter passed from the CRD configuration.
-func setHelmValue(currentValues *yaml.Node, key string, value interface{}) error {
+func setHelmValue(currentValues *yaml.Node, key string, value any) error {
 	current := currentValues
 
 	// an unmarshalled document has a DocumentNode at the root, but
@@ -1008,7 +1020,7 @@ func applyHelmValueWrites(root *yaml.Node, originalData []byte, writes []helmVal
 			return nil, fmt.Errorf("failed to set image parameter %s value: %v", w.kind, err)
 		}
 	}
-	return marshalWithIndent(root, defaultIndent, hasExplicitDocumentStart(originalData))
+	return marshalWithIndent(root, defaultIndent, leadingDocumentStartPrefix(originalData))
 }
 
 // patchHelmValuesInPlace edits value text directly in originalData. It succeeds
@@ -1087,7 +1099,7 @@ func isSafePlainScalar(s string) bool {
 	// Reject values a YAML parser resolves as a non-string (int, float, bool,
 	// null): written unquoted, an image tag like "1.20" or "true" would
 	// round-trip as a float/bool instead of a string.
-	var v interface{}
+	var v any
 	if err := yaml.Unmarshal([]byte(s), &v); err != nil {
 		return false
 	}

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -2223,12 +2223,12 @@ registries:
 		// whose Payload() is nil, so godigest.FromBytes(nil) is the image manifest digest.
 		payloadType := "application/vnd.dev.cosign.simplesigning.v1+json"
 		imgManifestDigest := godigest.FromBytes(nil).String()
-		payload := fmt.Appendf(nil,
+		payload := []byte(fmt.Sprintf(
 			`{"critical":{"image":{"docker-manifest-digest":"%s"}}}`,
 			imgManifestDigest,
-		)
+		))
 		pae := append(
-			fmt.Appendf(nil, "DSSEv1 %d %s %d ", len(payloadType), payloadType, len(payload)),
+			[]byte(fmt.Sprintf("DSSEv1 %d %s %d ", len(payloadType), payloadType, len(payload))),
 			payload...,
 		)
 		paeHash := sha256.Sum256(pae)
@@ -4411,7 +4411,7 @@ replicas: 1
 		require.NoError(t, err)
 		assert.NotEmpty(t, override)
 
-		var out map[string]any
+		var out map[string]interface{}
 		err = yaml.Unmarshal(override, &out)
 		require.NoError(t, err)
 
@@ -4475,7 +4475,7 @@ replicas: 1
 		require.NoError(t, err)
 		assert.NotEmpty(t, override)
 
-		var out map[string]any
+		var out map[string]interface{}
 		err = yaml.Unmarshal(override, &out)
 		require.NoError(t, err)
 		_, ok := out["image.tag"]
@@ -4839,7 +4839,7 @@ image:
 		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
 
-		output, err := marshalWithIndent(&input, defaultIndent)
+		output, err := marshalWithIndent(&input, defaultIndent, false)
 		require.NoError(t, err)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})
@@ -4858,7 +4858,7 @@ image:
 		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
 
-		output, err := marshalWithIndent(&input, defaultIndent)
+		output, err := marshalWithIndent(&input, defaultIndent, false)
 		require.NoError(t, err)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})
@@ -4886,7 +4886,7 @@ image:
 		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
 
-		output, err := marshalWithIndent(&input, defaultIndent)
+		output, err := marshalWithIndent(&input, defaultIndent, false)
 		require.NoError(t, err)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})
@@ -4908,7 +4908,7 @@ tag: v2.0.0
 		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
 
-		output, err := marshalWithIndent(&input, defaultIndent)
+		output, err := marshalWithIndent(&input, defaultIndent, false)
 		require.NoError(t, err)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})
@@ -4929,7 +4929,7 @@ tag: v2.0.0
 		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
 
-		output, err := marshalWithIndent(&input, defaultIndent)
+		output, err := marshalWithIndent(&input, defaultIndent, false)
 		require.NoError(t, err)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})
@@ -4987,7 +4987,7 @@ image:
 		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
 
-		output, err := marshalWithIndent(&input, defaultIndent)
+		output, err := marshalWithIndent(&input, defaultIndent, false)
 		require.NoError(t, err)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})
@@ -5020,7 +5020,7 @@ image:
 		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
 
-		output, err := marshalWithIndent(&input, defaultIndent)
+		output, err := marshalWithIndent(&input, defaultIndent, false)
 		require.NoError(t, err)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})
@@ -5051,7 +5051,7 @@ image:
 		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
 
-		output, err := marshalWithIndent(&input, defaultIndent)
+		output, err := marshalWithIndent(&input, defaultIndent, false)
 		require.NoError(t, err)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})
@@ -5082,7 +5082,7 @@ images:
 		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
 
-		output, err := marshalWithIndent(&input, defaultIndent)
+		output, err := marshalWithIndent(&input, defaultIndent, false)
 		require.NoError(t, err)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})
@@ -5121,7 +5121,7 @@ images:
 		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
 
-		output, err := marshalWithIndent(&input, defaultIndent)
+		output, err := marshalWithIndent(&input, defaultIndent, false)
 		require.NoError(t, err)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})
@@ -5154,7 +5154,7 @@ extraContainers:
 		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
 
-		output, err := marshalWithIndent(&input, defaultIndent)
+		output, err := marshalWithIndent(&input, defaultIndent, false)
 		require.NoError(t, err)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})
@@ -5187,7 +5187,7 @@ extraContainers:
 		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
 
-		output, err := marshalWithIndent(&input, defaultIndent)
+		output, err := marshalWithIndent(&input, defaultIndent, false)
 		require.NoError(t, err)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})
@@ -5345,9 +5345,9 @@ func Test_GetWriteBackConfig(t *testing.T) {
 
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: new("git"),
+			Method: stringPtr("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: new("mybranch:mytargetbranch"),
+				Branch: stringPtr("mybranch:mytargetbranch"),
 			},
 		}
 
@@ -5383,9 +5383,9 @@ func Test_GetWriteBackConfig(t *testing.T) {
 
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: new("git"),
+			Method: stringPtr("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: new(":mytargetbranch"),
+				Branch: stringPtr(":mytargetbranch"),
 			},
 		}
 
@@ -5420,9 +5420,9 @@ func Test_GetWriteBackConfig(t *testing.T) {
 
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: new("git"),
+			Method: stringPtr("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: new("mybranch"),
+				Branch: stringPtr("mybranch"),
 			},
 		}
 
@@ -5460,7 +5460,7 @@ func Test_GetWriteBackConfig(t *testing.T) {
 
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: new("argocd"),
+			Method: stringPtr("argocd"),
 		}
 
 		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, nil, settings)
@@ -5497,10 +5497,10 @@ func Test_GetWriteBackConfig(t *testing.T) {
 
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: new("git"),
+			Method: stringPtr("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch:          new("mybranch:mytargetbranch"),
-				WriteBackTarget: new("kustomization:../bar"),
+				Branch:          stringPtr("mybranch:mytargetbranch"),
+				WriteBackTarget: stringPtr("kustomization:../bar"),
 			},
 		}
 
@@ -5539,10 +5539,10 @@ func Test_GetWriteBackConfig(t *testing.T) {
 
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: new("git"),
+			Method: stringPtr("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch:          new("mybranch:mytargetbranch"),
-				WriteBackTarget: new("helmvalues:../bar/values.yaml"),
+				Branch:          stringPtr("mybranch:mytargetbranch"),
+				WriteBackTarget: stringPtr("helmvalues:../bar/values.yaml"),
 			},
 		}
 
@@ -5581,10 +5581,10 @@ func Test_GetWriteBackConfig(t *testing.T) {
 
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: new("git"),
+			Method: stringPtr("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch:          new("mybranch:mytargetbranch"),
-				WriteBackTarget: new("helmvalues"),
+				Branch:          stringPtr("mybranch:mytargetbranch"),
+				WriteBackTarget: stringPtr("helmvalues"),
 			},
 		}
 
@@ -5623,10 +5623,10 @@ func Test_GetWriteBackConfig(t *testing.T) {
 
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: new("git"),
+			Method: stringPtr("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch:          new("mybranch:mytargetbranch"),
-				WriteBackTarget: new("helmvalues:/helm/app/values.yaml"),
+				Branch:          stringPtr("mybranch:mytargetbranch"),
+				WriteBackTarget: stringPtr("helmvalues:/helm/app/values.yaml"),
 			},
 		}
 
@@ -5665,10 +5665,10 @@ func Test_GetWriteBackConfig(t *testing.T) {
 
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: new("git"),
+			Method: stringPtr("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch:          new("mybranch:mytargetbranch"),
-				WriteBackTarget: new("target/folder/app-parameters.yaml"),
+				Branch:          stringPtr("mybranch:mytargetbranch"),
+				WriteBackTarget: stringPtr("target/folder/app-parameters.yaml"),
 			},
 		}
 
@@ -5707,9 +5707,9 @@ func Test_GetWriteBackConfig(t *testing.T) {
 
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: new("git:error:argocd-image-updater/git-creds"),
+			Method: stringPtr("git:error:argocd-image-updater/git-creds"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: new("mybranch:mytargetbranch"),
+				Branch: stringPtr("mybranch:mytargetbranch"),
 			},
 		}
 
@@ -5744,9 +5744,9 @@ func Test_GetWriteBackConfig(t *testing.T) {
 
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: new("argocd"),
+			Method: stringPtr("argocd"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: new("mybranch:mytargetbranch"),
+				Branch: stringPtr("mybranch:mytargetbranch"),
 			},
 		}
 
@@ -5783,9 +5783,9 @@ func Test_GetWriteBackConfig(t *testing.T) {
 
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: new("unknown"),
+			Method: stringPtr("unknown"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: new("mybranch:mytargetbranch"),
+				Branch: stringPtr("mybranch:mytargetbranch"),
 			},
 		}
 
@@ -5826,9 +5826,9 @@ func Test_GetGitCreds(t *testing.T) {
 		}
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: new("git:secret:argocd-image-updater/git-creds"),
+			Method: stringPtr("git:secret:argocd-image-updater/git-creds"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: new("mybranch:mytargetbranch"),
+				Branch: stringPtr("mybranch:mytargetbranch"),
 			},
 		}
 
@@ -5873,9 +5873,9 @@ func Test_GetGitCreds(t *testing.T) {
 		}
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: new("git:secret:argocd-image-updater/git-creds"),
+			Method: stringPtr("git:secret:argocd-image-updater/git-creds"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: new("mybranch:mytargetbranch"),
+				Branch: stringPtr("mybranch:mytargetbranch"),
 			},
 		}
 
@@ -5919,9 +5919,9 @@ func Test_GetGitCreds(t *testing.T) {
 			}
 			// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 			settings := &iuapi.WriteBackConfig{
-				Method: new("git:secret:argocd-image-updater/git-creds"),
+				Method: stringPtr("git:secret:argocd-image-updater/git-creds"),
 				GitConfig: &iuapi.GitConfig{
-					Branch: new("mybranch:mytargetbranch"),
+					Branch: stringPtr("mybranch:mytargetbranch"),
 				},
 			}
 
@@ -5960,9 +5960,9 @@ func Test_GetGitCreds(t *testing.T) {
 		}
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: new("git:secret:argocd-image-updater/git-creds"),
+			Method: stringPtr("git:secret:argocd-image-updater/git-creds"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: new("mybranch:mytargetbranch"),
+				Branch: stringPtr("mybranch:mytargetbranch"),
 			},
 		}
 
@@ -6019,9 +6019,9 @@ func Test_GetGitCreds(t *testing.T) {
 		}
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: new("git"),
+			Method: stringPtr("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: new("mybranch:mytargetbranch"),
+				Branch: stringPtr("mybranch:mytargetbranch"),
 			},
 		}
 
@@ -6065,9 +6065,9 @@ func Test_GetGitCreds(t *testing.T) {
 		}
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: new("git"),
+			Method: stringPtr("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: new("mybranch:mytargetbranch"),
+				Branch: stringPtr("mybranch:mytargetbranch"),
 			},
 		}
 
@@ -6108,9 +6108,9 @@ func Test_GetGitCreds(t *testing.T) {
 		}
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: new("git"),
+			Method: stringPtr("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: new("mybranch:mytargetbranch"),
+				Branch: stringPtr("mybranch:mytargetbranch"),
 			},
 		}
 
@@ -6151,9 +6151,9 @@ func Test_GetGitCreds(t *testing.T) {
 		}
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: new("git"),
+			Method: stringPtr("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: new("mybranch:mytargetbranch"),
+				Branch: stringPtr("mybranch:mytargetbranch"),
 			},
 		}
 
@@ -6195,10 +6195,10 @@ func Test_GetGitCreds(t *testing.T) {
 
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: new("git:secret:argocd-image-updater/git-creds"),
+			Method: stringPtr("git:secret:argocd-image-updater/git-creds"),
 			GitConfig: &iuapi.GitConfig{
-				Branch:     new("mybranch:mytargetbranch"),
-				Repository: new("git@github.com:example/example.git"),
+				Branch:     stringPtr("mybranch:mytargetbranch"),
+				Repository: stringPtr("git@github.com:example/example.git"),
 			},
 		}
 
@@ -6695,9 +6695,9 @@ replacements: []
 		}).Return(fmt.Errorf("could not configure git"))
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: new("git"),
+			Method: stringPtr("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: new("mybranch:mytargetbranch"),
+				Branch: stringPtr("mybranch:mytargetbranch"),
 			},
 		}
 
@@ -6728,9 +6728,9 @@ replacements: []
 		gitMock.On("Push", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: new("git"),
+			Method: stringPtr("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: new("mybranch:mytargetbranch"),
+				Branch: stringPtr("mybranch:mytargetbranch"),
 			},
 		}
 		ctx := context.Background()
@@ -6756,9 +6756,9 @@ replacements: []
 		gitMock.On("Push", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: new("git"),
+			Method: stringPtr("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: new("mybranch:mytargetbranch"),
+				Branch: stringPtr("mybranch:mytargetbranch"),
 			},
 		}
 		ctx := context.Background()
@@ -6783,9 +6783,9 @@ replacements: []
 		gitMock.On("Push", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: new("git"),
+			Method: stringPtr("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: new("mybranch:mytargetbranch"),
+				Branch: stringPtr("mybranch:mytargetbranch"),
 			},
 		}
 		ctx := context.Background()
@@ -6811,9 +6811,9 @@ replacements: []
 		gitMock.On("Push", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: new("git"),
+			Method: stringPtr("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: new("mybranch:mytargetbranch"),
+				Branch: stringPtr("mybranch:mytargetbranch"),
 			},
 		}
 		ctx := context.Background()
@@ -6839,9 +6839,9 @@ replacements: []
 		gitMock.On("Push", mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("cannot push"))
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: new("git"),
+			Method: stringPtr("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: new("mybranch:mytargetbranch"),
+				Branch: stringPtr("mybranch:mytargetbranch"),
 			},
 		}
 		ctx := context.Background()
@@ -6869,9 +6869,9 @@ replacements: []
 		gitMock.On("SymRefToBranch", mock.Anything).Return("", fmt.Errorf("failed to resolve ref"))
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: new("git"),
+			Method: stringPtr("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: new("mybranch:mytargetbranch"),
+				Branch: stringPtr("mybranch:mytargetbranch"),
 			},
 		}
 
@@ -7272,6 +7272,11 @@ plugin:
 	})
 }
 
+// Helper function to create string pointers for testing
+func stringPtr(s string) *string {
+	return &s
+}
+
 // TestMarshalParamsOverride_PreservesFormatting verifies that when every write
 // updates an existing key, the values file is patched in place with byte-exact
 // preservation of comments, blank lines, indentation, anchors and inline
@@ -7559,6 +7564,132 @@ func TestMarshalParamsOverride_FallsBackForQuotedTarget(t *testing.T) {
 	tag, err := getHelmValue(&got, "config.image.tag")
 	require.NoError(t, err)
 	assert.Equal(t, "v2.0.0", tag)
+}
+
+// TestMarshalParamsOverride_PreservesDocumentStart_Kustomize verifies that a
+// Kustomize write-back keeps a leading YAML document-start marker ("---")
+// when the original file had one, and does not introduce one when it didn't.
+// argocd-image-updater's write-back re-marshals the target file through a
+// yaml.Encoder that has no memory of the source's original formatting, so
+// this is a deliberate, explicit round-trip rather than an accident of the
+// underlying library - and it has to hold in both directions: always adding
+// the marker would just move the "document-start" lint failure onto anyone
+// who enforces its absence instead of its presence.
+func TestMarshalParamsOverride_PreservesDocumentStart_Kustomize(t *testing.T) {
+	app := v1alpha1.Application{
+		ObjectMeta: v1.ObjectMeta{Name: "testapp"},
+		Spec: v1alpha1.ApplicationSpec{
+			Source: &v1alpha1.ApplicationSource{
+				RepoURL:        "https://example.com/example",
+				TargetRevision: "main",
+				Kustomize: &v1alpha1.ApplicationSourceKustomize{
+					Images: v1alpha1.KustomizeImages{"foo"},
+				},
+			},
+		},
+		Status: v1alpha1.ApplicationStatus{
+			SourceType: v1alpha1.ApplicationSourceTypeKustomize,
+		},
+	}
+	applicationImages := &ApplicationImages{
+		Application: app,
+		Images:      ImageList{NewImage(image.NewFromIdentifier("nginx"))},
+	}
+
+	t.Run("preserves marker when present", func(t *testing.T) {
+		originalData := []byte("---\nkustomize:\n  images:\n  - baz\n")
+		out, err := marshalParamsOverride(context.Background(), applicationImages, originalData)
+		require.NoError(t, err)
+		assert.True(t, strings.HasPrefix(string(out), "---\n"),
+			"expected output to start with '---', got: %q", string(out))
+	})
+
+	t.Run("does not add marker when absent", func(t *testing.T) {
+		originalData := []byte("kustomize:\n  images:\n  - baz\n")
+		out, err := marshalParamsOverride(context.Background(), applicationImages, originalData)
+		require.NoError(t, err)
+		assert.False(t, strings.HasPrefix(string(out), "---"),
+			"expected no '---' in output, got: %q", string(out))
+	})
+
+	t.Run("recognizes a tab-separated marker", func(t *testing.T) {
+		originalData := []byte("---\t# header\nkustomize:\n  images:\n  - baz\n")
+		out, err := marshalParamsOverride(context.Background(), applicationImages, originalData)
+		require.NoError(t, err)
+		assert.True(t, strings.HasPrefix(string(out), "---\n"),
+			"expected output to start with '---', got: %q", string(out))
+	})
+
+	t.Run("recognizes a marker after a leading YAML directive", func(t *testing.T) {
+		originalData := []byte("%YAML 1.2\n---\nkustomize:\n  images:\n  - baz\n")
+		out, err := marshalParamsOverride(context.Background(), applicationImages, originalData)
+		require.NoError(t, err)
+		assert.True(t, strings.HasPrefix(string(out), "---\n"),
+			"expected output to start with '---', got: %q", string(out))
+	})
+
+	t.Run("does not treat an indented marker as a document start", func(t *testing.T) {
+		originalData := []byte("   ---\nkustomize:\n  images:\n  - baz\n")
+		out, err := marshalParamsOverride(context.Background(), applicationImages, originalData)
+		require.NoError(t, err)
+		assert.False(t, strings.HasPrefix(string(out), "---"),
+			"expected no '---' in output, got: %q", string(out))
+	})
+}
+
+// TestMarshalParamsOverride_PreservesDocumentStart_HelmFallback exercises the
+// applyHelmValueWrites fallback path (setHelmValue + marshalWithIndent, not
+// the in-place byte patcher) to confirm it also carries the document-start
+// choice through, not just the Kustomize/plugin/plain-Helm branches in
+// marshalParamsOverride itself.
+func TestMarshalParamsOverride_PreservesDocumentStart_HelmFallback(t *testing.T) {
+	originalData := []byte(`---
+config:
+  image:
+    repository: myapp
+    tag: "v1.0.0"
+`)
+
+	app := v1alpha1.Application{
+		ObjectMeta: v1.ObjectMeta{Name: "testapp"},
+		Spec: v1alpha1.ApplicationSpec{
+			Sources: []v1alpha1.ApplicationSource{
+				{
+					Chart: "my-app",
+					Helm: &v1alpha1.ApplicationSourceHelm{
+						ReleaseName: "my-app",
+						ValueFiles:  []string{"$values/some/dir/values.yaml"},
+						Parameters: []v1alpha1.HelmParameter{
+							{Name: "config.image.repository", Value: "myapp", ForceString: true},
+							{Name: "config.image.tag", Value: "v2.0.0", ForceString: true},
+						},
+					},
+					RepoURL:        "https://example.com/example",
+					TargetRevision: "main",
+				},
+				{Ref: "values", RepoURL: "https://example.com/example2", TargetRevision: "main"},
+			},
+		},
+		Status: v1alpha1.ApplicationStatus{
+			SourceTypes: []v1alpha1.ApplicationSourceType{v1alpha1.ApplicationSourceTypeHelm, ""},
+			Summary:     v1alpha1.ApplicationSummary{Images: []string{"myapp:v1.0.0"}},
+		},
+	}
+
+	im := NewImage(image.NewFromIdentifier("app=myapp"))
+	im.HelmImageName = "config.image.repository"
+	im.HelmImageTag = "config.image.tag"
+
+	applicationImages := &ApplicationImages{
+		Application:     app,
+		Images:          ImageList{im},
+		WriteBackConfig: &WriteBackConfig{Target: "./test-values.yaml"},
+	}
+
+	out, err := marshalParamsOverride(context.Background(), applicationImages, originalData)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(string(out), "---\n"),
+		"expected fallback path to preserve leading '---', got: %q", string(out))
 }
 
 // TestApplyHelmValueWrites_ArrayIndexMismatchDoesNotPatch exercises the write

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -2223,12 +2223,12 @@ registries:
 		// whose Payload() is nil, so godigest.FromBytes(nil) is the image manifest digest.
 		payloadType := "application/vnd.dev.cosign.simplesigning.v1+json"
 		imgManifestDigest := godigest.FromBytes(nil).String()
-		payload := []byte(fmt.Sprintf(
+		payload := fmt.Appendf(nil,
 			`{"critical":{"image":{"docker-manifest-digest":"%s"}}}`,
 			imgManifestDigest,
-		))
+		)
 		pae := append(
-			[]byte(fmt.Sprintf("DSSEv1 %d %s %d ", len(payloadType), payloadType, len(payload))),
+			fmt.Appendf(nil, "DSSEv1 %d %s %d ", len(payloadType), payloadType, len(payload)),
 			payload...,
 		)
 		paeHash := sha256.Sum256(pae)
@@ -4411,7 +4411,7 @@ replicas: 1
 		require.NoError(t, err)
 		assert.NotEmpty(t, override)
 
-		var out map[string]interface{}
+		var out map[string]any
 		err = yaml.Unmarshal(override, &out)
 		require.NoError(t, err)
 
@@ -4475,7 +4475,7 @@ replicas: 1
 		require.NoError(t, err)
 		assert.NotEmpty(t, override)
 
-		var out map[string]interface{}
+		var out map[string]any
 		err = yaml.Unmarshal(override, &out)
 		require.NoError(t, err)
 		_, ok := out["image.tag"]
@@ -4839,7 +4839,7 @@ image:
 		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
 
-		output, err := marshalWithIndent(&input, defaultIndent, false)
+		output, err := marshalWithIndent(&input, defaultIndent, nil)
 		require.NoError(t, err)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})
@@ -4858,7 +4858,7 @@ image:
 		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
 
-		output, err := marshalWithIndent(&input, defaultIndent, false)
+		output, err := marshalWithIndent(&input, defaultIndent, nil)
 		require.NoError(t, err)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})
@@ -4886,7 +4886,7 @@ image:
 		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
 
-		output, err := marshalWithIndent(&input, defaultIndent, false)
+		output, err := marshalWithIndent(&input, defaultIndent, nil)
 		require.NoError(t, err)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})
@@ -4908,7 +4908,7 @@ tag: v2.0.0
 		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
 
-		output, err := marshalWithIndent(&input, defaultIndent, false)
+		output, err := marshalWithIndent(&input, defaultIndent, nil)
 		require.NoError(t, err)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})
@@ -4929,7 +4929,7 @@ tag: v2.0.0
 		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
 
-		output, err := marshalWithIndent(&input, defaultIndent, false)
+		output, err := marshalWithIndent(&input, defaultIndent, nil)
 		require.NoError(t, err)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})
@@ -4987,7 +4987,7 @@ image:
 		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
 
-		output, err := marshalWithIndent(&input, defaultIndent, false)
+		output, err := marshalWithIndent(&input, defaultIndent, nil)
 		require.NoError(t, err)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})
@@ -5020,7 +5020,7 @@ image:
 		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
 
-		output, err := marshalWithIndent(&input, defaultIndent, false)
+		output, err := marshalWithIndent(&input, defaultIndent, nil)
 		require.NoError(t, err)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})
@@ -5051,7 +5051,7 @@ image:
 		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
 
-		output, err := marshalWithIndent(&input, defaultIndent, false)
+		output, err := marshalWithIndent(&input, defaultIndent, nil)
 		require.NoError(t, err)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})
@@ -5082,7 +5082,7 @@ images:
 		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
 
-		output, err := marshalWithIndent(&input, defaultIndent, false)
+		output, err := marshalWithIndent(&input, defaultIndent, nil)
 		require.NoError(t, err)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})
@@ -5121,7 +5121,7 @@ images:
 		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
 
-		output, err := marshalWithIndent(&input, defaultIndent, false)
+		output, err := marshalWithIndent(&input, defaultIndent, nil)
 		require.NoError(t, err)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})
@@ -5154,7 +5154,7 @@ extraContainers:
 		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
 
-		output, err := marshalWithIndent(&input, defaultIndent, false)
+		output, err := marshalWithIndent(&input, defaultIndent, nil)
 		require.NoError(t, err)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})
@@ -5187,7 +5187,7 @@ extraContainers:
 		err = setHelmValue(&input, key, value)
 		require.NoError(t, err)
 
-		output, err := marshalWithIndent(&input, defaultIndent, false)
+		output, err := marshalWithIndent(&input, defaultIndent, nil)
 		require.NoError(t, err)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(output)))
 	})
@@ -5345,9 +5345,9 @@ func Test_GetWriteBackConfig(t *testing.T) {
 
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: stringPtr("git"),
+			Method: new("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: stringPtr("mybranch:mytargetbranch"),
+				Branch: new("mybranch:mytargetbranch"),
 			},
 		}
 
@@ -5383,9 +5383,9 @@ func Test_GetWriteBackConfig(t *testing.T) {
 
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: stringPtr("git"),
+			Method: new("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: stringPtr(":mytargetbranch"),
+				Branch: new(":mytargetbranch"),
 			},
 		}
 
@@ -5420,9 +5420,9 @@ func Test_GetWriteBackConfig(t *testing.T) {
 
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: stringPtr("git"),
+			Method: new("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: stringPtr("mybranch"),
+				Branch: new("mybranch"),
 			},
 		}
 
@@ -5460,7 +5460,7 @@ func Test_GetWriteBackConfig(t *testing.T) {
 
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: stringPtr("argocd"),
+			Method: new("argocd"),
 		}
 
 		wbc, err := newWBCFromSettings(context.Background(), &app, &kubeClient, nil, settings)
@@ -5497,10 +5497,10 @@ func Test_GetWriteBackConfig(t *testing.T) {
 
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: stringPtr("git"),
+			Method: new("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch:          stringPtr("mybranch:mytargetbranch"),
-				WriteBackTarget: stringPtr("kustomization:../bar"),
+				Branch:          new("mybranch:mytargetbranch"),
+				WriteBackTarget: new("kustomization:../bar"),
 			},
 		}
 
@@ -5539,10 +5539,10 @@ func Test_GetWriteBackConfig(t *testing.T) {
 
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: stringPtr("git"),
+			Method: new("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch:          stringPtr("mybranch:mytargetbranch"),
-				WriteBackTarget: stringPtr("helmvalues:../bar/values.yaml"),
+				Branch:          new("mybranch:mytargetbranch"),
+				WriteBackTarget: new("helmvalues:../bar/values.yaml"),
 			},
 		}
 
@@ -5581,10 +5581,10 @@ func Test_GetWriteBackConfig(t *testing.T) {
 
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: stringPtr("git"),
+			Method: new("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch:          stringPtr("mybranch:mytargetbranch"),
-				WriteBackTarget: stringPtr("helmvalues"),
+				Branch:          new("mybranch:mytargetbranch"),
+				WriteBackTarget: new("helmvalues"),
 			},
 		}
 
@@ -5623,10 +5623,10 @@ func Test_GetWriteBackConfig(t *testing.T) {
 
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: stringPtr("git"),
+			Method: new("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch:          stringPtr("mybranch:mytargetbranch"),
-				WriteBackTarget: stringPtr("helmvalues:/helm/app/values.yaml"),
+				Branch:          new("mybranch:mytargetbranch"),
+				WriteBackTarget: new("helmvalues:/helm/app/values.yaml"),
 			},
 		}
 
@@ -5665,10 +5665,10 @@ func Test_GetWriteBackConfig(t *testing.T) {
 
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: stringPtr("git"),
+			Method: new("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch:          stringPtr("mybranch:mytargetbranch"),
-				WriteBackTarget: stringPtr("target/folder/app-parameters.yaml"),
+				Branch:          new("mybranch:mytargetbranch"),
+				WriteBackTarget: new("target/folder/app-parameters.yaml"),
 			},
 		}
 
@@ -5707,9 +5707,9 @@ func Test_GetWriteBackConfig(t *testing.T) {
 
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: stringPtr("git:error:argocd-image-updater/git-creds"),
+			Method: new("git:error:argocd-image-updater/git-creds"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: stringPtr("mybranch:mytargetbranch"),
+				Branch: new("mybranch:mytargetbranch"),
 			},
 		}
 
@@ -5744,9 +5744,9 @@ func Test_GetWriteBackConfig(t *testing.T) {
 
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: stringPtr("argocd"),
+			Method: new("argocd"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: stringPtr("mybranch:mytargetbranch"),
+				Branch: new("mybranch:mytargetbranch"),
 			},
 		}
 
@@ -5783,9 +5783,9 @@ func Test_GetWriteBackConfig(t *testing.T) {
 
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: stringPtr("unknown"),
+			Method: new("unknown"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: stringPtr("mybranch:mytargetbranch"),
+				Branch: new("mybranch:mytargetbranch"),
 			},
 		}
 
@@ -5826,9 +5826,9 @@ func Test_GetGitCreds(t *testing.T) {
 		}
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: stringPtr("git:secret:argocd-image-updater/git-creds"),
+			Method: new("git:secret:argocd-image-updater/git-creds"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: stringPtr("mybranch:mytargetbranch"),
+				Branch: new("mybranch:mytargetbranch"),
 			},
 		}
 
@@ -5873,9 +5873,9 @@ func Test_GetGitCreds(t *testing.T) {
 		}
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: stringPtr("git:secret:argocd-image-updater/git-creds"),
+			Method: new("git:secret:argocd-image-updater/git-creds"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: stringPtr("mybranch:mytargetbranch"),
+				Branch: new("mybranch:mytargetbranch"),
 			},
 		}
 
@@ -5919,9 +5919,9 @@ func Test_GetGitCreds(t *testing.T) {
 			}
 			// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 			settings := &iuapi.WriteBackConfig{
-				Method: stringPtr("git:secret:argocd-image-updater/git-creds"),
+				Method: new("git:secret:argocd-image-updater/git-creds"),
 				GitConfig: &iuapi.GitConfig{
-					Branch: stringPtr("mybranch:mytargetbranch"),
+					Branch: new("mybranch:mytargetbranch"),
 				},
 			}
 
@@ -5960,9 +5960,9 @@ func Test_GetGitCreds(t *testing.T) {
 		}
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: stringPtr("git:secret:argocd-image-updater/git-creds"),
+			Method: new("git:secret:argocd-image-updater/git-creds"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: stringPtr("mybranch:mytargetbranch"),
+				Branch: new("mybranch:mytargetbranch"),
 			},
 		}
 
@@ -6019,9 +6019,9 @@ func Test_GetGitCreds(t *testing.T) {
 		}
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: stringPtr("git"),
+			Method: new("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: stringPtr("mybranch:mytargetbranch"),
+				Branch: new("mybranch:mytargetbranch"),
 			},
 		}
 
@@ -6065,9 +6065,9 @@ func Test_GetGitCreds(t *testing.T) {
 		}
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: stringPtr("git"),
+			Method: new("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: stringPtr("mybranch:mytargetbranch"),
+				Branch: new("mybranch:mytargetbranch"),
 			},
 		}
 
@@ -6108,9 +6108,9 @@ func Test_GetGitCreds(t *testing.T) {
 		}
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: stringPtr("git"),
+			Method: new("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: stringPtr("mybranch:mytargetbranch"),
+				Branch: new("mybranch:mytargetbranch"),
 			},
 		}
 
@@ -6151,9 +6151,9 @@ func Test_GetGitCreds(t *testing.T) {
 		}
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: stringPtr("git"),
+			Method: new("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: stringPtr("mybranch:mytargetbranch"),
+				Branch: new("mybranch:mytargetbranch"),
 			},
 		}
 
@@ -6195,10 +6195,10 @@ func Test_GetGitCreds(t *testing.T) {
 
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: stringPtr("git:secret:argocd-image-updater/git-creds"),
+			Method: new("git:secret:argocd-image-updater/git-creds"),
 			GitConfig: &iuapi.GitConfig{
-				Branch:     stringPtr("mybranch:mytargetbranch"),
-				Repository: stringPtr("git@github.com:example/example.git"),
+				Branch:     new("mybranch:mytargetbranch"),
+				Repository: new("git@github.com:example/example.git"),
 			},
 		}
 
@@ -6695,9 +6695,9 @@ replacements: []
 		}).Return(fmt.Errorf("could not configure git"))
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: stringPtr("git"),
+			Method: new("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: stringPtr("mybranch:mytargetbranch"),
+				Branch: new("mybranch:mytargetbranch"),
 			},
 		}
 
@@ -6728,9 +6728,9 @@ replacements: []
 		gitMock.On("Push", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: stringPtr("git"),
+			Method: new("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: stringPtr("mybranch:mytargetbranch"),
+				Branch: new("mybranch:mytargetbranch"),
 			},
 		}
 		ctx := context.Background()
@@ -6756,9 +6756,9 @@ replacements: []
 		gitMock.On("Push", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: stringPtr("git"),
+			Method: new("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: stringPtr("mybranch:mytargetbranch"),
+				Branch: new("mybranch:mytargetbranch"),
 			},
 		}
 		ctx := context.Background()
@@ -6783,9 +6783,9 @@ replacements: []
 		gitMock.On("Push", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: stringPtr("git"),
+			Method: new("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: stringPtr("mybranch:mytargetbranch"),
+				Branch: new("mybranch:mytargetbranch"),
 			},
 		}
 		ctx := context.Background()
@@ -6811,9 +6811,9 @@ replacements: []
 		gitMock.On("Push", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: stringPtr("git"),
+			Method: new("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: stringPtr("mybranch:mytargetbranch"),
+				Branch: new("mybranch:mytargetbranch"),
 			},
 		}
 		ctx := context.Background()
@@ -6839,9 +6839,9 @@ replacements: []
 		gitMock.On("Push", mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("cannot push"))
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: stringPtr("git"),
+			Method: new("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: stringPtr("mybranch:mytargetbranch"),
+				Branch: new("mybranch:mytargetbranch"),
 			},
 		}
 		ctx := context.Background()
@@ -6869,9 +6869,9 @@ replacements: []
 		gitMock.On("SymRefToBranch", mock.Anything).Return("", fmt.Errorf("failed to resolve ref"))
 		// Create iuapi.WriteBackConfig that represents the same configuration as the annotations
 		settings := &iuapi.WriteBackConfig{
-			Method: stringPtr("git"),
+			Method: new("git"),
 			GitConfig: &iuapi.GitConfig{
-				Branch: stringPtr("mybranch:mytargetbranch"),
+				Branch: new("mybranch:mytargetbranch"),
 			},
 		}
 
@@ -7272,11 +7272,6 @@ plugin:
 	})
 }
 
-// Helper function to create string pointers for testing
-func stringPtr(s string) *string {
-	return &s
-}
-
 // TestMarshalParamsOverride_PreservesFormatting verifies that when every write
 // updates an existing key, the values file is patched in place with byte-exact
 // preservation of comments, blank lines, indentation, anchors and inline
@@ -7616,16 +7611,16 @@ func TestMarshalParamsOverride_PreservesDocumentStart_Kustomize(t *testing.T) {
 		originalData := []byte("---\t# header\nkustomize:\n  images:\n  - baz\n")
 		out, err := marshalParamsOverride(context.Background(), applicationImages, originalData)
 		require.NoError(t, err)
-		assert.True(t, strings.HasPrefix(string(out), "---\n"),
-			"expected output to start with '---', got: %q", string(out))
+		assert.True(t, strings.HasPrefix(string(out), "---\t# header\n"),
+			"expected output to start with '---\\t# header\\n', got: %q", string(out))
 	})
 
 	t.Run("recognizes a marker after a leading YAML directive", func(t *testing.T) {
 		originalData := []byte("%YAML 1.2\n---\nkustomize:\n  images:\n  - baz\n")
 		out, err := marshalParamsOverride(context.Background(), applicationImages, originalData)
 		require.NoError(t, err)
-		assert.True(t, strings.HasPrefix(string(out), "---\n"),
-			"expected output to start with '---', got: %q", string(out))
+		assert.True(t, strings.HasPrefix(string(out), "%YAML 1.2\n---\n"),
+			"expected output to start with '%%YAML 1.2\\n---\\n', got: %q", string(out))
 	})
 
 	t.Run("does not treat an indented marker as a document start", func(t *testing.T) {


### PR DESCRIPTION
If a yaml write-back target has an explicit document-start, the current update.go disregards it. This fix retains the explicit document-start but does not add one if it doesn't.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved existing YAML document-start markers (`---`) when updating Kustomize, Helm, plugin, and Helm values files.
  * Prevented markers from being added when they were not originally present.
  * Preserved leading blank lines, comments, and directives around markers.
  * Improved image digest updates for duplicate references and retained configured tag names when only digest data is available.

* **Tests**
  * Added regression coverage for YAML formatting preservation and image digest update scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->