### PR TITLE
fix(registry): surface OAuth token endpoint response body at trace level on auth failures

### DIFF
--- a/registry-scanner/pkg/registry/client.go
+++ b/registry-scanner/pkg/registry/client.go
@@ -170,14 +170,14 @@ func (t *tokenResponseLoggingTransport) RoundTrip(req *http.Request) (*http.Resp
 	n, _ := io.ReadFull(resp.Body, preview)
 	preview = preview[:n]
 
-	// Only trust json.Valid to mean "this is a normal token response" when
-	// the preview holds the entire body (n < tokenResponseLogSize, i.e. we
-	// hit EOF); a body truncated at the cap can't be conclusively judged
-	// valid or not, so it falls through to being logged like any other
-	// suspicious response.
+	// A truncated preview (n == tokenResponseLogSize) can't be conclusively
+	// judged invalid JSON, so it's only logged when the status itself is
+	// already suspicious; a successful response is never logged based on a
+	// truncated preview, since that could be a large-but-legitimate token
+	// response and logging it risks leaking a live access/refresh token.
 	success := resp.StatusCode >= 200 && resp.StatusCode < 300
-	completeValidJSON := n < tokenResponseLogSize && stdjson.Valid(preview)
-	if !success || !completeValidJSON {
+	invalidCompleteJSON := n < tokenResponseLogSize && !stdjson.Valid(preview)
+	if !success || invalidCompleteJSON {
 		log.LoggerFromContext(req.Context()).Tracef("Token endpoint %s returned HTTP %d, body: %q", req.URL, resp.StatusCode, preview)
 	}
 

--- a/registry-scanner/pkg/registry/client.go
+++ b/registry-scanner/pkg/registry/client.go
@@ -1,11 +1,13 @@
 package registry
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	stdjson "encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -123,6 +125,66 @@ func (rlt *rateLimitTransport) RoundTrip(r *http.Request) (*http.Response, error
 	return resp, err
 }
 
+// tokenResponseLogSize caps how much of the OAuth/token endpoint's HTTP
+// response body is buffered for trace logging, so a misbehaving auth server
+// can't force us to hold an unbounded response in memory.
+const tokenResponseLogSize = 4096
+
+// multiReadCloser pairs a Reader assembled for peeking at a response body
+// with the original body's Closer, so the reconstructed body can still be
+// closed correctly by its caller.
+type multiReadCloser struct {
+	io.Reader
+	io.Closer
+}
+
+// tokenResponseLoggingTransport wraps the RoundTripper used exclusively for
+// OAuth/token requests. When a registry's token endpoint returns something
+// that can't be decoded as JSON (an HTML error page, a WAF challenge, a
+// login redirect, etc.), the resulting "unable to decode token response"
+// error carries no detail about what was actually returned, and by the time
+// that error surfaces the response body has already been fully consumed by
+// the decoder - so even trace-level logging shows nothing useful. This peeks
+// at the start of the body for trace logging while leaving it intact for the
+// token decoder that reads it next.
+//
+// A successful token response is a small JSON object that may carry a live
+// access or refresh token (see postTokenResponse/getTokenResponse in the
+// vendored internal/client/auth/session.go), so it is never logged: only a
+// non-2xx status or a body that isn't valid JSON - i.e. exactly the cases
+// this exists to debug - triggers the trace log. Non-2xx bodies are always
+// logged regardless of content, since a broken auth server could in theory
+// echo request data back in an error page; that's an accepted tradeoff for
+// making auth failures debuggable.
+type tokenResponseLoggingTransport struct {
+	next http.RoundTripper
+}
+
+func (t *tokenResponseLoggingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.next.RoundTrip(req)
+	if err != nil || resp == nil || resp.Body == nil {
+		return resp, err
+	}
+
+	preview := make([]byte, tokenResponseLogSize)
+	n, _ := io.ReadFull(resp.Body, preview)
+	preview = preview[:n]
+
+	// Only trust json.Valid to mean "this is a normal token response" when
+	// the preview holds the entire body (n < tokenResponseLogSize, i.e. we
+	// hit EOF); a body truncated at the cap can't be conclusively judged
+	// valid or not, so it falls through to being logged like any other
+	// suspicious response.
+	success := resp.StatusCode >= 200 && resp.StatusCode < 300
+	completeValidJSON := n < tokenResponseLogSize && stdjson.Valid(preview)
+	if !success || !completeValidJSON {
+		log.LoggerFromContext(req.Context()).Tracef("Token endpoint %s returned HTTP %d, body: %q", req.URL, resp.StatusCode, preview)
+	}
+
+	resp.Body = &multiReadCloser{Reader: io.MultiReader(bytes.NewReader(preview), resp.Body), Closer: resp.Body}
+	return resp, nil
+}
+
 // getTokenActions returns the list of OAuth2 Bearer token actions to request
 // for the given registry API. Extend this function when a registry requires
 // additional scopes beyond the default "pull".
@@ -154,7 +216,7 @@ func (clt *registryClient) NewRepository(ctx context.Context, nameInRepository s
 	authTransport := transport.NewTransport(
 		clt.endpoint.GetTransport(ctx), auth.NewAuthorizer(
 			challengeManager1,
-			auth.NewTokenHandler(clt.endpoint.GetTransport(ctx), clt.creds, nameInRepository, actions...),
+			auth.NewTokenHandler(&tokenResponseLoggingTransport{next: clt.endpoint.GetTransport(ctx)}, clt.creds, nameInRepository, actions...),
 			auth.NewBasicHandler(clt.creds)))
 
 	rlt := &rateLimitTransport{

--- a/registry-scanner/pkg/registry/client.go
+++ b/registry-scanner/pkg/registry/client.go
@@ -139,23 +139,15 @@ type multiReadCloser struct {
 }
 
 // tokenResponseLoggingTransport wraps the RoundTripper used exclusively for
-// OAuth/token requests. When a registry's token endpoint returns something
-// that can't be decoded as JSON (an HTML error page, a WAF challenge, a
-// login redirect, etc.), the resulting "unable to decode token response"
-// error carries no detail about what was actually returned, and by the time
-// that error surfaces the response body has already been fully consumed by
-// the decoder - so even trace-level logging shows nothing useful. This peeks
-// at the start of the body for trace logging while leaving it intact for the
-// token decoder that reads it next.
+// OAuth/token requests. It peeks at the start of the response body for trace
+// logging while leaving it intact for the token decoder that reads it next.
 //
 // A successful token response is a small JSON object that may carry a live
-// access or refresh token (see postTokenResponse/getTokenResponse in the
-// vendored internal/client/auth/session.go), so it is never logged: only a
-// non-2xx status or a body that isn't valid JSON - i.e. exactly the cases
-// this exists to debug - triggers the trace log. Non-2xx bodies are always
-// logged regardless of content, since a broken auth server could in theory
-// echo request data back in an error page; that's an accepted tradeoff for
-// making auth failures debuggable.
+// access or refresh token, so it is never logged: only a non-2xx status or a
+// body that isn't valid JSON triggers the trace log. Non-2xx bodies are
+// always logged regardless of content, since a broken auth server could in
+// theory echo request data back in an error page; that's an accepted
+// tradeoff for making auth failures debuggable.
 type tokenResponseLoggingTransport struct {
 	next http.RoundTripper
 }
@@ -167,16 +159,19 @@ func (t *tokenResponseLoggingTransport) RoundTrip(req *http.Request) (*http.Resp
 	}
 
 	preview := make([]byte, tokenResponseLogSize)
-	n, _ := io.ReadFull(resp.Body, preview)
+	n, readErr := io.ReadFull(resp.Body, preview)
 	preview = preview[:n]
 
-	// A truncated preview (n == tokenResponseLogSize) can't be conclusively
-	// judged invalid JSON, so it's only logged when the status itself is
-	// already suspicious; a successful response is never logged based on a
-	// truncated preview, since that could be a large-but-legitimate token
-	// response and logging it risks leaking a live access/refresh token.
+	// io.ReadFull reports io.EOF/io.ErrUnexpectedEOF when the body ends
+	// before filling preview - a complete, if short, read. Any other error
+	// means the read itself failed partway through (e.g. a dropped
+	// connection), so preview holds only a fragment of the real body; treat
+	// that like a cap-truncated preview and never judge it invalid JSON, so
+	// a successful response is never logged based on a fragment that could
+	// be a partial live access/refresh token.
+	bodyFullyRead := readErr == nil || errors.Is(readErr, io.EOF) || errors.Is(readErr, io.ErrUnexpectedEOF)
 	success := resp.StatusCode >= 200 && resp.StatusCode < 300
-	invalidCompleteJSON := n < tokenResponseLogSize && !stdjson.Valid(preview)
+	invalidCompleteJSON := bodyFullyRead && n < tokenResponseLogSize && !stdjson.Valid(preview)
 	if !success || invalidCompleteJSON {
 		log.LoggerFromContext(req.Context()).Tracef("Token endpoint %s returned HTTP %d, body: %q", req.URL, resp.StatusCode, preview)
 	}

--- a/registry-scanner/pkg/registry/client_test.go
+++ b/registry-scanner/pkg/registry/client_test.go
@@ -258,30 +258,55 @@ func TestTokenResponseLoggingTransport_PreservesBody(t *testing.T) {
 // TestTokenResponseLoggingTransport_DoesNotLogSuccessfulTokenResponse guards
 // against leaking a live access/refresh token: a normal, successful token
 // response is valid JSON and must never be written to the logs, even at
-// trace level.
+// trace level - including when the response is large enough to fill or
+// exceed the preview cap, where the token decoder can no longer tell from
+// the truncated preview alone whether the full body is valid JSON.
 func TestTokenResponseLoggingTransport_DoesNotLogSuccessfulTokenResponse(t *testing.T) {
-	logger, hook := logrustest.NewNullLogger()
-	logger.SetLevel(logrus.TraceLevel)
-	ctx := log.ContextWithLogger(context.Background(), logrus.NewEntry(logger))
+	// padTokenBody builds a valid JSON token response whose serialized size
+	// is at least targetSize, by padding an extra field with 'x' characters.
+	padTokenBody := func(targetSize int) string {
+		const template = `{"access_token":"super-secret-access-token","refresh_token":"super-secret-refresh-token","pad":"%s"}`
+		overhead := len(fmt.Sprintf(template, ""))
+		padLen := 0
+		if targetSize > overhead {
+			padLen = targetSize - overhead
+		}
+		return fmt.Sprintf(template, strings.Repeat("x", padLen))
+	}
 
-	const tokenBody = `{"access_token":"super-secret-access-token","refresh_token":"super-secret-refresh-token"}`
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "small body", body: `{"access_token":"super-secret-access-token","refresh_token":"super-secret-refresh-token"}`},
+		{name: "body exactly at preview cap", body: padTokenBody(tokenResponseLogSize)},
+		{name: "body above preview cap", body: padTokenBody(tokenResponseLogSize + 1024)},
+	}
 
-	next := new(mocks.RoundTripper)
-	req := httptest.NewRequest(http.MethodGet, "http://example.com/token", nil).WithContext(ctx)
-	next.On("RoundTrip", req).Return(&http.Response{
-		StatusCode: http.StatusOK,
-		Body:       io.NopCloser(strings.NewReader(tokenBody)),
-	}, nil)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, hook := logrustest.NewNullLogger()
+			logger.SetLevel(logrus.TraceLevel)
+			ctx := log.ContextWithLogger(context.Background(), logrus.NewEntry(logger))
 
-	tr := &tokenResponseLoggingTransport{next: next}
-	resp, err := tr.RoundTrip(req)
-	require.NoError(t, err)
+			next := new(mocks.RoundTripper)
+			req := httptest.NewRequest(http.MethodGet, "http://example.com/token", nil).WithContext(ctx)
+			next.On("RoundTrip", req).Return(&http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(tt.body)),
+			}, nil)
 
-	gotBody, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	assert.Equal(t, tokenBody, string(gotBody))
+			tr := &tokenResponseLoggingTransport{next: next}
+			resp, err := tr.RoundTrip(req)
+			require.NoError(t, err)
 
-	assert.Empty(t, hook.AllEntries(), "a successful, valid JSON token response must not be logged")
+			gotBody, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			assert.Equal(t, tt.body, string(gotBody))
+
+			assert.Empty(t, hook.AllEntries(), "a successful, valid JSON token response must not be logged")
+		})
+	}
 }
 
 // TestTokenResponseLoggingTransport_LogsBodyOnDecodeFailure reproduces the

