### PR TITLE
fix(crd): remove commonUpdateSettings defaults at the CRD level

### DIFF
--- a/api/v1alpha1/imageupdater_types.go
+++ b/api/v1alpha1/imageupdater_types.go
@@ -177,13 +177,11 @@ type CommonUpdateSettings struct {
 	// Examples: "semver", "latest", "digest", "name".
 	// This acts as the default if not overridden at a more specific level.
 	// +optional
-	// +kubebuilder:default:="semver"
 	UpdateStrategy *string `json:"updateStrategy,omitempty"`
 
 	// ForceUpdate specifies whether updates should be forced.
 	// This acts as the default if not overridden.
 	// +optional
-	// +kubebuilder:default:=false
 	ForceUpdate *bool `json:"forceUpdate,omitempty"`
 
 	// AllowTags is a regex pattern for tags to allow.

--- a/config/crd/bases/argocd-image-updater.argoproj.io_imageupdaters.yaml
+++ b/config/crd/bases/argocd-image-updater.argoproj.io_imageupdaters.yaml
@@ -76,7 +76,6 @@ spec:
                             This acts as the default if not overridden.
                           type: string
                         forceUpdate:
-                          default: false
                           description: |-
                             ForceUpdate specifies whether updates should be forced.
                             This acts as the default if not overridden.
@@ -103,7 +102,6 @@ spec:
                             This acts as the default if not overridden.
                           type: string
                         updateStrategy:
-                          default: semver
                           description: |-
                             UpdateStrategy defines the update strategy to apply.
                             Examples: "semver", "latest", "digest", "name".
@@ -138,7 +136,6 @@ spec:
                                   This acts as the default if not overridden.
                                 type: string
                               forceUpdate:
-                                default: false
                                 description: |-
                                   ForceUpdate specifies whether updates should be forced.
                                   This acts as the default if not overridden.
@@ -165,7 +162,6 @@ spec:
                                   This acts as the default if not overridden.
                                 type: string
                               updateStrategy:
-                                default: semver
                                 description: |-
                                   UpdateStrategy defines the update strategy to apply.
                                   Examples: "semver", "latest", "digest", "name".
@@ -499,7 +495,6 @@ spec:
                       This acts as the default if not overridden.
                     type: string
                   forceUpdate:
-                    default: false
                     description: |-
                       ForceUpdate specifies whether updates should be forced.
                       This acts as the default if not overridden.
@@ -526,7 +521,6 @@ spec:
                       This acts as the default if not overridden.
                     type: string
                   updateStrategy:
-                    default: semver
                     description: |-
                       UpdateStrategy defines the update strategy to apply.
                       Examples: "semver", "latest", "digest", "name".

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -75,7 +75,6 @@ spec:
                             This acts as the default if not overridden.
                           type: string
                         forceUpdate:
-                          default: false
                           description: |-
                             ForceUpdate specifies whether updates should be forced.
                             This acts as the default if not overridden.
@@ -102,7 +101,6 @@ spec:
                             This acts as the default if not overridden.
                           type: string
                         updateStrategy:
-                          default: semver
                           description: |-
                             UpdateStrategy defines the update strategy to apply.
                             Examples: "semver", "latest", "digest", "name".
@@ -137,7 +135,6 @@ spec:
                                   This acts as the default if not overridden.
                                 type: string
                               forceUpdate:
-                                default: false
                                 description: |-
                                   ForceUpdate specifies whether updates should be forced.
                                   This acts as the default if not overridden.
@@ -164,7 +161,6 @@ spec:
                                   This acts as the default if not overridden.
                                 type: string
                               updateStrategy:
-                                default: semver
                                 description: |-
                                   UpdateStrategy defines the update strategy to apply.
                                   Examples: "semver", "latest", "digest", "name".
@@ -498,7 +494,6 @@ spec:
                       This acts as the default if not overridden.
                     type: string
                   forceUpdate:
-                    default: false
                     description: |-
                       ForceUpdate specifies whether updates should be forced.
                       This acts as the default if not overridden.
@@ -525,7 +520,6 @@ spec:
                       This acts as the default if not overridden.
                     type: string
                   updateStrategy:
-                    default: semver
                     description: |-
                       UpdateStrategy defines the update strategy to apply.
                       Examples: "semver", "latest", "digest", "name".

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,24 @@ A tool to automatically update the container images of Kubernetes workloads
 that are managed by
 [Argo CD](https://github.com/argoproj/argo-cd).
 
+!!!warning "Migrate common update settings when upgrading to v1.4.0 CRDs"
+    In v1.0.0 through v1.3.x, the ImageUpdater CRD defaulted and stored
+    `updateStrategy: semver` and `forceUpdate: false` when these fields were
+    omitted from any existing `commonUpdateSettings`. These stored values
+    prevented inheritance from `spec.commonUpdateSettings` to
+    `spec.applicationRefs[].commonUpdateSettings` and
+    `spec.applicationRefs[].images[].commonUpdateSettings`, and from
+    `spec.applicationRefs[].commonUpdateSettings` to
+    `spec.applicationRefs[].images[].commonUpdateSettings`.
+
+    `ImageUpdater` resources created with v1.4.0 CRDs or later may therefore
+    behave differently from resources created with previous CRDs.
+
+    Because these values are persisted, upgrading to v1.4.0 CRDs alone does not
+    fix existing resources. After upgrading the CRDs, manually remove
+    unintentional `forceUpdate` and `updateStrategy` values, or delete and
+    recreate the affected `ImageUpdater` resources to restore inheritance.
+
 !!!warning "spec.namespace Field Removed"
     The `spec.namespace` field has been removed from the `ImageUpdater` API. Any CR that includes `spec.namespace` will fail validation. The controller uses the ImageUpdater CR's `metadata.namespace` to determine which namespace to search for applications. For details and migration examples, see [Namespace Field Removal](#namespace-field-removal) below.
 


### PR DESCRIPTION
Defaults for these fields are already handled within `newImageFromCommonUpdateSettings` and having them set by default by Kubernetes prevents `mergeCommonUpdateSettings` to properly handle inheritance from `spec.commonUpdateSettings` to
`spec.applicationRefs.*.images.*.commonUpdateSettings`.

Not setting any default is something already correctly tested but in practice the following `ImageUpdater` resource would have incorrectly defaulted `updateStrategy` to `semver` and `forceUpdate` to `false`:

```yaml
apiVersion: argocd-image-updater.argoproj.io/v1alpha1
kind: ImageUpdater
metadata:
  name: broken-default
  namespace: argocd
spec:
  commonUpdateSettings:
    updateStrategy: digest
    forceUpdate: true
  applicationRefs:
    - namePattern: my-app
      images:
        - alias: app
          imageName: something
          commonUpdateSettings: {}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed automatic default values for update strategy and force-update settings.
  * These options now remain unset unless explicitly configured, while existing field types and validation remain unchanged.
  * This prevents unintended settings from being applied across global, application, and image configurations.

* **Documentation**
  * Added an upgrade warning about potential inheritance changes in existing resources.
  * Documented steps for removing unintended persisted values or recreating affected resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->