### PR TITLE
fix(registry): controller sends unauthenticated registry requests — registries.conf credentials AND per-image pullSecret never reach the wire

### DIFF
--- a/registry-scanner/pkg/registry/client.go
+++ b/registry-scanner/pkg/registry/client.go
@@ -6,6 +6,7 @@ import (
 	stdjson "encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -123,6 +124,147 @@ func (rlt *rateLimitTransport) RoundTrip(r *http.Request) (*http.Response, error
 	return resp, err
 }
 
+// challengeRetryTransport learns authentication challenges from real
+// repository responses instead of only from the /v2/ ping.
+//
+// The docker/distribution auth flow assumes a registry's /v2/ root advertises
+// the same authentication requirements as its repositories: NewRepository
+// pings /v2/ once, records whatever WWW-Authenticate challenge comes back, and
+// endpointAuthorizer attaches credentials to later requests only if a
+// challenge was recorded for that endpoint. Registries such as zot can be
+// configured to serve /v2/ anonymously while still requiring authentication on
+// individual repositories. Those answer the ping with 200 and no challenge, so
+// nothing is ever recorded and the configured credentials are never sent --
+// every tag and manifest read fails with "unauthorized: authentication
+// required".
+//
+// This round tripper closes that gap: when a repository request comes back 401
+// with a WWW-Authenticate header and no challenge is yet known for the
+// endpoint, it records the challenge and replays the request once. The replay
+// goes back through endpointAuthorizer, which now finds the challenge and
+// applies the matching handler. Credentials are therefore only ever sent to a
+// registry that asked for them, and whatever scheme the registry names is
+// honoured, so this covers Bearer as well as Basic.
+type challengeRetryTransport struct {
+	base    http.RoundTripper
+	manager challenge.Manager
+	creds   credentials
+	// root is the endpoint's own /v2/ API root. Challenges are learned only for
+	// this exact root, never for a host a request was redirected to. Blob reads
+	// on large registries redirect to object storage under paths that can
+	// themselves contain "/v2/" (the distribution S3 layout is
+	// /docker/registry/v2/blobs/...), and a signed-URL rejection there must
+	// never cause registry credentials to be replayed at a third party.
+	root url.URL
+}
+
+// RoundTrip implements http.RoundTripper.
+func (crt *challengeRetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := crt.base.RoundTrip(req)
+	if err != nil || resp.StatusCode != http.StatusUnauthorized {
+		return resp, err
+	}
+	challenges := challenge.ResponseChallenges(resp)
+	if len(challenges) == 0 {
+		return resp, nil
+	}
+	// Replaying a request that has a body requires GetBody to rewind it. Every
+	// call this client makes is a bodyless GET, so this only guards against
+	// future callers.
+	if req.Body != nil && req.GetBody == nil {
+		return resp, nil
+	}
+
+	pingURL, ok := v2RootURL(req.URL)
+	if !ok || pingURL != crt.root {
+		return resp, nil
+	}
+
+	logCtx := log.LoggerFromContext(req.Context())
+
+	// A challenge was already known for this endpoint, so endpointAuthorizer
+	// acted on it and the registry still said no. That is a genuine
+	// authentication failure rather than a discovery gap, and retrying would
+	// only double the request count for every unauthorized repository.
+	if known, kerr := crt.manager.GetChallenges(pingURL); kerr != nil || len(known) > 0 {
+		return resp, nil
+	}
+
+	if !crt.canSatisfy(challenges) {
+		return resp, nil
+	}
+
+	// challenge.simpleManager keys challenges by the responding request's path
+	// verbatim, while endpointAuthorizer looks them up under that path
+	// truncated at /v2/. Re-key the response so the two agree.
+	if aerr := crt.manager.AddResponse(&http.Response{
+		StatusCode: resp.StatusCode,
+		Header:     resp.Header,
+		Request:    &http.Request{URL: &pingURL},
+	}); aerr != nil {
+		logCtx.Debugf("Could not record authentication challenge for %s: %v", pingURL.String(), aerr)
+		return resp, nil
+	}
+
+	if pingURL.Scheme != "https" {
+		for _, c := range challenges {
+			if c.Scheme == "basic" {
+				logCtx.Warnf("Registry %s requested HTTP Basic authentication over an unencrypted connection, credentials will be sent in cleartext", pingURL.Host)
+			}
+		}
+	}
+
+	// Drain and close the 401 so the underlying connection can be reused, then
+	// replay. A clone is used so the inner transport does not overwrite the
+	// bookkeeping it keyed on the original request.
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+	resp.Body.Close()
+
+	retryReq := req.Clone(req.Context())
+	if req.GetBody != nil {
+		body, berr := req.GetBody()
+		if berr != nil {
+			return nil, berr
+		}
+		retryReq.Body = body
+	}
+	logCtx.Debugf("Learned authentication challenge from %s, retrying with credentials", req.URL)
+	return crt.base.RoundTrip(retryReq)
+}
+
+// canSatisfy reports whether any offered scheme can actually be answered with
+// what this client holds. Recording a Basic challenge with no credentials to
+// answer it would make endpointAuthorizer fail the replay before it reaches
+// the wire, replacing the registry's own "unauthorized" with an opaque
+// "no basic auth credentials". Bearer is always worth attempting: token
+// services routinely issue anonymous pull tokens.
+func (crt *challengeRetryTransport) canSatisfy(challenges []challenge.Challenge) bool {
+	for _, c := range challenges {
+		if c.Scheme != "basic" {
+			return true
+		}
+		if crt.creds.username != "" && crt.creds.password != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// v2RootURL returns the /v2/ API root for a registry request URL. It mirrors
+// the truncation that endpointAuthorizer.ModifyRequest performs, so the key it
+// produces is the one challenges are looked up under.
+func v2RootURL(u *url.URL) (url.URL, bool) {
+	path := u.Path
+	if v2Root := strings.Index(path, "/v2/"); v2Root != -1 {
+		path = path[:v2Root+4]
+	} else if v1Root := strings.Index(path, "/v1/"); v1Root != -1 {
+		path = path[:v1Root] + "/v2/"
+	} else {
+		return url.URL{}, false
+	}
+	return url.URL{Scheme: u.Scheme, Host: u.Host, Path: path}, true
+}
+
 // getTokenActions returns the list of OAuth2 Bearer token actions to request
 // for the given registry API. Extend this function when a registry requires
 // additional scopes beyond the default "pull".
@@ -167,13 +309,29 @@ func (clt *registryClient) NewRepository(ctx context.Context, nameInRepository s
 	if err != nil {
 		return err
 	}
-	clt.regClient, err = client.NewRepository(named, urlToCall, rlt)
+
+	// Registries that serve /v2/ anonymously never produce a challenge at ping
+	// time, so learn from the repository responses as well. This wraps the
+	// rate limiter rather than sitting under it, so a replayed request also
+	// takes a rate-limit token.
+	pingURL, err := url.Parse(urlToCall + "/v2/")
+	if err != nil {
+		return err
+	}
+	authRT := &challengeRetryTransport{
+		base:    rlt,
+		manager: challengeManager1,
+		creds:   clt.creds,
+		root:    url.URL{Scheme: pingURL.Scheme, Host: pingURL.Host, Path: pingURL.Path},
+	}
+
+	clt.regClient, err = client.NewRepository(named, urlToCall, authRT)
 	if err != nil {
 		return err
 	}
 	// Store the authenticated HTTP client for use by Referrers and any other
 	// raw-HTTP calls that the distribution ManifestService doesn't cover.
-	clt.httpClient = &http.Client{Transport: rlt}
+	clt.httpClient = &http.Client{Transport: authRT}
 	// Keep the plain repository path so Referrers can build the correct URL.
 	clt.nameInRepository = nameInRepository
 	return nil

--- a/registry-scanner/pkg/registry/client.go
+++ b/registry-scanner/pkg/registry/client.go
@@ -164,8 +164,7 @@ func (crt *challengeRetryTransport) RoundTrip(req *http.Request) (*http.Response
 	if err != nil || resp.StatusCode != http.StatusUnauthorized {
 		return resp, err
 	}
-	challenges := challenge.ResponseChallenges(resp)
-	if len(challenges) == 0 {
+	if len(challenge.ResponseChallenges(resp)) == 0 {
 		return resp, nil
 	}
 	// Replaying a request that has a body requires GetBody to rewind it. Every
@@ -190,16 +189,22 @@ func (crt *challengeRetryTransport) RoundTrip(req *http.Request) (*http.Response
 		return resp, nil
 	}
 
-	if !crt.canSatisfy(challenges) {
+	usable, rawUsable := crt.satisfiableChallenges(resp)
+	if len(usable) == 0 {
 		return resp, nil
 	}
 
 	// challenge.simpleManager keys challenges by the responding request's path
 	// verbatim, while endpointAuthorizer looks them up under that path
-	// truncated at /v2/. Re-key the response so the two agree.
+	// truncated at /v2/. Re-key the response so the two agree, carrying only the
+	// schemes this client can answer.
+	header := make(http.Header, 1)
+	for _, raw := range rawUsable {
+		header.Add("WWW-Authenticate", raw)
+	}
 	if aerr := crt.manager.AddResponse(&http.Response{
 		StatusCode: resp.StatusCode,
-		Header:     resp.Header,
+		Header:     header,
 		Request:    &http.Request{URL: &pingURL},
 	}); aerr != nil {
 		logCtx.Debugf("Could not record authentication challenge for %s: %v", pingURL.String(), aerr)
@@ -207,7 +212,7 @@ func (crt *challengeRetryTransport) RoundTrip(req *http.Request) (*http.Response
 	}
 
 	if pingURL.Scheme != "https" {
-		for _, c := range challenges {
+		for _, c := range usable {
 			if c.Scheme == "basic" {
 				logCtx.Warnf("Registry %s requested HTTP Basic authentication over an unencrypted connection, credentials will be sent in cleartext", pingURL.Host)
 			}
@@ -232,22 +237,48 @@ func (crt *challengeRetryTransport) RoundTrip(req *http.Request) (*http.Response
 	return crt.base.RoundTrip(retryReq)
 }
 
-// canSatisfy reports whether any offered scheme can actually be answered with
-// what this client holds. Recording a Basic challenge with no credentials to
-// answer it would make endpointAuthorizer fail the replay before it reaches
-// the wire, replacing the registry's own "unauthorized" with an opaque
-// "no basic auth credentials". Bearer is always worth attempting: token
-// services routinely issue anonymous pull tokens.
-func (crt *challengeRetryTransport) canSatisfy(challenges []challenge.Challenge) bool {
-	for _, c := range challenges {
-		if c.Scheme != "basic" {
-			return true
-		}
-		if crt.creds.username != "" && crt.creds.password != "" {
-			return true
+// satisfiableChallenges returns the offered challenges this client can actually
+// answer, together with the raw WWW-Authenticate lines that produced them.
+//
+// Filtering has to happen before the challenges are recorded, not after.
+// endpointAuthorizer runs the handler for every recorded challenge and aborts
+// the whole request on the first handler error, so a Basic challenge recorded
+// with no credentials to answer it sinks the replay before it reaches the wire
+// -- even when a Bearer challenge offered alongside it would have succeeded
+// anonymously -- and replaces the registry's own "unauthorized" with an opaque
+// "no basic auth credentials".
+func (crt *challengeRetryTransport) satisfiableChallenges(resp *http.Response) ([]challenge.Challenge, []string) {
+	var (
+		usable []challenge.Challenge
+		raw    []string
+	)
+	for _, line := range resp.Header.Values("WWW-Authenticate") {
+		header := make(http.Header, 1)
+		header.Set("WWW-Authenticate", line)
+		// The parser yields at most one challenge per header line, so keeping
+		// the line is equivalent to keeping the challenge it parsed to.
+		for _, c := range challenge.ResponseChallenges(&http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Header:     header,
+		}) {
+			if !crt.canSatisfy(c) {
+				continue
+			}
+			usable = append(usable, c)
+			raw = append(raw, line)
 		}
 	}
-	return false
+	return usable, raw
+}
+
+// canSatisfy reports whether an offered scheme can be answered with what this
+// client holds. Bearer is always worth attempting: token services routinely
+// issue anonymous pull tokens.
+func (crt *challengeRetryTransport) canSatisfy(c challenge.Challenge) bool {
+	if c.Scheme != "basic" {
+		return true
+	}
+	return crt.creds.username != "" && crt.creds.password != ""
 }
 
 // v2RootURL returns the /v2/ API root for a registry request URL. It mirrors

--- a/registry-scanner/pkg/registry/client_test.go
+++ b/registry-scanner/pkg/registry/client_test.go
@@ -383,6 +383,100 @@ func TestNewRepository_AnonymousRootBadCredentials(t *testing.T) {
 	assert.Len(t, *authHeaders, 2, "expected exactly one replay after the challenge was learned")
 }
 
+// TestNewRepository_AnonymousRootMixedChallengeNoCredentials covers a 401 that
+// offers Bearer and Basic together while no credentials are configured -- the
+// shape of a public repository on a registry that advertises both schemes.
+// endpointAuthorizer aborts a request on the first handler error, so recording
+// the unanswerable Basic challenge alongside the Bearer one would kill the
+// replay with "no basic auth credentials" even though the token service hands
+// out anonymous pull tokens. Only satisfiable schemes may be recorded.
+func TestNewRepository_AnonymousRootMixedChallengeNoCredentials(t *testing.T) {
+	const repo = "public/app"
+
+	tokenService := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"token":"anonymous-token"}`)
+	}))
+	defer tokenService.Close()
+
+	var authHeaders []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/v2/"+repo+"/tags/list", func(w http.ResponseWriter, r *http.Request) {
+		authHeaders = append(authHeaders, r.Header.Get("Authorization"))
+		if r.Header.Get("Authorization") != "Bearer anonymous-token" {
+			w.Header().Add("WWW-Authenticate",
+				fmt.Sprintf(`Bearer realm=%q,service="test"`, tokenService.URL))
+			w.Header().Add("WWW-Authenticate", `Basic realm="test"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, `{"name":%q,"tags":["stg-latest"]}`, repo)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	ep := &RegistryEndpoint{RegistryAPI: server.URL, Limiter: ratelimit.New(100)}
+	client, err := NewClient(ep, "", "")
+	require.NoError(t, err)
+	require.NoError(t, client.NewRepository(context.Background(), repo))
+
+	tags, err := client.Tags(context.Background())
+	require.NoError(t, err)
+	assert.Contains(t, tags, "stg-latest")
+
+	require.Len(t, authHeaders, 2)
+	assert.Empty(t, authHeaders[0])
+	assert.Equal(t, "Bearer anonymous-token", authHeaders[1])
+}
+
+// TestNewRepository_AnonymousRootMixedChallengeUnauthorized pins the error the
+// caller sees when the same mixed challenge cannot be answered at all. It must
+// stay the registry's own 401 rather than an authorizer-level error raised
+// before the request ever reaches the wire.
+func TestNewRepository_AnonymousRootMixedChallengeUnauthorized(t *testing.T) {
+	const repo = "private/app"
+
+	tokenService := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"token":"anonymous-token"}`)
+	}))
+	defer tokenService.Close()
+
+	var authHeaders []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/v2/"+repo+"/tags/list", func(w http.ResponseWriter, r *http.Request) {
+		authHeaders = append(authHeaders, r.Header.Get("Authorization"))
+		w.Header().Add("WWW-Authenticate",
+			fmt.Sprintf(`Bearer realm=%q,service="test"`, tokenService.URL))
+		w.Header().Add("WWW-Authenticate", `Basic realm="test"`)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprint(w, `{"errors":[{"code":"UNAUTHORIZED","message":"authentication required"}]}`)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	ep := &RegistryEndpoint{RegistryAPI: server.URL, Limiter: ratelimit.New(100)}
+	client, err := NewClient(ep, "", "")
+	require.NoError(t, err)
+	require.NoError(t, client.NewRepository(context.Background(), repo))
+
+	_, err = client.Tags(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unauthorized")
+	assert.NotContains(t, err.Error(), "no basic auth credentials",
+		"the registry's own 401 must reach the caller, not an authorizer error")
+	assert.Len(t, authHeaders, 2, "expected exactly one replay after the challenge was learned")
+}
+
 func TestRoundTrip_Success(t *testing.T) {
 	// Create mocks
 	mockLimiter := new(mocks.Limiter)

--- a/registry-scanner/pkg/registry/client_test.go
+++ b/registry-scanner/pkg/registry/client_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/opencontainers/image-spec/specs-go"
 
 	distclient "github.com/argoproj-labs/argocd-image-updater/registry-scanner/pkg/registry/internal/client"
+	"github.com/argoproj-labs/argocd-image-updater/registry-scanner/pkg/registry/internal/client/auth/challenge"
 
 	"github.com/distribution/distribution/v3"
 	"github.com/distribution/distribution/v3/registry/api/errcode"
@@ -167,6 +168,219 @@ func TestNewRepository(t *testing.T) {
 		require.Error(t, err)
 	})
 
+}
+
+// anonymousRootRegistry builds a registry whose /v2/ root answers anonymously
+// with 200 and no challenge, while the tags endpoint for a single repository
+// demands the given auth scheme. It records the Authorization header seen on
+// every tags request, in order.
+func anonymousRootRegistry(t *testing.T, repo, scheme string, authorized func(*http.Request) bool) (*httptest.Server, *[]string) {
+	t.Helper()
+
+	var authHeaders []string
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/v2/"+repo+"/tags/list", func(w http.ResponseWriter, r *http.Request) {
+		authHeaders = append(authHeaders, r.Header.Get("Authorization"))
+		if !authorized(r) {
+			w.Header().Set("WWW-Authenticate", scheme+` realm="test"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, `{"name":%q,"tags":["stg-latest"]}`, repo)
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return server, &authHeaders
+}
+
+// TestNewRepository_AnonymousRootBasicAuthRepo reproduces the scenario reported
+// against a zot registry: the /v2/ root allows anonymous access (200, no
+// WWW-Authenticate challenge), but the tags endpoint for a given repository
+// requires Basic auth. The ping therefore records no challenge, so the
+// credentials have to be learned from the repository's own 401.
+func TestNewRepository_AnonymousRootBasicAuthRepo(t *testing.T) {
+	const repo = "shrestech/printready-web"
+
+	server, authHeaders := anonymousRootRegistry(t, repo, "Basic", func(r *http.Request) bool {
+		user, pass, ok := r.BasicAuth()
+		return ok && user == "testuser" && pass == "testpass"
+	})
+
+	ep := &RegistryEndpoint{RegistryAPI: server.URL, Limiter: ratelimit.New(100)}
+	client, err := NewClient(ep, "testuser", "testpass")
+	require.NoError(t, err)
+	require.NoError(t, client.NewRepository(context.Background(), repo))
+
+	tags, err := client.Tags(context.Background())
+	require.NoError(t, err)
+	assert.Contains(t, tags, "stg-latest")
+
+	// First attempt goes out anonymously, the 401 teaches the challenge, the
+	// replay carries the configured credentials.
+	require.Len(t, *authHeaders, 2)
+	assert.Empty(t, (*authHeaders)[0])
+	assert.NotEmpty(t, (*authHeaders)[1])
+}
+
+// TestNewRepository_AnonymousRootPublicRepo guards the scope of the fix: a
+// repository that never challenges must keep being scanned anonymously, even
+// when credentials are configured for the endpoint. Attaching them preemptively
+// would break public repositories on registries where the configured
+// credentials are stale or scoped elsewhere.
+func TestNewRepository_AnonymousRootPublicRepo(t *testing.T) {
+	const repo = "public/app"
+
+	server, authHeaders := anonymousRootRegistry(t, repo, "Basic", func(r *http.Request) bool { return true })
+
+	ep := &RegistryEndpoint{RegistryAPI: server.URL, Limiter: ratelimit.New(100)}
+	client, err := NewClient(ep, "testuser", "testpass")
+	require.NoError(t, err)
+	require.NoError(t, client.NewRepository(context.Background(), repo))
+
+	tags, err := client.Tags(context.Background())
+	require.NoError(t, err)
+	assert.Contains(t, tags, "stg-latest")
+
+	require.Len(t, *authHeaders, 1)
+	assert.Empty(t, (*authHeaders)[0], "credentials must not be sent to a repository that never asked for them")
+}
+
+// TestNewRepository_AnonymousRootBearerRepo covers the other half of the same
+// gap: an anonymous /v2/ root in front of repositories protected by a Bearer
+// token service. Learning the challenge from the repository response is
+// scheme-agnostic, so the token handler is selected here without the client
+// needing to guess.
+func TestNewRepository_AnonymousRootBearerRepo(t *testing.T) {
+	const repo = "private/app"
+
+	tokenService := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok := r.BasicAuth()
+		if !ok || user != "testuser" || pass != "testpass" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"token":"issued-token"}`)
+	}))
+	defer tokenService.Close()
+
+	var authHeaders []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/v2/"+repo+"/tags/list", func(w http.ResponseWriter, r *http.Request) {
+		authHeaders = append(authHeaders, r.Header.Get("Authorization"))
+		if r.Header.Get("Authorization") != "Bearer issued-token" {
+			w.Header().Set("WWW-Authenticate",
+				fmt.Sprintf(`Bearer realm=%q,service="test"`, tokenService.URL))
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, `{"name":%q,"tags":["stg-latest"]}`, repo)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	ep := &RegistryEndpoint{RegistryAPI: server.URL, Limiter: ratelimit.New(100)}
+	client, err := NewClient(ep, "testuser", "testpass")
+	require.NoError(t, err)
+	require.NoError(t, client.NewRepository(context.Background(), repo))
+
+	tags, err := client.Tags(context.Background())
+	require.NoError(t, err)
+	assert.Contains(t, tags, "stg-latest")
+
+	require.Len(t, authHeaders, 2)
+	assert.Empty(t, authHeaders[0])
+	assert.Equal(t, "Bearer issued-token", authHeaders[1])
+}
+
+// TestNewRepository_RedirectedBlobIsNotLearnedFrom covers the blob-redirect
+// shape used by large registries: the blob read is redirected to object storage
+// under a path that also contains "/v2/", and that host rejects the request.
+// Credentials for the registry must not be replayed at the redirect target.
+func TestNewRepository_RedirectedBlobIsNotLearnedFrom(t *testing.T) {
+	var storageAuthHeaders []string
+
+	storage := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		storageAuthHeaders = append(storageAuthHeaders, r.Header.Get("Authorization"))
+		w.Header().Set("WWW-Authenticate", `Basic realm="storage"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer storage.Close()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/v2/some/app/blobs/", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, storage.URL+"/docker/registry/v2/blobs/sha256/deadbeef", http.StatusTemporaryRedirect)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	ep := &RegistryEndpoint{RegistryAPI: server.URL, Limiter: ratelimit.New(100)}
+	client, err := NewClient(ep, "testuser", "testpass")
+	require.NoError(t, err)
+	require.NoError(t, client.NewRepository(context.Background(), "some/app"))
+
+	_, err = client.(*registryClient).BlobContent(context.Background(),
+		godigest.Digest("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+	require.Error(t, err)
+
+	require.Len(t, storageAuthHeaders, 1, "the redirect target must not be retried")
+	assert.Empty(t, storageAuthHeaders[0], "registry credentials must not be sent to the redirect target")
+}
+
+// TestNewRepository_AnonymousRootNoCredentials asserts that a Basic challenge
+// the client cannot answer is left unrecorded. Recording it would make
+// endpointAuthorizer fail the next request with "no basic auth credentials"
+// before it reaches the wire, replacing the registry's own error and hiding the
+// 401 from IsAuthError.
+func TestNewRepository_AnonymousRootNoCredentials(t *testing.T) {
+	const repo = "private/app"
+
+	server, authHeaders := anonymousRootRegistry(t, repo, "Basic", func(r *http.Request) bool { return false })
+
+	ep := &RegistryEndpoint{RegistryAPI: server.URL, Limiter: ratelimit.New(100)}
+	client, err := NewClient(ep, "", "")
+	require.NoError(t, err)
+	require.NoError(t, client.NewRepository(context.Background(), repo))
+
+	_, err = client.Tags(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unauthorized")
+	assert.NotContains(t, err.Error(), "no basic auth credentials",
+		"the registry's own 401 must reach the caller, not an authorizer error")
+	assert.Len(t, *authHeaders, 1, "no replay is possible without credentials")
+}
+
+// TestNewRepository_AnonymousRootBadCredentials asserts the replay happens at
+// most once. A registry that rejects the credentials it asked for must not send
+// the client into a retry loop.
+func TestNewRepository_AnonymousRootBadCredentials(t *testing.T) {
+	const repo = "private/app"
+
+	server, authHeaders := anonymousRootRegistry(t, repo, "Basic", func(r *http.Request) bool { return false })
+
+	ep := &RegistryEndpoint{RegistryAPI: server.URL, Limiter: ratelimit.New(100)}
+	client, err := NewClient(ep, "testuser", "wrongpass")
+	require.NoError(t, err)
+	require.NoError(t, client.NewRepository(context.Background(), repo))
+
+	_, err = client.Tags(context.Background())
+	require.Error(t, err)
+	assert.Len(t, *authHeaders, 2, "expected exactly one replay after the challenge was learned")
 }
 
 func TestRoundTrip_Success(t *testing.T) {
@@ -744,6 +958,26 @@ func TestPing(t *testing.T) {
 		_, err := ping(context.Background(), mockManager, ep, "")
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "unsupported protocol scheme")
+	})
+
+	// A registry that answers the ping anonymously must not have a challenge
+	// invented for it. Credentials are only ever attached in response to a
+	// challenge the registry actually sent; see challengeRetryTransport.
+	t.Run("anonymous root registers no challenge", func(t *testing.T) {
+		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer testServer.Close()
+		manager := challenge.NewSimpleManager()
+		ep := &RegistryEndpoint{RegistryAPI: testServer.URL}
+		_, err := ping(context.Background(), manager, ep, "")
+		require.NoError(t, err)
+
+		u, err := url.Parse(testServer.URL + "/v2/")
+		require.NoError(t, err)
+		challenges, err := manager.GetChallenges(*u)
+		require.NoError(t, err)
+		assert.Empty(t, challenges)
 	})
 }
 


### PR DESCRIPTION
Fixes #1797 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Registry access now handles repositories that require authentication even when the registry root allows anonymous access.
  * Supports Basic and Bearer authentication challenges, including requests with replayable bodies and mixed authentication responses.
  * Prevents credentials from being sent to unrelated redirect targets or public repositories.
  * Preserves appropriate authentication errors when credentials cannot satisfy a challenge.
  * Warns when Basic authentication is used over unencrypted HTTP.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->