### PR TITLE
fix(helm): improve getHelmParamNames func to return defaults for image-name and image-tag param names

### DIFF
--- a/pkg/argocd/argocd.go
+++ b/pkg/argocd/argocd.go
@@ -769,20 +769,20 @@ func parseImageList(ctx context.Context, kubeClient *kube.ImageUpdaterKubernetes
 func getHelmParamNames(img *Image) (string, string) {
 	// Return default values without symbolic name given
 	if img == nil || img.ImageAlias == "" {
-		return "image.name", "image.tag"
+		return common.DefaultHelmImageName, common.DefaultHelmImageTag
 	}
-
-	var helmParamName, helmParamVersion string
 
 	// Image spec is a full-qualified specifier, if we have it, we return early
 	if param := img.HelmImageSpec; param != "" {
 		return strings.TrimSpace(param), ""
 	}
 
+	helmParamName := common.DefaultHelmImageName
 	if param := img.HelmImageName; param != "" {
 		helmParamName = param
 	}
 
+	helmParamVersion := common.DefaultHelmImageTag
 	if param := img.HelmImageTag; param != "" {
 		helmParamVersion = param
 	}

--- a/pkg/argocd/argocd_test.go
+++ b/pkg/argocd/argocd_test.go
@@ -18,6 +18,7 @@ import (
 	ctrlFake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	api "github.com/argoproj-labs/argocd-image-updater/api/v1alpha1"
+	"github.com/argoproj-labs/argocd-image-updater/pkg/common"
 	"github.com/argoproj-labs/argocd-image-updater/pkg/kube"
 	"github.com/argoproj-labs/argocd-image-updater/registry-scanner/pkg/image"
 	registryKube "github.com/argoproj-labs/argocd-image-updater/registry-scanner/pkg/kube"
@@ -1115,7 +1116,7 @@ func Test_GetHelmParamNames(t *testing.T) {
 		assert.Equal(t, "image.tag", tag)
 	})
 
-	t.Run("Find non-existing image name and image tag", func(t *testing.T) {
+	t.Run("Default image name and image tag with alias", func(t *testing.T) {
 		name, tag := getHelmParamNames(
 			&Image{
 				ContainerImage: &image.ContainerImage{
@@ -1124,11 +1125,11 @@ func Test_GetHelmParamNames(t *testing.T) {
 				HelmImageName: "",
 				HelmImageTag:  ""},
 		)
-		assert.Empty(t, name)
-		assert.Empty(t, tag)
+		assert.Equal(t, common.DefaultHelmImageName, name)
+		assert.Equal(t, common.DefaultHelmImageTag, tag)
 	})
 
-	t.Run("Find existing image tag", func(t *testing.T) {
+	t.Run("Find existing image tag with default image name", func(t *testing.T) {
 		name, tag := getHelmParamNames(
 			&Image{
 				ContainerImage: &image.ContainerImage{
@@ -1136,11 +1137,11 @@ func Test_GetHelmParamNames(t *testing.T) {
 				},
 				HelmImageTag: "image.tag"},
 		)
-		assert.Empty(t, name)
+		assert.Equal(t, common.DefaultHelmImageName, name)
 		assert.Equal(t, "image.tag", tag)
 	})
 
-	t.Run("No suitable image found", func(t *testing.T) {
+	t.Run("Default image name and image tag with alias and no helm fields", func(t *testing.T) {
 		name, tag := getHelmParamNames(
 			&Image{
 				ContainerImage: &image.ContainerImage{
@@ -1148,8 +1149,8 @@ func Test_GetHelmParamNames(t *testing.T) {
 				},
 			},
 		)
-		assert.Empty(t, name)
-		assert.Empty(t, tag)
+		assert.Equal(t, common.DefaultHelmImageName, name)
+		assert.Equal(t, common.DefaultHelmImageTag, tag)
 	})
 
 }

--- a/pkg/argocd/update_test.go
+++ b/pkg/argocd/update_test.go
@@ -3518,7 +3518,7 @@ replicas: 1
 		assert.Equal(t, strings.TrimSpace(strings.ReplaceAll(expected, "\t", "  ")), strings.TrimSpace(string(yaml)))
 	})
 
-	t.Run("Missing image-tag for helmvalues write-back-target", func(t *testing.T) {
+	t.Run("Default image-tag for helmvalues write-back-target when only image-name is set", func(t *testing.T) {
 		app := v1alpha1.Application{
 			ObjectMeta: v1.ObjectMeta{
 				Name: "testapp",
@@ -3530,12 +3530,12 @@ replicas: 1
 					Helm: &v1alpha1.ApplicationSourceHelm{
 						Parameters: []v1alpha1.HelmParameter{
 							{
-								Name:        "dockerimage.name",
+								Name:        "image.name",
 								Value:       "nginx",
 								ForceString: true,
 							},
 							{
-								Name:        "dockerimage.tag",
+								Name:        "image.tag",
 								Value:       "v1.0.0",
 								ForceString: true,
 							},
@@ -3565,12 +3565,12 @@ replicas: 1
 			},
 		}
 
-		_, err := marshalParamsOverride(context.Background(), applicationImages, originalData)
-		assert.Error(t, err)
-		assert.Equal(t, "could not find an image-tag for image nginx", err.Error())
+		yaml, err := marshalParamsOverride(context.Background(), applicationImages, originalData)
+		require.NoError(t, err)
+		assert.NotEmpty(t, yaml)
 	})
 
-	t.Run("Missing image-name for helmvalues write-back-target", func(t *testing.T) {
+	t.Run("Default image-name for helmvalues write-back-target when only image-tag is set", func(t *testing.T) {
 		app := v1alpha1.Application{
 			ObjectMeta: v1.ObjectMeta{
 				Name: "testapp",
@@ -3617,9 +3617,9 @@ replicas: 1
 			},
 		}
 
-		_, err := marshalParamsOverride(context.Background(), applicationImages, originalData)
-		assert.Error(t, err)
-		assert.Equal(t, "could not find an image-name for image nginx", err.Error())
+		yaml, err := marshalParamsOverride(context.Background(), applicationImages, originalData)
+		require.NoError(t, err)
+		assert.NotEmpty(t, yaml)
 	})
 
 	t.Run("Image-name value not found uses fallback from ContainerImage", func(t *testing.T) {

--- a/test/ginkgo/go.mod
+++ b/test/ginkgo/go.mod
@@ -15,7 +15,6 @@ require (
 	k8s.io/apiextensions-apiserver v0.36.1
 	k8s.io/apimachinery v0.36.1
 	k8s.io/client-go v0.36.1
-	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 	sigs.k8s.io/controller-runtime v0.24.1
 )
 
@@ -166,6 +165,7 @@ require (
 	k8s.io/kube-openapi v0.0.0-20260519202549-bbf5c5577288 // indirect
 	k8s.io/kubectl v0.36.1 // indirect
 	k8s.io/kubernetes v1.36.1 // indirect
+	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	oras.land/oras-go/v2 v2.6.2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/kustomize/api v0.21.1 // indirect


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Helm image configurations with only a name or tag now use appropriate default parameter names.
  * Helm values write-back now succeeds for partial image configurations instead of reporting missing-parameter errors.
* **Tests**
  * Expanded coverage for aliased images and incomplete Helm image settings.
* **Chores**
  * Updated dependency classification without changing the dependency version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->