--- a/registry-scanner/pkg/registry/client_test.go
+++ b/registry-scanner/pkg/registry/client_test.go
@@ -309,6 +309,54 @@ func TestTokenResponseLoggingTransport_DoesNotLogSuccessfulTokenResponse(t *test
 	}
 }
 
+// erroringBody is an io.ReadCloser that returns some data and then a
+// non-EOF error, simulating a connection dropped partway through a response.
+type erroringBody struct {
+	data []byte
+	err  error
+}
+
+func (b *erroringBody) Read(p []byte) (int, error) {
+	if len(b.data) == 0 {
+		return 0, b.err
+	}
+	n := copy(p, b.data)
+	b.data = b.data[n:]
+	if len(b.data) == 0 {
+		return n, b.err
+	}
+	return n, nil
+}
+
+func (b *erroringBody) Close() error { return nil }
+
+// TestTokenResponseLoggingTransport_DoesNotLogOnReadError guards against
+// leaking a fragment of a live access/refresh token: if reading a successful
+// (2xx) response body fails partway through (e.g. a dropped connection), the
+// resulting preview is an incomplete fragment - almost certainly not valid
+// JSON - and must not be logged, since it could be part of a real token.
+func TestTokenResponseLoggingTransport_DoesNotLogOnReadError(t *testing.T) {
+	logger, hook := logrustest.NewNullLogger()
+	logger.SetLevel(logrus.TraceLevel)
+	ctx := log.ContextWithLogger(context.Background(), logrus.NewEntry(logger))
+
+	next := new(mocks.RoundTripper)
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/token", nil).WithContext(ctx)
+	next.On("RoundTrip", req).Return(&http.Response{
+		StatusCode: http.StatusOK,
+		Body:       &erroringBody{data: []byte(`{"access_token":"super-secret-`), err: io.ErrClosedPipe},
+	}, nil)
+
+	tr := &tokenResponseLoggingTransport{next: next}
+	resp, err := tr.RoundTrip(req)
+	require.NoError(t, err)
+
+	_, err = io.ReadAll(resp.Body)
+	assert.ErrorIs(t, err, io.ErrClosedPipe)
+
+	assert.Empty(t, hook.AllEntries(), "a fragment from a failed read of a successful response must not be logged")
+}
+
 // TestTokenResponseLoggingTransport_LogsBodyOnDecodeFailure reproduces the
 // scenario reported for issue 1024: a registry's token endpoint responds
 // with an HTML page (e.g. from a WAF or misconfigured proxy) instead of

