### PR TITLE
fix(git-writeback): only commit image-managed Helm parameters to .argocd-source override file

### DIFF
--- a/pkg/argocd/update.go
+++ b/pkg/argocd/update.go
@@ -663,10 +663,34 @@ func marshalParamsOverride(ctx context.Context, applicationImages *ApplicationIm
 			if appSource.Helm == nil {
 				return []byte{}, nil
 			}
+
+			// Only the Helm parameters that Image Updater actually manages (the
+			// image name/tag or image-spec parameter of each tracked image) may be
+			// written to the override file. appSource.Helm.Parameters reflects the
+			// live Application, which can also carry unrelated overrides (e.g. set
+			// manually via the Argo CD UI/API); those must not be persisted to git.
+			managedParamNames := make(map[string]bool)
+			for _, img := range applicationImages.Images {
+				helmParamName, helmParamVersion := getHelmParamNames(img)
+				if helmParamName != "" {
+					managedParamNames[helmParamName] = true
+				}
+				if helmParamVersion != "" {
+					managedParamNames[helmParamVersion] = true
+				}
+			}
+
+			managedParams := make([]v1alpha1.HelmParameter, 0, len(appSource.Helm.Parameters))
+			for _, p := range appSource.Helm.Parameters {
+				if managedParamNames[p.Name] {
+					managedParams = append(managedParams, p)
+				}
+			}
+
 			var params helmOverride
 			newParams := helmOverride{
 				Helm: helmParameters{
-					Parameters: appSource.Helm.Parameters,
+					Parameters: managedParams,
 				},
 			}
 

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -2740,18 +2740,17 @@ kustomize:
 	})
 
 	t.Run("Valid Helm source", func(t *testing.T) {
+		// foo and bar are live overrides on the Application that are not
+		// managed by any tracked image (the image below uses no alias, so
+		// it only manages the default image.name/image.tag parameters).
+		// They must not be written to the override file - see GitHub issue
+		// #1174.
 		expected := `
 helm:
   parameters:
-  - name: bar
-    value: foo
-    forcestring: true
   - name: baz
     value: baz
     forcestring: false
-  - name: foo
-    value: bar
-    forcestring: true
 `
 		app := v1alpha1.Application{
 			ObjectMeta: v1.ObjectMeta{
@@ -2803,15 +2802,11 @@ helm:
 	})
 
 	t.Run("Empty originalData error with valid Helm source", func(t *testing.T) {
+		// foo and bar are unrelated to the tracked image (see above), so a
+		// fresh override file must come out with no parameters at all.
 		expected := `
 helm:
-  parameters:
-  - name: bar
-    value: foo
-    forcestring: true
-  - name: foo
-    value: bar
-    forcestring: true
+  parameters: []
 `
 		app := v1alpha1.Application{
 			ObjectMeta: v1.ObjectMeta{
@@ -2857,15 +2852,11 @@ helm:
 	})
 
 	t.Run("Invalid unmarshal originalData error with valid Helm source", func(t *testing.T) {
+		// Same as above: foo and bar are unrelated to the tracked image, so
+		// the regenerated override file must come out with no parameters.
 		expected := `
 helm:
-  parameters:
-  - name: bar
-    value: foo
-    forcestring: true
-  - name: foo
-    value: bar
-    forcestring: true
+  parameters: []
 `
 		app := v1alpha1.Application{
 			ObjectMeta: v1.ObjectMeta{
@@ -2908,6 +2899,67 @@ helm:
 		require.NoError(t, err)
 		assert.NotEmpty(t, yaml)
 		assert.Equal(t, strings.TrimSpace(strings.ReplaceAll(expected, "\t", "  ")), strings.TrimSpace(string(yaml)))
+	})
+
+	t.Run("GitHub issue #1174 - only image-managed Helm parameters are committed", func(t *testing.T) {
+		expected := `
+helm:
+  parameters:
+  - name: image.name
+    value: nginx
+    forcestring: true
+  - name: image.tag
+    value: 1.2.3
+    forcestring: true
+`
+		app := v1alpha1.Application{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "testapp",
+			},
+			Spec: v1alpha1.ApplicationSpec{
+				Source: &v1alpha1.ApplicationSource{
+					RepoURL:        "https://example.com/example",
+					TargetRevision: "main",
+					Helm: &v1alpha1.ApplicationSourceHelm{
+						Parameters: []v1alpha1.HelmParameter{
+							{
+								Name:        "image.name",
+								Value:       "nginx",
+								ForceString: true,
+							},
+							{
+								Name:        "image.tag",
+								Value:       "1.2.3",
+								ForceString: true,
+							},
+							{
+								// Set through the Argo CD UI/API, unrelated
+								// to any tracked image - must not leak into
+								// the git-managed override file.
+								Name:        "replicas",
+								Value:       "0",
+								ForceString: false,
+							},
+						},
+					},
+				},
+			},
+			Status: v1alpha1.ApplicationStatus{
+				SourceType: v1alpha1.ApplicationSourceTypeHelm,
+			},
+		}
+
+		applicationImages := &ApplicationImages{
+			Application: app,
+			Images: ImageList{
+				NewImage(
+					image.NewFromIdentifier("nginx")),
+			},
+		}
+		yaml, err := marshalParamsOverride(context.Background(), applicationImages, nil)
+		require.NoError(t, err)
+		assert.NotEmpty(t, yaml)
+		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(yaml)))
 	})
 
 	t.Run("Empty Helm source", func(t *testing.T) {
@@ -6410,9 +6462,12 @@ helm:
 		app.Spec.Source.TargetRevision = "HEAD"
 		wbc.GitBranch = ""
 
+		trackedImage := NewImage(image.NewFromIdentifier("myalias=nginx"))
+		trackedImage.HelmImageName = "bar"
+		trackedImage.HelmImageTag = "baz"
 		applicationImages := &ApplicationImages{
 			Application:     *app,
-			Images:          ImageList{},
+			Images:          ImageList{trackedImage},
 			WriteBackConfig: wbc,
 		}
 		err = commitChanges(ctx, applicationImages, nil)
@@ -6473,9 +6528,12 @@ helm:
 		app.Spec.Source.TargetRevision = "HEAD"
 		wbc.GitBranch = ""
 
+		trackedImage := NewImage(image.NewFromIdentifier("myalias=nginx"))
+		trackedImage.HelmImageName = "bar"
+		trackedImage.HelmImageTag = "baz"
 		applicationImages := &ApplicationImages{
 			Application:     *app,
-			Images:          ImageList{},
+			Images:          ImageList{trackedImage},
 			WriteBackConfig: wbc,
 		}
 		err = commitChanges(ctx, applicationImages, nil)
@@ -6536,9 +6594,12 @@ helm:
 		app.Spec.Source.TargetRevision = "HEAD"
 		wbc.GitBranch = ""
 
+		trackedImage := NewImage(image.NewFromIdentifier("myalias=nginx"))
+		trackedImage.HelmImageName = "bar"
+		trackedImage.HelmImageTag = "baz"
 		applicationImages := &ApplicationImages{
 			Application:     *app,
-			Images:          ImageList{},
+			Images:          ImageList{trackedImage},
 			WriteBackConfig: wbc,
 		}
 		err = commitChanges(ctx, applicationImages, nil)


### PR DESCRIPTION
Motivation:
When using the git write-back method with the default
.argocd-source-<appName>.yaml override file, argocd-image-updater
wrote the ENTIRE live list of Application Helm parameters
(app.Spec.Source.Helm.Parameters) into the git-tracked override file,
not just the parameters it manages for tracked images. Any other
parameter override present on the live Application - for example one
set manually through the Argo CD UI/API, which patches the live
Application directly and is not meant to be persisted to git by
image-updater - got permanently committed to git on the next
image-updater write-back run. This is a persistence-correctness bug,
not data loss or a crash: no data disappears, but an unrelated,
possibly transient override becomes durably tracked in git and can no
longer be changed live, since the committed file value then takes
precedence.

Approach:
In marshalParamsOverride (pkg/argocd/update.go), the default-format
Helm branch now computes the set of Helm parameter names that
image-updater actually manages, by calling the existing
getHelmParamNames helper (the same helper SetHelmImage already uses)
for every image in applicationImages.Images. appSource.Helm.Parameters
is filtered down to only those managed names before being merged into
the override file via the existing mergeHelmOverride. Anything already
committed in the override file that isn't in the managed set is left
untouched - only the previously unrestricted "import everything from
the live app" step is narrowed. This mirrors the per-image filtering
already used by the neighboring custom helmvalues-target branch.

Validation:
- go build ./...
- go test ./pkg/argocd/... - full package suite passes, including
  three updated Test_MarshalParamsOverride subtests that previously
  encoded the old, unrestricted behavior as expected output, and three
  updated Test_CommitUpdates subtests. Added a new regression test,
  "GitHub issue #1174 - only image-managed Helm parameters are
  committed", asserting an unrelated live parameter (mirroring the
  reporter's "replicas" example) is excluded while the tracked image's
  name/tag parameters are written.
- go test ./... - all packages pass; the only failure is the
  test/e2e suite, which requires a live cluster and kubectl (not
  available here) and is unrelated to this change.
- make test (this repo's documented full unit-test target) passes
  cleanly for every package.
- golangci-lint run ./pkg/argocd/... reports 0 issues. golangci-lint
  run ./... reports 2 pre-existing goimports issues in untouched
  generated files (api/v1alpha1/zz_generated.deepcopy.go,
  ext/git/mocks/Client.go), unrelated to this change.

Report: https://github.com/argoproj-labs/argocd-image-updater/issues/1174
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

Fixes #1174

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Helm write-back data now includes only image-managed parameters.
  * Unrelated application overrides are excluded from generated configuration.
  * Improved handling of existing, empty, invalid, and new Helm override data.

* **Tests**
  * Expanded coverage for filtered Helm parameters and generated override files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->