### PR TITLE
fix(registry): send configured credentials to registries with an anonymous /v2/ root

### DIFF
--- a/registry-scanner/pkg/registry/client.go
+++ b/registry-scanner/pkg/registry/client.go
@@ -144,7 +144,7 @@ func getTokenActions(registryAPI string) []string {
 func (clt *registryClient) NewRepository(ctx context.Context, nameInRepository string) error {
 	urlToCall := strings.TrimSuffix(clt.endpoint.RegistryAPI, "/")
 	challengeManager1 := challenge.NewSimpleManager()
-	_, err := ping(ctx, challengeManager1, clt.endpoint, "")
+	_, err := ping(ctx, challengeManager1, clt.endpoint, "", clt.creds)
 	if err != nil {
 		return err
 	}
@@ -545,7 +545,7 @@ func (clt *registryClient) Referrers(ctx context.Context, dgst digest.Digest) ([
 
 // Implementation of ping method to initialize the challenge list
 // Without this, tokenHandler and AuthorizationHandler won't work
-func ping(ctx context.Context, manager challenge.Manager, endpoint *RegistryEndpoint, versionHeader string) ([]auth.APIVersion, error) {
+func ping(ctx context.Context, manager challenge.Manager, endpoint *RegistryEndpoint, versionHeader string, creds credentials) ([]auth.APIVersion, error) {
 	httpc := &http.Client{Transport: endpoint.GetTransport(ctx)}
 	url := endpoint.RegistryAPI + "/v2/"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -564,6 +564,26 @@ func ping(ctx context.Context, manager challenge.Manager, endpoint *RegistryEndp
 
 	if err := manager.AddResponse(resp); err != nil {
 		return nil, err
+	}
+
+	// Some registries (e.g. zot) allow anonymous access to the /v2/ root
+	// endpoint but require authentication on individual repositories. Such a
+	// registry answers this ping with 200 and no WWW-Authenticate header, so
+	// no challenge gets recorded and the endpointAuthorizer would never
+	// attach the configured credentials to the later tag/manifest requests
+	// that do require them. When credentials are configured for this
+	// endpoint, register a synthetic Basic challenge so they get sent
+	// preemptively instead of only in reaction to a challenge that never
+	// arrives.
+	if resp.StatusCode == http.StatusOK && creds.username != "" && creds.password != "" {
+		syntheticChallenge := &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Header:     http.Header{"Www-Authenticate": []string{fmt.Sprintf("Basic realm=%q", endpoint.RegistryAPI)}},
+			Request:    resp.Request,
+		}
+		if err := manager.AddResponse(syntheticChallenge); err != nil {
+			return nil, err
+		}
 	}
 
 	return auth.APIVersions(resp, versionHeader), err

--- a/registry-scanner/pkg/registry/client_test.go
+++ b/registry-scanner/pkg/registry/client_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/opencontainers/image-spec/specs-go"
 
 	distclient "github.com/argoproj-labs/argocd-image-updater/registry-scanner/pkg/registry/internal/client"
+	"github.com/argoproj-labs/argocd-image-updater/registry-scanner/pkg/registry/internal/client/auth/challenge"
 
 	"github.com/distribution/distribution/v3"
 	"github.com/distribution/distribution/v3/registry/api/errcode"
@@ -167,6 +168,50 @@ func TestNewRepository(t *testing.T) {
 		require.Error(t, err)
 	})
 
+}
+
+// TestNewRepository_AnonymousRootBasicAuthRepo reproduces the scenario reported
+// against a zot registry: the /v2/ root allows anonymous access (200, no
+// WWW-Authenticate challenge), but the tags endpoint for a given repository
+// requires Basic auth. Before the fix, no challenge was ever recorded for
+// this endpoint, so the endpointAuthorizer never attached the configured
+// credentials and every tag/manifest request went out unauthenticated.
+func TestNewRepository_AnonymousRootBasicAuthRepo(t *testing.T) {
+	var gotAuthHeader string
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/v2/shrestech/printready-web/tags/list", func(w http.ResponseWriter, r *http.Request) {
+		gotAuthHeader = r.Header.Get("Authorization")
+		user, pass, ok := r.BasicAuth()
+		if !ok || user != "testuser" || pass != "testpass" {
+			w.Header().Set("WWW-Authenticate", `Basic realm="zot"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"name":"shrestech/printready-web","tags":["stg-latest"]}`)
+	})
+
+	mockServer := httptest.NewServer(mux)
+	defer mockServer.Close()
+
+	ep := &RegistryEndpoint{
+		RegistryAPI: mockServer.URL,
+		Limiter:     ratelimit.New(100),
+	}
+	client, err := NewClient(ep, "testuser", "testpass")
+	require.NoError(t, err)
+	err = client.NewRepository(context.Background(), "shrestech/printready-web")
+	require.NoError(t, err)
+
+	tags, err := client.Tags(context.Background())
+	require.NoError(t, err)
+	assert.Contains(t, tags, "stg-latest")
+	assert.NotEmpty(t, gotAuthHeader, "expected the configured credentials to be sent on the first request, not just after a 401")
 }
 
 func TestRoundTrip_Success(t *testing.T) {
@@ -712,7 +757,7 @@ func TestPing(t *testing.T) {
 		ep, err := GetRegistryEndpoint(context.Background(), &image.ContainerImage{RegistryURL: ""})
 		require.NoError(t, err)
 		mockManager.On("AddResponse", mock.Anything).Return(fmt.Errorf("fail ping"))
-		_, err = ping(context.Background(), mockManager, ep, "")
+		_, err = ping(context.Background(), mockManager, ep, "", credentials{})
 		require.Error(t, err)
 	})
 
@@ -721,7 +766,7 @@ func TestPing(t *testing.T) {
 		ep, err := GetRegistryEndpoint(context.Background(), &image.ContainerImage{RegistryURL: ""})
 		require.NoError(t, err)
 		mockManager.On("AddResponse", mock.Anything).Return(nil)
-		_, err = ping(context.Background(), mockManager, ep, "")
+		_, err = ping(context.Background(), mockManager, ep, "", credentials{})
 		require.NoError(t, err)
 	})
 
@@ -732,7 +777,7 @@ func TestPing(t *testing.T) {
 		mockManager := new(mocks.Manager)
 		ep := &RegistryEndpoint{RegistryAPI: testServer.URL}
 		mockManager.On("AddResponse", mock.Anything).Return(nil)
-		_, err := ping(context.Background(), mockManager, ep, "")
+		_, err := ping(context.Background(), mockManager, ep, "", credentials{})
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "does not seem to be a valid v2 Docker Registry API")
 	})