--- a/registry-scanner/pkg/registry/client_test.go
+++ b/registry-scanner/pkg/registry/client_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -15,6 +17,8 @@ import (
 	"github.com/distribution/distribution/v3/manifest/schema2"
 	godigest "github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/specs-go"
+	"github.com/sirupsen/logrus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
 
 	distclient "github.com/argoproj-labs/argocd-image-updater/registry-scanner/pkg/registry/internal/client"
 
@@ -28,6 +32,7 @@ import (
 	"go.uber.org/ratelimit"
 
 	"github.com/argoproj-labs/argocd-image-updater/registry-scanner/pkg/image"
+	"github.com/argoproj-labs/argocd-image-updater/registry-scanner/pkg/log"
 	"github.com/argoproj-labs/argocd-image-updater/registry-scanner/pkg/options"
 	"github.com/argoproj-labs/argocd-image-updater/registry-scanner/pkg/registry/mocks"
 	"github.com/argoproj-labs/argocd-image-updater/registry-scanner/pkg/tag"
@@ -218,6 +223,118 @@ func TestRoundTrip_Failure(t *testing.T) {
 	mockTransport.AssertExpectations(t)
 	assert.Error(t, err)
 	assert.Nil(t, actualResp)
+}
+
+// TestTokenResponseLoggingTransport_PreservesBody verifies that peeking at
+// the response body for trace logging does not corrupt what a downstream
+// reader (the token JSON decoder) sees, for bodies both smaller and larger
+// than the logging preview cap.
+func TestTokenResponseLoggingTransport_PreservesBody(t *testing.T) {
+	cases := map[string]string{
+		"smaller than preview cap": `{"access_token":"short-token"}`,
+		"larger than preview cap":  `{"access_token":"` + strings.Repeat("a", tokenResponseLogSize*2) + `"}`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			next := new(mocks.RoundTripper)
+			req := httptest.NewRequest(http.MethodGet, "http://example.com/token", nil)
+			next.On("RoundTrip", req).Return(&http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+			}, nil)
+
+			tr := &tokenResponseLoggingTransport{next: next}
+			resp, err := tr.RoundTrip(req)
+			require.NoError(t, err)
+
+			gotBody, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			assert.Equal(t, body, string(gotBody))
+			require.NoError(t, resp.Body.Close())
+		})
+	}
+}
+
+// TestTokenResponseLoggingTransport_DoesNotLogSuccessfulTokenResponse guards
+// against leaking a live access/refresh token: a normal, successful token
+// response is valid JSON and must never be written to the logs, even at
+// trace level.
+func TestTokenResponseLoggingTransport_DoesNotLogSuccessfulTokenResponse(t *testing.T) {
+	logger, hook := logrustest.NewNullLogger()
+	logger.SetLevel(logrus.TraceLevel)
+	ctx := log.ContextWithLogger(context.Background(), logrus.NewEntry(logger))
+
+	const tokenBody = `{"access_token":"super-secret-access-token","refresh_token":"super-secret-refresh-token"}`
+
+	next := new(mocks.RoundTripper)
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/token", nil).WithContext(ctx)
+	next.On("RoundTrip", req).Return(&http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(tokenBody)),
+	}, nil)
+
+	tr := &tokenResponseLoggingTransport{next: next}
+	resp, err := tr.RoundTrip(req)
+	require.NoError(t, err)
+
+	gotBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, tokenBody, string(gotBody))
+
+	assert.Empty(t, hook.AllEntries(), "a successful, valid JSON token response must not be logged")
+}
+
+// TestTokenResponseLoggingTransport_LogsBodyOnDecodeFailure reproduces the
+// scenario reported for issue 1024: a registry's token endpoint responds
+// with an HTML page (e.g. from a WAF or misconfigured proxy) instead of
+// JSON. The token decode fails with an opaque error, but trace-level
+// logging should now surface the actual response body to aid debugging.
+func TestTokenResponseLoggingTransport_LogsBodyOnDecodeFailure(t *testing.T) {
+	const htmlBody = `<html><body>Access Denied</body></html>`
+
+	logger, hook := logrustest.NewNullLogger()
+	logger.SetLevel(logrus.TraceLevel)
+	ctx := log.ContextWithLogger(context.Background(), logrus.NewEntry(logger))
+
+	var serverURL string
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="%s/token",service="mock-registry"`, serverURL))
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, htmlBody)
+	})
+
+	mockServer := httptest.NewServer(mux)
+	serverURL = mockServer.URL
+	defer mockServer.Close()
+
+	ep := &RegistryEndpoint{
+		RegistryAPI: mockServer.URL,
+		Limiter:     ratelimit.New(100),
+	}
+	client, err := NewClient(ep, "", "")
+	require.NoError(t, err)
+
+	err = client.NewRepository(ctx, "test/myimage")
+	require.NoError(t, err)
+
+	_, err = client.Tags(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unable to decode token response")
+
+	var loggedBody bool
+	for _, entry := range hook.AllEntries() {
+		if strings.Contains(entry.Message, htmlBody) {
+			loggedBody = true
+			break
+		}
+	}
+	assert.True(t, loggedBody, "expected trace log to contain the raw token endpoint response body")
 }
 
 func TestRefreshToken(t *testing.T) {


### PR DESCRIPTION
Motivation:
When a registry's OAuth/token endpoint returns something that isn't
JSON - an HTML error page, a WAF challenge, a login redirect, etc. -
the vendored distribution client fails with an opaque "unable to
decode token response: invalid character '<' looking for beginning of
value" error. By the time that error surfaces, the response body has
already been fully consumed by the JSON decoder, so even
--loglevel trace shows nothing about what the registry actually
returned, leaving no way to diagnose the failure.

Approach:
The decode itself happens in registry-scanner/pkg/registry/internal/client/auth/session.go,
which is a mechanically-synced copy of docker/distribution's internal
client (see the go.mod comment and the "make get-distribution-internal"
target) - hand-editing it would be reverted on the next resync, so the
fix lives one layer up in this repo's own (non-vendored)
registry-scanner/pkg/registry/client.go instead.

A new tokenResponseLoggingTransport wraps only the RoundTripper passed
to auth.NewTokenHandler (not the transport used for manifest/blob/tag
requests), peeks at up to 4096 bytes of the token endpoint's response
body, and reconstructs the body so the downstream JSON decoder still
sees it unmodified. To avoid ever logging a live access or refresh
token, the preview is only written to the trace log when the response
doesn't look like a normal, successful token fetch: a non-2xx status,
or a body that isn't valid JSON - which is exactly the failure mode
this exists to debug.

Validation:
Ran, from registry-scanner/:
  - go build ./...                                  (clean)
  - go vet ./...                                     (clean)
  - GNUPG_DISABLED=true go test -race -count=1 ./...  (all packages pass,
    pkg/registry at 87.1% coverage)
  - golangci-lint run --timeout 5m ./pkg/registry/... (v2.12.2, matching
    CI's pinned version: "0 issues")
  - go mod tidy && git diff --exit-code -- go.mod go.sum (no diff)
Also confirmed go build ./... succeeds from the repo root (the main
module replaces registry-scanner with ./registry-scanner/ locally).

Added TestTokenResponseLoggingTransport_LogsBodyOnDecodeFailure, which
reproduces the reported scenario end-to-end against an httptest server
whose /token handler returns an HTML body: it asserts the resulting
error still contains "unable to decode token response" and that a
trace-level log entry now contains the raw HTML body. I verified by
hand that this test fails if the one-line wiring change in
NewRepository is reverted (i.e. using the unwrapped transport), and
passes with it - a genuine failing-before/passing-after test, not
just new code with no regression coverage.
Also added TestTokenResponseLoggingTransport_PreservesBody (body
integrity is unaffected by the peek, for bodies both under and over
the 4096-byte cap) and
TestTokenResponseLoggingTransport_DoesNotLogSuccessfulTokenResponse
(a normal, valid-JSON token response - which may carry a live
access/refresh token - is never written to the log).

User-visible behavior on success is unchanged; the only change is that
--loglevel trace now shows the token endpoint's raw response body when
that endpoint returns something other than a normal 2xx JSON token
response, which is the specific gap this issue reports.

Report: https://github.com/argoproj-labs/argocd-image-updater/issues/1024
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

Fixes #1024

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics for failed or malformed authentication token responses.
  * Preserved token response data so authentication continues to work correctly.
  * Prevented incomplete response fragments from being logged when response reading fails.

* **Tests**
  * Added coverage for response preservation, successful responses without unnecessary logging, and malformed response diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->