### PR TITLE
fix: recognize bare registry auth error codes

### DIFF
--- a/registry-scanner/pkg/registry/client.go
+++ b/registry-scanner/pkg/registry/client.go
@@ -450,7 +450,9 @@ func TagInfoFromReferences(ctx context.Context, client *registryClient, opts *op
 
 // IsAuthError reports whether err is an authentication/authorization failure (401/403)
 // from the distribution registry client. It uses errors.As to detect the client's
-// typed errors and errcode instead of matching error strings.
+// typed errors and errcode instead of matching error strings. This function handles
+// both structured errcode.Error values and bare errcode.ErrorCode values to ensure
+// comprehensive authentication error detection across different registry response formats.
 func IsAuthError(ctx context.Context, err error) bool {
 	log := log.LoggerFromContext(ctx)
 	if err == nil {

--- a/registry-scanner/pkg/registry/client.go
+++ b/registry-scanner/pkg/registry/client.go
@@ -475,12 +475,18 @@ func IsAuthError(ctx context.Context, err error) bool {
 	var errs errcode.Errors
 	if errors.As(err, &errs) {
 		for _, e := range errs {
+			var code errcode.ErrorCode
 			var errcodeErr errcode.Error
-			if errors.As(e, &errcodeErr) {
-				if errors.Is(errcodeErr.Code, errcode.ErrorCodeUnauthorized) || errors.Is(errcodeErr.Code, errcode.ErrorCodeDenied) {
-					log.Debugf("auth error from registry: %s", errcodeErr.Code.Message())
-					return true
-				}
+			switch {
+			case errors.As(e, &errcodeErr):
+				code = errcodeErr.Code
+			case errors.As(e, &code):
+			default:
+				continue
+			}
+			if code == errcode.ErrorCodeUnauthorized || code == errcode.ErrorCodeDenied {
+				log.Debugf("auth error from registry: %s", code.Message())
+				return true
 			}
 		}
 	}

--- a/registry-scanner/pkg/registry/client_test.go
+++ b/registry-scanner/pkg/registry/client_test.go
@@ -812,6 +812,12 @@ func TestIsAuthError(t *testing.T) {
 		assert.True(t, IsAuthError(ctx, err))
 	})
 
+	t.Run("non-canonical JSON errcode.Errors returns true", func(t *testing.T) {
+		var err errcode.Errors
+		require.NoError(t, json.Unmarshal([]byte(`{"errors":[{"code":"UNAUTHORIZED","message":"you shall not pass"}]}`), &err))
+		assert.True(t, IsAuthError(ctx, err))
+	})
+
 	t.Run("errcode.Errors with other code returns false", func(t *testing.T) {
 		err := errcode.Errors{errcode.ErrorCodeUnknown.WithMessage("something else")}
 		assert.False(t, IsAuthError(ctx, err))

--- a/registry-scanner/pkg/registry/client_test.go
+++ b/registry-scanner/pkg/registry/client_test.go
@@ -799,20 +799,24 @@ func TestIsAuthError(t *testing.T) {
 	})
 
 	t.Run("bare errcode.Errors with Unauthorized returns true", func(t *testing.T) {
+		// Test that bare errcode.ErrorCodeUnauthorized values are recognized as auth errors
 		assert.True(t, IsAuthError(ctx, errcode.Errors{errcode.ErrorCodeUnauthorized}))
 	})
 
 	t.Run("bare errcode.Errors with Denied returns true", func(t *testing.T) {
+		// Test that bare errcode.ErrorCodeDenied values are recognized as auth errors
 		assert.True(t, IsAuthError(ctx, errcode.Errors{errcode.ErrorCodeDenied}))
 	})
 
 	t.Run("canonical JSON errcode.Errors returns true", func(t *testing.T) {
+		// Test that canonical JSON errcode.Error responses are recognized as auth errors
 		var err errcode.Errors
 		require.NoError(t, json.Unmarshal([]byte(`{"errors":[{"code":"UNAUTHORIZED","message":"authentication required"}]}`), &err))
 		assert.True(t, IsAuthError(ctx, err))
 	})
 
 	t.Run("non-canonical JSON errcode.Errors returns true", func(t *testing.T) {
+		// Test that non-canonical JSON errcode.Error responses are recognized as auth errors
 		var err errcode.Errors
 		require.NoError(t, json.Unmarshal([]byte(`{"errors":[{"code":"UNAUTHORIZED","message":"you shall not pass"}]}`), &err))
 		assert.True(t, IsAuthError(ctx, err))

--- a/registry-scanner/pkg/registry/client_test.go
+++ b/registry-scanner/pkg/registry/client_test.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -794,6 +795,20 @@ func TestIsAuthError(t *testing.T) {
 
 	t.Run("errcode.Errors with Denied returns true", func(t *testing.T) {
 		err := errcode.Errors{errcode.ErrorCodeDenied.WithMessage("access denied")}
+		assert.True(t, IsAuthError(ctx, err))
+	})
+
+	t.Run("bare errcode.Errors with Unauthorized returns true", func(t *testing.T) {
+		assert.True(t, IsAuthError(ctx, errcode.Errors{errcode.ErrorCodeUnauthorized}))
+	})
+
+	t.Run("bare errcode.Errors with Denied returns true", func(t *testing.T) {
+		assert.True(t, IsAuthError(ctx, errcode.Errors{errcode.ErrorCodeDenied}))
+	})
+
+	t.Run("canonical JSON errcode.Errors returns true", func(t *testing.T) {
+		var err errcode.Errors
+		require.NoError(t, json.Unmarshal([]byte(`{"errors":[{"code":"UNAUTHORIZED","message":"authentication required"}]}`), &err))
 		assert.True(t, IsAuthError(ctx, err))
 	})
 

--- a/registry-scanner/pkg/registry/client_test.go
+++ b/registry-scanner/pkg/registry/client_test.go
@@ -822,6 +822,14 @@ func TestIsAuthError(t *testing.T) {
 		assert.True(t, IsAuthError(ctx, err))
 	})
 
+	t.Run("non-canonical JSON errcode.Errors without message returns true", func(t *testing.T) {
+		// Test that registry error objects without a message field are recognized
+		// as auth errors; they decode to bare errcode.ErrorCode values
+		var err errcode.Errors
+		require.NoError(t, json.Unmarshal([]byte(`{"errors":[{"code":"UNAUTHORIZED"}]}`), &err))
+		assert.True(t, IsAuthError(ctx, err))
+	})
+
 	t.Run("errcode.Errors with other code returns false", func(t *testing.T) {
 		err := errcode.Errors{errcode.ErrorCodeUnknown.WithMessage("something else")}
 		assert.False(t, IsAuthError(ctx, err))


### PR DESCRIPTION
## Summary

- recognize bare `errcode.ErrorCode` values when classifying registry authentication errors
- preserve support for `errcode.Error` values and add regression coverage for bare and canonical JSON responses

Fixes #1802

## Verification

- `go test ./pkg/registry -run '^TestIsAuthError$' -count=1`
- `go test ./pkg/registry -count=1`
- `go vet ./pkg/registry`
- `git diff --check`

AI assistance was used to inspect the reported reproduction, implement the minimal fix, and add focused tests; the submitted change was reviewed against the repository's contribution requirements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of unauthorized and access-denied errors from registry responses.
  * Added consistent detection across direct error values and canonical or non-canonical JSON payloads, including responses with or without message fields.
  * Improved diagnostic details for authentication failures by reporting the relevant error code.
  * Registry authentication failures are now handled more consistently across supported response formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->