@@ -741,9 +786,44 @@ func TestPing(t *testing.T) {
 		mockManager := new(mocks.Manager)
 		ep := &RegistryEndpoint{RegistryAPI: ""}
 		mockManager.On("AddResponse", mock.Anything).Return(nil)
-		_, err := ping(context.Background(), mockManager, ep, "")
+		_, err := ping(context.Background(), mockManager, ep, "", credentials{})
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "unsupported protocol scheme")
+	})
+
+	t.Run("anonymous root, configured creds registers synthetic Basic challenge", func(t *testing.T) {
+		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer testServer.Close()
+		manager := challenge.NewSimpleManager()
+		ep := &RegistryEndpoint{RegistryAPI: testServer.URL}
+		_, err := ping(context.Background(), manager, ep, "", credentials{username: "user", password: "pass"})
+		require.NoError(t, err)
+
+		u, err := url.Parse(testServer.URL + "/v2/")
+		require.NoError(t, err)
+		challenges, err := manager.GetChallenges(*u)
+		require.NoError(t, err)
+		require.Len(t, challenges, 1)
+		assert.Equal(t, "basic", challenges[0].Scheme)
+	})
+
+	t.Run("anonymous root without configured creds registers no challenge", func(t *testing.T) {
+		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer testServer.Close()
+		manager := challenge.NewSimpleManager()
+		ep := &RegistryEndpoint{RegistryAPI: testServer.URL}
+		_, err := ping(context.Background(), manager, ep, "", credentials{})
+		require.NoError(t, err)
+
+		u, err := url.Parse(testServer.URL + "/v2/")
+		require.NoError(t, err)
+		challenges, err := manager.GetChallenges(*u)
+		require.NoError(t, err)
+		assert.Empty(t, challenges)
 	})
 }
 


