### PR TITLE
fix(image): keep the library namespace for non-Docker Hub registries

### DIFF
--- a/registry-scanner/pkg/image/image.go
+++ b/registry-scanner/pkg/image/image.go
@@ -35,15 +35,19 @@ func NewFromIdentifier(identifier string) *ContainerImage {
 	}
 	if parsed, err := reference.ParseNormalizedNamed(imgRef); err == nil {
 		img := ContainerImage{}
-		img.RegistryURL = reference.Domain(parsed)
+		domain := reference.Domain(parsed)
+		img.RegistryURL = domain
 		// remove default registry for backwards-compatibility
 		if img.RegistryURL == "docker.io" && !strings.HasPrefix(imgRef, "docker.io") {
 			img.RegistryURL = ""
 		}
 		img.ImageAlias = alias
 		img.ImageName = reference.Path(parsed)
-		// if library/ was added to the image name, remove it
-		if !strings.HasPrefix(imgRef, "library/") {
+		// Docker Hub images without a namespace get the implicit library/
+		// namespace from normalization, e.g. nginx becomes docker.io/library/nginx.
+		// Remove that namespace again. Other registries use library/ as a normal
+		// path element, so keep it there.
+		if domain == "docker.io" && !strings.HasPrefix(imgRef, "library/") {
 			img.ImageName = strings.TrimPrefix(img.ImageName, "library/")
 		}
 		// Check for both tag and digest - an image can have both (e.g., image:tag@sha256:...)

--- a/registry-scanner/pkg/image/image_test.go
+++ b/registry-scanner/pkg/image/image_test.go
@@ -43,6 +43,21 @@ func Test_ParseImageTags(t *testing.T) {
 		assert.Equal(t, "library/test-image", image.GetFullNameWithoutTag())
 	})
 
+	t.Run("library namespace is kept for a private registry", func(t *testing.T) {
+		image := NewFromIdentifier("harbor.example.com/library/test-image:0.1")
+		assert.Equal(t, "harbor.example.com", image.RegistryURL)
+		assert.Equal(t, "library/test-image", image.ImageName)
+		assert.Equal(t, "harbor.example.com/library/test-image:0.1", image.GetFullNameWithTag())
+		assert.Equal(t, "harbor.example.com/library/test-image", image.GetFullNameWithoutTag())
+	})
+
+	t.Run("nested library namespace is kept for a private registry", func(t *testing.T) {
+		image := NewFromIdentifier("harbor.example.com/library/nested/test-image:0.1")
+		assert.Equal(t, "harbor.example.com", image.RegistryURL)
+		assert.Equal(t, "library/nested/test-image", image.ImageName)
+		assert.Equal(t, "harbor.example.com/library/nested/test-image:0.1", image.GetFullNameWithTag())
+	})
+
 	t.Run("Parse valid image name with registry info", func(t *testing.T) {
 		image := NewFromIdentifier("gcr.io/jannfis/test-image:0.1")
 		assert.Equal(t, "gcr.io", image.RegistryURL)


### PR DESCRIPTION
Fixes #386

## The problem

`NewFromIdentifier` removes a `library/` prefix from the parsed image path without checking the registry domain:

```go
img.ImageName = reference.Path(parsed)
// if library/ was added to the image name, remove it
if !strings.HasPrefix(imgRef, "library/") {
    img.ImageName = strings.TrimPrefix(img.ImageName, "library/")
}
```

`reference.ParseNormalizedNamed` inserts `library/` only for Docker Hub images that carry no namespace (`nginx` becomes `docker.io/library/nginx`). On every other registry a leading `library/` is a real path element, but the code removes it there too. The `!strings.HasPrefix(imgRef, "library/")` guard only protects the bare short form `library/nginx`; it never matches once a registry domain leads the reference.

A Harbor image in the default `library` project therefore loses its project:

```
$ argocd-image-updater test harbor.example.com/library/paseo:v0.3.1
INFO[0000] retrieving information about image  image_name=harbor.example.com/paseo image_registry=harbor.example.com
FATA[0000] could not get tags: unknown: bad request: invalid repository name: paseo
```

The endpoint has no `defaultns` to restore the namespace, so the tag request goes to `/v2/paseo/tags/list` and the registry rejects it. Nested paths below `library/` (`my.private.registry/library/mynested/repo`, the case in #386) fail the same way.

## The fix

Strip the namespace only when the domain is `docker.io`:

```go
if domain == "docker.io" && !strings.HasPrefix(imgRef, "library/") {
    img.ImageName = strings.TrimPrefix(img.ImageName, "library/")
}
```

## Behaviour

Docker Hub is unchanged. `DefaultNS` still restores `library/` at request time for single-name images.

| Reference | Before | After |
|---|---|---|
| `nginx` | `nginx` | `nginx` |
| `library/nginx` | `library/nginx` | `library/nginx` |
| `docker.io/library/nginx` | `nginx` | `nginx` |
| `bitnami/nginx` | `bitnami/nginx` | `bitnami/nginx` |
| `harbor.example.com/library/paseo` | `paseo` ❌ | `library/paseo` ✅ |
| `harbor.example.com/library/nested/repo` | `nested/repo` ❌ | `library/nested/repo` ✅ |

## Not addressed

Issue #386 also faults the `len(strings.Split(img.ImageName, "/")) == 1` check in `registry.go` for skipping `defaultns` on multi-segment names. Relaxing that check would make Docker Hub expand `bitnami/nginx` into `library/bitnami/nginx`, so it needs separate discussion. With this change `defaultns` is no longer needed for the reported case: write `library/` in the image list and it survives parsing.

## Testing

Two subtests added to `Test_ParseImageTags`, covering the flat and the nested private-registry cases. Both fail on master with the reported symptom and pass with the fix. `registry-scanner/...` and the main module's `pkg/...`, `cmd/...`, `api/...`, `internal/...` suites all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected container image parsing for private registries so `library` namespaces are preserved.
  * Maintained Docker Hub behavior by removing only implicit `library/` prefixes when appropriate.
  * Improved handling of nested image paths and fully qualified image names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->