### PR TITLE
chore(deps): bump image updater from 1.2.2 to 1.3.0 in test/ginkgo

### DIFF
--- a/test/ginkgo/go.mod
+++ b/test/ginkgo/go.mod
@@ -3,7 +3,7 @@ module github.com/argoproj-labs/argocd-image-updater/test/ginkgo
 go 1.26.3
 
 require (
-	github.com/argoproj-labs/argocd-image-updater v1.2.2
+	github.com/argoproj-labs/argocd-image-updater v1.3.0
 	github.com/argoproj-labs/argocd-operator v0.19.0-rc1.0.20260806043718-4308d96d0a42
 	github.com/argoproj/argo-cd/gitops-engine v0.7.1-0.20250908182407-97ad5b59a627
 	github.com/argoproj/argo-cd/v3 v3.5.1


### PR DESCRIPTION
https://github.com/argoproj-labs/argocd-image-updater/releases/tag/v1.3.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the test module to use the latest image updater release, v1.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->