### PR TITLE
fix(cmd): default `test` command to the same registries-conf-path as run/webhook

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -3,9 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 	"runtime"
 
 	"github.com/argoproj-labs/argocd-image-updater/pkg/argocd"
+	"github.com/argoproj-labs/argocd-image-updater/pkg/common"
 	"github.com/argoproj-labs/argocd-image-updater/pkg/kube"
 	"github.com/argoproj-labs/argocd-image-updater/registry-scanner/pkg/image"
 	"github.com/argoproj-labs/argocd-image-updater/registry-scanner/pkg/log"
@@ -111,7 +113,9 @@ argocd-image-updater test nginx --allow-tags '^1.19.\d+(\-.*)*$' --update-strate
 			vc.Options = vc.Options.WithMetadata(vc.Strategy.NeedsMetadata())
 
 			if registriesConfPath != "" {
-				if err := registry.LoadRegistryConfiguration(imgCtx, registriesConfPath, false); err != nil {
+				if st, err := os.Stat(registriesConfPath); err != nil || st.IsDir() {
+					imgLogger.Infof("registries configuration not found or is a directory, using default configuration: path=%s", registriesConfPath)
+				} else if err := registry.LoadRegistryConfiguration(imgCtx, registriesConfPath, false); err != nil {
 					imgLogger.Fatalf("could not load registries configuration: %v", err)
 				}
 			}
@@ -180,7 +184,7 @@ argocd-image-updater test nginx --allow-tags '^1.19.\d+(\-.*)*$' --update-strate
 	runCmd.Flags().StringVar(&allowTags, "allow-tags", "", "only consider tags in registry that satisfy the match function")
 	runCmd.Flags().StringArrayVar(&ignoreTags, "ignore-tags", nil, "ignore tags in registry that match given glob pattern")
 	runCmd.Flags().StringVar(&strategy, "update-strategy", "semver", "update strategy to use (one of semver, newest-build, alphabetical, digest)")
-	runCmd.Flags().StringVar(&registriesConfPath, "registries-conf-path", "", "path to registries configuration")
+	runCmd.Flags().StringVar(&registriesConfPath, "registries-conf-path", common.DefaultRegistriesConfPath, "path to registries configuration")
 	runCmd.Flags().StringVar(&logLevel, "loglevel", "debug", "log level to use (one of trace, debug, info, warn, error)")
 	runCmd.Flags().StringVar(&kubeConfig, "kubeconfig", "", "path to your Kubernetes client configuration")
 	runCmd.Flags().StringVar(&credentials, "credentials", "", "the credentials definition for the test (overrides registry config)")

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -112,10 +112,21 @@ argocd-image-updater test nginx --allow-tags '^1.19.\d+(\-.*)*$' --update-strate
 			}
 			vc.Options = vc.Options.WithMetadata(vc.Strategy.NeedsMetadata())
 
+			// registriesConfPath defaults to "" so we can tell whether the user set it
+			// explicitly. When unset, fall back to the well-known default path only if it
+			// exists as a readable file; otherwise use the built-in in-memory defaults.
+			if registriesConfPath == "" {
+				if st, err := os.Stat(common.DefaultRegistriesConfPath); err == nil && !st.IsDir() {
+					registriesConfPath = common.DefaultRegistriesConfPath
+				} else {
+					imgLogger.Infof("no registries configuration at default path %s, using built-in defaults", common.DefaultRegistriesConfPath)
+				}
+			}
+
+			// The path is now either an explicit user value or a validated default. Any
+			// load error is fatal so misconfiguration is surfaced rather than masked.
 			if registriesConfPath != "" {
-				if st, err := os.Stat(registriesConfPath); err != nil || st.IsDir() {
-					imgLogger.Infof("registries configuration not found or is a directory, using default configuration: path=%s", registriesConfPath)
-				} else if err := registry.LoadRegistryConfiguration(imgCtx, registriesConfPath, false); err != nil {
+				if err := registry.LoadRegistryConfiguration(imgCtx, registriesConfPath, false); err != nil {
 					imgLogger.Fatalf("could not load registries configuration: %v", err)
 				}
 			}
@@ -184,7 +195,7 @@ argocd-image-updater test nginx --allow-tags '^1.19.\d+(\-.*)*$' --update-strate
 	runCmd.Flags().StringVar(&allowTags, "allow-tags", "", "only consider tags in registry that satisfy the match function")
 	runCmd.Flags().StringArrayVar(&ignoreTags, "ignore-tags", nil, "ignore tags in registry that match given glob pattern")
 	runCmd.Flags().StringVar(&strategy, "update-strategy", "semver", "update strategy to use (one of semver, newest-build, alphabetical, digest)")
-	runCmd.Flags().StringVar(&registriesConfPath, "registries-conf-path", common.DefaultRegistriesConfPath, "path to registries configuration")
+	runCmd.Flags().StringVar(&registriesConfPath, "registries-conf-path", "", "path to registries configuration")
 	runCmd.Flags().StringVar(&logLevel, "loglevel", "debug", "log level to use (one of trace, debug, info, warn, error)")
 	runCmd.Flags().StringVar(&kubeConfig, "kubeconfig", "", "path to your Kubernetes client configuration")
 	runCmd.Flags().StringVar(&credentials, "credentials", "", "the credentials definition for the test (overrides registry config)")

--- a/cmd/test_test.go
+++ b/cmd/test_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/argoproj-labs/argocd-image-updater/pkg/common"
 )
 
 // TestNewTestCommand tests various flags and their default values.
