### PR TITLE
chore(deps): bump registry-scanner from 1.2.1 to 1.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/argoproj-labs/argocd-image-updater
 go 1.26.3
 
 require (
-	github.com/argoproj-labs/argocd-image-updater/registry-scanner v1.2.1
+	github.com/argoproj-labs/argocd-image-updater/registry-scanner v1.3.0
 	github.com/argoproj/argo-cd/gitops-engine v0.7.1-0.20250908182407-97ad5b59a627
 	github.com/argoproj/argo-cd/v3 v3.5.1
 	github.com/bmatcuk/doublestar/v4 v4.10.0


### PR DESCRIPTION
https://github.com/argoproj-labs/argocd-image-updater/releases/tag/registry-scanner%2Fv1.3.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the registry scanning component to the latest compatible version, incorporating maintenance updates and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->