### PR DESCRIPTION
Motivation:
Registries such as zot can be configured to allow anonymous GET
requests to the /v2/ root endpoint while still requiring Basic auth
on tag and manifest reads for individual repositories. When the
image-updater controller talks to such a registry, it never sends an
Authorization header on any request, even when registries.conf
credentials or a per-image commonUpdateSettings.pullSecret are
correctly configured and resolved. Every update cycle fails with
"unauthorized: authentication required" and no image is ever updated.

Approach:
The registry client's NewRepository() pings /v2/ once and feeds that
single response into a docker/distribution-style challenge manager;
later requests only get an Authorization header attached if a
WWW-Authenticate challenge was previously recorded for that endpoint.
A registry that answers the /v2/ ping anonymously with 200 never
records a challenge, so the correctly-resolved credentials are simply
never attached to the requests that actually require them (the
challenge-based auth transport in
registry-scanner/pkg/registry/internal/client/auth only inspects
WWW-Authenticate headers on 401 responses).

ping() now also takes the endpoint's resolved credentials. When the
/v2/ ping succeeds anonymously (200) and credentials are configured
for the endpoint, it registers a synthetic Basic challenge for that
endpoint so the existing Basic-auth handler attaches the credentials
preemptively, instead of only in reaction to a challenge that never
arrives. This is a no-op for registries with no credentials
configured, and for registries that already return a proper
WWW-Authenticate challenge on the ping (the common case, e.g. Bearer
token flows), since a challenge is already recorded there.

Note: this specifically fixes registries protected by Basic auth on
an anonymous-root endpoint (as reported). A registry with an
anonymous root but Bearer-only auth on repositories is a separate,
unreported scenario and is not addressed here.

Validation:
cd registry-scanner && go build ./...   (passes)
cd registry-scanner && go test ./pkg/registry/...   (passes, run
  repeatedly with a freshly cleared build cache)
cd registry-scanner && golangci-lint run --timeout 5m ./pkg/registry/...
  (v2.12.2, matching this repo's CI pin; 0 issues)
cd registry-scanner && go vet ./pkg/registry/...   (clean)
cd registry-scanner && go mod tidy   (no diff to go.mod/go.sum)

Added TestNewRepository_AnonymousRootBasicAuthRepo, an end-to-end
test with a real httptest server reproducing the reported scenario
(anonymous 200 on /v2/, Basic-auth-protected tags endpoint). Manually
confirmed this test fails against the pre-fix code with "unexpected
error: unauthorized" and passes against the fix.

Could not run the main module's own `go build ./...` / `go test
./...` locally: the machine's disk is at ~94-100% capacity system-wide
(large unrelated caches, unrelated to this repository, consume most
of it), and the main module's dependency tree (which includes the
full k8s.io/client-go and k8s.io/kubernetes graphs) needs more build
cache headroom than is available even right after clearing the Go
build cache. This change does not alter any exported API of the
registry package (only an unexported function's signature and its
single in-package call site changed), so it should not affect the
main module's ability to build against it.

Report: https://github.com/argoproj-labs/argocd-image-updater/issues/1797
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
Assisted-by: claude-sonnet-5 (via Claude Code)

Fixes #1797

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access to private registry repositories when the registry root allows anonymous access but subsequent requests require authentication.
  * Configured credentials are now sent preemptively when appropriate, preventing initial tag-request failures.

* **Tests**
  * Added coverage for authenticated requests against registries with anonymous roots.
  * Added validation for authentication behavior with and without configured credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->