@@ -22,7 +20,7 @@ func TestNewTestCommand(t *testing.T) {
 	asser.Equal("", testCmd.Flag("allow-tags").Value.String())
 	asser.Equal("[]", testCmd.Flag("ignore-tags").Value.String())
 	asser.Equal("semver", testCmd.Flag("update-strategy").Value.String())
-	asser.Equal(common.DefaultRegistriesConfPath, testCmd.Flag("registries-conf-path").Value.String())
+	asser.Equal("", testCmd.Flag("registries-conf-path").Value.String())
 	asser.Equal("debug", testCmd.Flag("loglevel").Value.String())
 	asser.Equal("", testCmd.Flag("kubeconfig").Value.String())
 	asser.Equal("", testCmd.Flag("credentials").Value.String())

--- a/cmd/test_test.go
+++ b/cmd/test_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/argoproj-labs/argocd-image-updater/pkg/common"
 )
 
 // TestNewTestCommand tests various flags and their default values.
@@ -20,7 +22,7 @@ func TestNewTestCommand(t *testing.T) {
 	asser.Equal("", testCmd.Flag("allow-tags").Value.String())
 	asser.Equal("[]", testCmd.Flag("ignore-tags").Value.String())
 	asser.Equal("semver", testCmd.Flag("update-strategy").Value.String())
-	asser.Equal("", testCmd.Flag("registries-conf-path").Value.String())
+	asser.Equal(common.DefaultRegistriesConfPath, testCmd.Flag("registries-conf-path").Value.String())
 	asser.Equal("debug", testCmd.Flag("loglevel").Value.String())
 	asser.Equal("", testCmd.Flag("kubeconfig").Value.String())
 	asser.Equal("", testCmd.Flag("credentials").Value.String())


### PR DESCRIPTION
Motivation:
The `test` subcommand's `--registries-conf-path` flag defaulted to an
empty string, while `run` and `webhook` both default it to
common.DefaultRegistriesConfPath ("/app/config/registries.conf"). As a
result, running `argocd-image-updater test <image>` inside a live pod
silently ignored the registries.conf mounted into that pod (including
any registry-level `credentials:` source such as `ext:<script>`) and
fell back to the built-in default registry list with no credentials.

This likely explains the "no basic auth credentials" error reported
when testing an image against a private ECR registry that was
configured with an `ext:` credential script in registries.conf: the
`test` command never loaded that config in the first place, so it
never invoked the script and made an anonymous (unauthenticated)
request instead. This is a plausible root cause for the report, not a
confirmed reproduction of that specific user's environment.

Approach:
- Default the `--registries-conf-path` flag to
  common.DefaultRegistriesConfPath, matching cmd/run.go and
  cmd/webhook.go, so `test` reflects the same configuration the
  controller actually uses by default.
- Since that default path won't exist when running `test` locally
  outside a pod (the command's own --help examples show bare
  `argocd-image-updater test nginx`), stat the path first and, if it
  is missing or a directory, log and fall back to the default in-memory
  registry configuration instead of failing, mirroring the existing
  non-fatal handling in cmd/common.go's SetupCommon.

Validation:
- go build ./... and go vet ./... pass.
- go test ./cmd/... passes, including the updated TestNewTestCommand
  which now asserts the new default flag value.
- go test ./... passes (all packages green except test/e2e, which
  requires a live cluster/kubectl and is excluded from `make test`
  by the Makefile itself).
- golangci-lint run --timeout 5m ./cmd/... (v2.12.2, matching the
  version pinned in .github/workflows/ci-tests.yaml) reports 0 issues.
- registry-scanner module (untouched by this change) still builds and
  its tests still pass.
- No dedicated runtime test was added for the new not-found/is-dir
  branch itself, since it lives inline in the cobra command's Run
  closure alongside Kubernetes client setup and is not easily
  isolated without a larger refactor; the flag-default assertion in
  TestNewTestCommand is the test coverage for the behavioral change.

Report: https://github.com/argoproj-labs/argocd-image-updater/issues/929
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

Fixes #929

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the test command’s handling of registry configuration.
  - Automatically uses the standard configuration when available.
  - Falls back to built-in registry defaults with an informational message when no valid configuration file is found.
  - Explicitly provided configuration paths continue to be honored, and errors loading them remain clearly reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->